### PR TITLE
Call detox correctly

### DIFF
--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -12,9 +12,7 @@
     "test:ios:cocoapods": "COCOAPODS=yes ./test_ios.sh",
     "test:ios:vanilla": "COCOAPODS=no ./test_ios.sh",
     "test:android": "./test_android.sh",
-    "test": "run-s test:{ios,android}",
-    "detox:build": "detox build",
-    "detox:test": "detox test"
+    "test": "run-s test:{ios,android}"
   },
   "devDependencies": {
     "jest": "^24.5.0",

--- a/packages/test-app/test_android.sh
+++ b/packages/test-app/test_android.sh
@@ -6,7 +6,7 @@ pushd project
     yarn react-native link
 popd
 
-yarn detox:build --configuration android
+detox build --configuration android
 
 # Android E2E tests are not working yet
-# yarn detox:test --configuration android
+# detox test --configuration android

--- a/packages/test-app/test_ios.sh
+++ b/packages/test-app/test_ios.sh
@@ -22,5 +22,5 @@ pushd project/ios
     fi
 popd
 
-yarn detox build --configuration ios-$cfg
-yarn detox test --configuration ios-$cfg --loglevel trace
+detox build --configuration ios-$cfg
+detox test --configuration ios-$cfg --loglevel trace


### PR DESCRIPTION
The detox command can be called without `yarn`.

This update to make `test_android.sh` and `test_ios.sh` consistent.