### PR TITLE
Bug Fix: Upgrade Kotlin Gradle Plugin

### DIFF
--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.60'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.21'
     }
 }
 
@@ -38,8 +38,8 @@ repositories {
 
 
 dependencies {
-    api 'com.segment.analytics.android:analytics:4.+'
+    implementation 'com.segment.analytics.android:analytics:4.+'
 
-    api 'com.facebook.react:react-native:+'
-    api 'org.jetbrains.kotlin:kotlin-stdlib:1.2.+'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.3.+'
 }

--- a/packages/integrations/template/android/build.gradle
+++ b/packages/integrations/template/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.60'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.0'
     }
 }
 


### PR DESCRIPTION
With React-Native 0.59 you need to use the kotlin-gradle-plugin 1.3.0+. Failure to do so results in the following error:

```
FAILURE: Build failed with an exception.

* What went wrong:
The Android Gradle plugin supports only Kotlin Gradle plugin version 1.3.0 and higher.
The following dependencies do not satisfy the required version:
project ':@segment_analytics-react-native' -> org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.60
```

I was not sure what your `integrations` package is for, but I've made the changes to that also.

I've tested these changes on my app and can confirm the errors go away, but I'm not familiar with Kotlin so I can't really speak to whether I've botched something up or not.

I'm happy to help out further if I have indeed done something screwy, but will need some direction.