### PR TITLE
Add support for setup to resolve its promises

### DIFF
--- a/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
+++ b/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
@@ -28,6 +28,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.Promise
 import com.segment.analytics.Analytics
 import com.segment.analytics.Properties
 import com.segment.analytics.Traits
@@ -41,7 +42,7 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
     override fun getName() = "RNAnalytics"
 
     @ReactMethod
-    fun setup(options: ReadableMap) {
+    fun setup(options: ReadableMap, promise: Promise) {
         val builder = Analytics
                 .Builder(reactApplicationContext, options.getString("writeKey"))
                 .flushQueueSize(options.getInt("flushAt"))
@@ -69,9 +70,14 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
             builder.logLevel(Analytics.LogLevel.VERBOSE)
         }
 
-        Analytics.setSingletonInstance(
-            RNAnalytics.buildWithIntegrations(builder)
-        )
+        try {
+            Analytics.setSingletonInstance(
+                RNAnalytics.buildWithIntegrations(builder)
+            )
+            promise.resolve(true)
+        } catch(e: Exception) {
+            promise.reject("E_SEGMENT_ERROR", e)
+        }
     }
 
     @ReactMethod

--- a/packages/core/ios/RNAnalytics/RNAnalytics.m
+++ b/packages/core/ios/RNAnalytics/RNAnalytics.m
@@ -32,7 +32,10 @@ RCT_EXPORT_MODULE()
 
 @synthesize bridge = _bridge;
 
-RCT_EXPORT_METHOD(setup:(NSDictionary*)options) {
+RCT_EXPORT_METHOD(setup:(NSDictionary*)options
+          setupResolver:(RCTPromiseResolveBlock)resolve
+          setupRejecter:(RCTPromiseRejectBlock)reject)
+{
     SEGAnalyticsConfiguration* config = [SEGAnalyticsConfiguration configurationWithWriteKey:options[@"writeKey"]];
     
     config.recordScreenViews = [options[@"recordScreenViews"] boolValue];
@@ -46,7 +49,13 @@ RCT_EXPORT_METHOD(setup:(NSDictionary*)options) {
     }
     
     [SEGAnalytics debug:[options[@"debug"] boolValue]];
-    [SEGAnalytics setupWithConfiguration:config];
+
+    @try {
+        [SEGAnalytics setupWithConfiguration:config];
+    }
+    @catch (NSException *exception) {
+        reject(exception);
+    }
     
     // On iOS we use method swizzling to intercept lifecycle events
     // However, React-Native calls our library after applicationDidFinishLaunchingWithOptions: is called
@@ -60,6 +69,7 @@ RCT_EXPORT_METHOD(setup:(NSDictionary*)options) {
                                                withObject:_bridge.launchOptions];
         }
     }
+    resolve(YES);
 }
 
 #define withContext(context) @{@"context": context}


### PR DESCRIPTION
With this change the setup method will now resolve its promises and
thereby be able to catch errors during setup.

This is not currently sufficiently tested, but I wanted some feedback if this is the correct approach before hardening this. Since there is no development branch on this repo I just made this to master.

This is related to and tries to fix https://github.com/segmentio/analytics-react-native/issues/16 .