### PR TITLE
Pull android tool versions from root project

### DIFF
--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -12,13 +12,17 @@ buildscript {
     }
 }
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 26
-    buildToolsVersion = '26.0.3'
+    compileSdkVersion safeExtGet('compileSdkVersion', 26)
+    buildToolsVersion safeExtGet('buildToolsVersion', '26.0.3')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 26
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 26)
         versionCode 1
         versionName '1.0'
     }

--- a/packages/integrations/template/android/build.gradle
+++ b/packages/integrations/template/android/build.gradle
@@ -12,12 +12,16 @@ buildscript {
     }
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 26
+    compileSdkVersion safeExtGet('compileSdkVersion', 26)
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 26
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 26)
         versionCode 1
         versionName '1.0'
 


### PR DESCRIPTION
If the host react native application is using a different version of the android sdk build tools, build warnings will be displayed about incompatibilities.  This addresses that by using the values defined in the root project.

This is the approach used by the current [react-native-create-library template](https://github.com/frostney/react-native-create-library/blob/master/templates/android.js#L28).