### PR TITLE
ci(publish): fix publish job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,10 @@ workflows:
 
   build_test_and_publish:
     jobs:
-      - install
+      - install:
+          filters:
+            tags:
+              only: /.*/
       - test-android: *requiresTestApp
       - test-ios-vanilla: *requiresTestApp
       - test-ios-cocoapods: *requiresTestApp
@@ -158,6 +161,9 @@ workflows:
       - build-integrations: *requiresInstall
       - build-core: *requiresInstall
       - build-test-app:
+          filters:
+            tags:
+              only: /.*/
           requires:
             - build-core
             - build-integrations
@@ -174,4 +180,4 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.+)?/
             branches:
-              ignore: /.*/
+              ignore: /.*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,7 @@ jobs:
       - *getDeps
       - *attach
       - run: npm config set "//registry.npmjs.org/:_authToken" $NPM_AUTH
+      - run: npm config set @segment:registry https://registry.npmjs.org/ --global
       - run: yarn deploy
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
       - *getDeps
       - *attach
       - run: npm config set "//registry.npmjs.org/:_authToken" $NPM_AUTH
-      - run: npm config set @segment:registry https://registry.npmjs.org/ --global
+      - run: sudo npm config set @segment:registry https://registry.npmjs.org/ --global
       - run: yarn deploy
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,4 @@
 defaults:
-  noTagFilters: &noTagFilters
-    filters:
-      tags:
-        only: /.*/
-  requiresInstall: &requiresInstall
-    <<: *noTagFilters
-    requires:
-      - install
-  requiresTestApp: &requiresTestApp
-    <<: *noTagFilters
-    requires:
-      - build-test-app
   attach: &attach
     attach_workspace:
       at: .
@@ -153,20 +141,55 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - test-android: *requiresTestApp
-      - test-ios-vanilla: *requiresTestApp
-      - test-ios-cocoapods: *requiresTestApp
-      - test-core: *requiresInstall
-      - lint: *requiresInstall
-      - build-integrations: *requiresInstall
-      - build-core: *requiresInstall
-      - build-test-app:
+      - build-integrations:
+          requires:
+            - install
           filters:
             tags:
               only: /.*/
+      - build-core:
+          requires:
+            - install
+          filters:
+            tags:
+              only: /.*/
+      - build-test-app:
           requires:
             - build-core
             - build-integrations
+          filters:
+            tags:
+              only: /.*/
+      - test-core:
+          requires:
+            - install
+          filters:
+            tags:
+              only: /.*/
+      - test-android:
+          requires:
+            -  build-test-app
+          filters:
+            tags:
+              only: /.*/
+      - test-ios-vanilla:
+          requires:
+            -  build-test-app
+          filters:
+            tags:
+              only: /.*/
+      - test-ios-cocoapods:
+          requires:
+            -  build-test-app
+          filters:
+            tags:
+              only: /.*/
+      - lint:
+          requires:
+            - install
+          filters:
+            tags:
+              only: /.*/
       - publish:
           context: snyk
           requires:
@@ -177,7 +200,7 @@ workflows:
             - test-core
             - lint
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.+)?/
-            branches:
-              ignore: /.*


### PR DESCRIPTION
This adds filters to jobs that publish depends on so that the publish job can run on tags.
Reference: https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag.