### PR TITLE
Move application lifecycle tracking in Android to the native wrapper

### DIFF
--- a/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
+++ b/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
@@ -114,7 +114,7 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
         }
 
         val builder = Analytics
-                .Builder(reactApplicationContext, options.getString("writeKey"))
+                .Builder(reactApplicationContext, writeKey)
                 .flushQueueSize(options.getInt("flushAt"))
 
         if(options.getBoolean("recordScreenViews")) {

--- a/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
+++ b/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
@@ -24,11 +24,14 @@
 
 package com.segment.analytics.reactnative.core
 
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
 import com.facebook.react.bridge.*
 import com.segment.analytics.Analytics
 import com.segment.analytics.Properties
 import com.segment.analytics.Traits
 import com.segment.analytics.ValueMap
+import com.segment.analytics.internal.Utils.getSegmentSharedPreferences
 import java.util.concurrent.TimeUnit
 
 class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaModule(context) {
@@ -39,11 +42,67 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
 
     companion object {
         private var singletonJsonConfig: String? = null
+        private var key: String? = null
+        private var versionKey = "version"
+        private var buildKey = "build"
+    }
+
+    private fun getPackageInfo(): PackageInfo {
+        val packageManager = reactApplicationContext.packageManager
+        try {
+            return packageManager.getPackageInfo(reactApplicationContext.packageName, 0)
+        } catch (e: PackageManager.NameNotFoundException) {
+            throw AssertionError("Package not found: " + reactApplicationContext.packageName)
+        }
+    }
+
+    /**
+     * Tracks application lifecycle events - Application Installed, Application Updated and Application Opened
+     * This is built to exactly mirror the application lifecycle tracking in analytics-android
+     */
+    private fun trackApplicationLifecycleEvents() {
+        // Get the current version.
+        var packageInfo = this.getPackageInfo()
+        val currentVersion = packageInfo.versionName
+        val currentBuild = packageInfo.versionCode
+
+        // Get the previous recorded version.
+        val sharedPreferences = getSegmentSharedPreferences(reactApplicationContext, key)
+        val previousVersion = sharedPreferences.getString(versionKey, null)
+        val previousBuild = sharedPreferences.getInt(buildKey, -1)
+
+        // Check and track Application Installed or Application Updated.
+        if (previousBuild == -1) {
+            var installedProperties = Properties()
+            installedProperties[versionKey] = currentVersion
+            installedProperties[buildKey] = currentBuild
+            analytics.track("Application Installed", installedProperties)
+        } else if (currentBuild != previousBuild) {
+            var updatedProperties = Properties()
+            updatedProperties[versionKey] = currentVersion
+            updatedProperties[buildKey] = currentBuild
+            updatedProperties["previous_$versionKey"] = previousVersion
+            updatedProperties["previous_$buildKey"] = previousBuild
+            analytics.track("Application Updated", updatedProperties)
+        }
+
+        // Track Application Opened.
+        var appOpenedProperties = Properties()
+        appOpenedProperties[versionKey] = currentVersion
+        appOpenedProperties[buildKey] = currentBuild
+        analytics.track("Application Opened", appOpenedProperties)
+
+        // Update the recorded version.
+        val editor = sharedPreferences.edit()
+        editor.putString(versionKey, currentVersion)
+        editor.putInt(buildKey, currentBuild)
+        editor.apply()
     }
 
     @ReactMethod
     fun setup(options: ReadableMap, promise: Promise) {
         val json = options.getString("json")
+        val writeKey = options.getString("writeKey")
 
         if(singletonJsonConfig != null) {
             if(json == singletonJsonConfig) {
@@ -62,9 +121,6 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
             builder.recordScreenViews()
         }
 
-        if(options.getBoolean("trackAppLifecycleEvents")) {
-            builder.trackApplicationLifecycleEvents()
-        }
 
         if(options.getBoolean("trackAttributionData")) {
             builder.trackAttributionInformation()
@@ -90,6 +146,12 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
         }
 
         singletonJsonConfig = json
+        key = writeKey
+
+        if(options.getBoolean("trackAppLifecycleEvents")) {
+            this.trackApplicationLifecycleEvents()
+        }
+
         promise.resolve(null)
     }
 


### PR DESCRIPTION
Fixes #36

## Bug
Application lifecycle events (Application Installed, Opened, Updated) in Android are not being tracked.

## Cause
In the analytics-android package, lifecycle events being tracked in the callback of [`onActivityCreated`](https://github.com/segmentio/analytics-android/blob/master/analytics/src/main/java/com/segment/analytics/Analytics.java#L292). However, neither `onActivityCreated` or `onActivityStarted` are ever called when using this library via the native wrapper. The other lifecycle methods, e.g. `onActivityResumed`, `onActivityPaused`, `onActivityStopped` etc are called as expected, which makes this a React Native specific bug.

The most likely reason for this is that `MainActivity` is created to run the React Native app before the native Analytics client is initialised, so that `onActivityCreated` and `onActivityStarted` for the `MainActivity` would have been triggered before the Analytics client has subscribed to them.

## Solution
Move the lifecycle tracking code into the native wrapper.

The logic for lifecycle tracking is mirrored exactly as in `analytics-android`, and the `trackAppLifecycleEvents` flag will no longer be passed down to the native package, but handled in the wrapper.

## Testing
Tested locally using Android Studio and a Nexus emulator, running Android 8.
Confirmed that each of the three lifecycle events are correctly sent and can be seen in the Live Debugger (`https://app.segment.com/[name]/sources/android/debugger`)

![Screenshot 2019-06-06 at 11 37 27](https://user-images.githubusercontent.com/6534400/59026965-967bcb00-884f-11e9-8508-6d7a3db76c3a.png)
