### PR TITLE
chore(test-app): fix Android build

### DIFF
--- a/packages/test-app/android-workaround.js
+++ b/packages/test-app/android-workaround.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+
+// As of today (Oct 23) react-native is broken on Android
+// We're fixing this by patching the repository order in the main gradle file of the Android project
+// See:
+// - https://github.com/facebook/react-native/pull/21910
+// - https://github.com/facebook/react-native/issues/21907#issuecomment-432319128
+
+const fs = require('fs')
+const path = require('path')
+
+const gradlePath = path.resolve(__dirname, 'project/android/build.gradle')
+
+fs.writeFileSync(
+    gradlePath,
+    fs
+        .readFileSync(gradlePath, 'utf-8')
+        .replace(/google\(\)/g, '')
+        .replace(/jcenter\(\)/g, 'google()\njcenter()')
+)

--- a/packages/test-app/generate.sh
+++ b/packages/test-app/generate.sh
@@ -32,3 +32,5 @@ analytics
   .setup('$SEGMENT_WRITE_TOKEN')
     .then(() => console.log('Analytics ready'))
 EOF
+
+../android-workaround.js


### PR DESCRIPTION
CI is broken on Android since today, applying a quick workaround to keep CI green while the react-native team figures it out.

See:
- facebook/react-native#21910
- facebook/react-native#21907