### PR TITLE
Fix android detox build

### DIFF
--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -12,7 +12,9 @@
     "test:ios:cocoapods": "COCOAPODS=yes ./test_ios.sh",
     "test:ios:vanilla": "COCOAPODS=no ./test_ios.sh",
     "test:android": "./test_android.sh",
-    "test": "run-s test:{ios,android}"
+    "test": "run-s test:{ios,android}",
+    "detox:build": "detox build",
+    "detox:test": "detox test"
   },
   "devDependencies": {
     "jest": "^24.5.0",

--- a/packages/test-app/test_android.sh
+++ b/packages/test-app/test_android.sh
@@ -6,7 +6,7 @@ pushd project
     yarn react-native link
 popd
 
-yarn detox build --configuration android
+yarn detox:build --configuration android
 
 # Android E2E tests are not working yet
-# yarn detox test --configuration android
+# yarn detox:test --configuration android


### PR DESCRIPTION
The end to end tests for detox aren't actually being run during the `test-android` step, just the detox app is built.

The build fails with the following error, because yarn cannot find the detox binary:

![Screenshot 2019-06-06 at 15 17 03](https://user-images.githubusercontent.com/6534400/59040241-2d578000-886e-11e9-920d-bb5470547908.png)

This adds the detox command to `package.json` in the test app.