### PR TITLE
chore(core): add prepublish step

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,8 @@
     "lint": "tslint -p .",
     "test": "jest",
     "deploy": "./deploy.sh",
-    "release": "standard-version --infile ../../CHANGELOG.md"
+    "release": "standard-version --infile ../../CHANGELOG.md",
+    "prepublish": "yarn build"
   },
   "devDependencies": {
     "@types/jest": "^23.3.1",


### PR DESCRIPTION
Adds a `prepublish` step to `core`. `integrations` doesn't need it as packages are pre-built.

Tested with:

```bash
$ cd packages/core
$ npm publish --dry-run
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.

> @segment/analytics-react-native@1.0.1 prepublish .
> yarn build

yarn run v1.16.0
$ run-s build:{clean,ts,pkg}
npm WARN lifecycle The node binary used for scripts is /var/folders/f6/nps199ns421g6qcxh2_93tk00000gn/T/yarn--1560352057410-0.6452185138163682/node but npm is using /usr/local/Cellar/node/12.3.1/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.

> @segment/analytics-react-native@1.0.1 build:clean /Users/fathy/Documents/Git/segment/analytics-react-native/packages/core
> rimraf build

npm WARN lifecycle The node binary used for scripts is /var/folders/f6/nps199ns421g6qcxh2_93tk00000gn/T/yarn--1560352057410-0.6452185138163682/node but npm is using /usr/local/Cellar/node/12.3.1/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.

> @segment/analytics-react-native@1.0.1 build:ts /Users/fathy/Documents/Git/segment/analytics-react-native/packages/core
> run-p build:ts:*

npm WARN lifecycle The node binary used for scripts is /var/folders/f6/nps199ns421g6qcxh2_93tk00000gn/T/yarn--1560352057410-0.6452185138163682/node but npm is using /usr/local/Cellar/node/12.3.1/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.

> @segment/analytics-react-native@1.0.1 build:ts:cjs /Users/fathy/Documents/Git/segment/analytics-react-native/packages/core
> tsc --target es5 --outDir build/cjs --module commonjs

npm WARN lifecycle The node binary used for scripts is /var/folders/f6/nps199ns421g6qcxh2_93tk00000gn/T/yarn--1560352057410-0.6452185138163682/node but npm is using /usr/local/Cellar/node/12.3.1/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.

> @segment/analytics-react-native@1.0.1 build:ts:esm /Users/fathy/Documents/Git/segment/analytics-react-native/packages/core
> tsc --target es5 --outDir build/esm --module esnext

npm WARN lifecycle The node binary used for scripts is /var/folders/f6/nps199ns421g6qcxh2_93tk00000gn/T/yarn--1560352057410-0.6452185138163682/node but npm is using /usr/local/Cellar/node/12.3.1/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.

> @segment/analytics-react-native@1.0.1 build:pkg /Users/fathy/Documents/Git/segment/analytics-react-native/packages/core
> ts-node -T src/make-pkg.ts > build/package.json

✨  Done in 5.95s.
npm notice 
npm notice 📦  @segment/analytics-react-native@1.0.1
npm notice === Tarball Contents === 
npm notice 2.0kB  package.json                                                                      
npm notice 14.8kB README.md                                                                         
npm notice 904B   RNAnalytics.podspec                                                               
npm notice 1.1kB  android/build.gradle                                                              
npm notice 61B    android/src/main/AndroidManifest.xml                                              
npm notice 1.7kB  android/src/main/java/com/segment/analytics/reactnative/core/RNAnalytics.kt       
npm notice 7.2kB  android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt 
npm notice 1.8kB  android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsPackage.kt
npm notice 453B   build/cjs/__mocks__/bridge.d.ts                                                   
npm notice 391B   build/cjs/__mocks__/bridge.js                                                     
npm notice 538B   build/cjs/__mocks__/bridge.js.map                                                 
npm notice 11B    build/cjs/__tests__/analytics.spec.d.ts                                           
npm notice 7.8kB  build/cjs/__tests__/analytics.spec.js                                             
npm notice 4.0kB  build/cjs/__tests__/analytics.spec.js.map                                         
npm notice 62B    build/cjs/__tests__/bridge.spec.d.ts                                              
npm notice 629B   build/cjs/__tests__/bridge.spec.js                                                
npm notice 658B   build/cjs/__tests__/bridge.spec.js.map                                            
npm notice 11B    build/cjs/__tests__/configuration.spec.d.ts                                       
npm notice 6.8kB  build/cjs/__tests__/configuration.spec.js                                         
npm notice 2.1kB  build/cjs/__tests__/configuration.spec.js.map                                     
npm notice 11B    build/cjs/__tests__/index.spec.d.ts                                               
npm notice 348B   build/cjs/__tests__/index.spec.js                                                 
npm notice 312B   build/cjs/__tests__/index.spec.js.map                                             
npm notice 11.0kB build/cjs/analytics.d.ts                                                          
npm notice 17.5kB build/cjs/analytics.js                                                            
npm notice 3.5kB  build/cjs/analytics.js.map                                                        
npm notice 1.3kB  build/cjs/bridge.d.ts                                                             
npm notice 319B   build/cjs/bridge.js                                                               
npm notice 258B   build/cjs/bridge.js.map                                                           
npm notice 293B   build/cjs/configuration.d.ts                                                      
npm notice 5.8kB  build/cjs/configuration.js                                                        
npm notice 1.3kB  build/cjs/configuration.js.map                                                    
npm notice 181B   build/cjs/index.d.ts                                                              
npm notice 249B   build/cjs/index.js                                                                
npm notice 184B   build/cjs/index.js.map                                                            
npm notice 11B    build/cjs/make-pkg.d.ts                                                           
npm notice 237B   build/cjs/make-pkg.js                                                             
npm notice 226B   build/cjs/make-pkg.js.map                                                         
npm notice 1.6kB  build/cjs/middleware.d.ts                                                         
npm notice 7.6kB  build/cjs/middleware.js                                                           
npm notice 3.0kB  build/cjs/middleware.js.map                                                       
npm notice 57B    build/cjs/utils.d.ts                                                              
npm notice 230B   build/cjs/utils.js                                                                
npm notice 207B   build/cjs/utils.js.map                                                            
npm notice 910B   build/cjs/wrapper.d.ts                                                            
npm notice 5.6kB  build/cjs/wrapper.js                                                              
npm notice 1.2kB  build/cjs/wrapper.js.map                                                          
npm notice 453B   build/esm/__mocks__/bridge.d.ts                                                   
npm notice 311B   build/esm/__mocks__/bridge.js                                                     
npm notice 535B   build/esm/__mocks__/bridge.js.map                                                 
npm notice 11B    build/esm/__tests__/analytics.spec.d.ts                                           
npm notice 7.6kB  build/esm/__tests__/analytics.spec.js                                             
npm notice 4.1kB  build/esm/__tests__/analytics.spec.js.map                                         
npm notice 62B    build/esm/__tests__/bridge.spec.d.ts                                              
npm notice 629B   build/esm/__tests__/bridge.spec.js                                                
npm notice 658B   build/esm/__tests__/bridge.spec.js.map                                            
npm notice 11B    build/esm/__tests__/configuration.spec.d.ts                                       
npm notice 6.6kB  build/esm/__tests__/configuration.spec.js                                         
npm notice 2.1kB  build/esm/__tests__/configuration.spec.js.map                                     
npm notice 11B    build/esm/__tests__/index.spec.d.ts                                               
npm notice 259B   build/esm/__tests__/index.spec.js                                                 
npm notice 355B   build/esm/__tests__/index.spec.js.map                                             
npm notice 11.0kB build/esm/analytics.d.ts                                                          
npm notice 17.4kB build/esm/analytics.js                                                            
npm notice 3.6kB  build/esm/analytics.js.map                                                        
npm notice 1.3kB  build/esm/bridge.d.ts                                                             
npm notice 224B   build/esm/bridge.js                                                               
npm notice 282B   build/esm/bridge.js.map                                                           
npm notice 293B   build/esm/configuration.d.ts                                                      
npm notice 5.7kB  build/esm/configuration.js                                                        
npm notice 1.3kB  build/esm/configuration.js.map                                                    
npm notice 181B   build/esm/index.d.ts                                                              
npm notice 135B   build/esm/index.js                                                                
npm notice 216B   build/esm/index.js.map                                                            
npm notice 11B    build/esm/make-pkg.d.ts                                                           
npm notice 139B   build/esm/make-pkg.js                                                             
npm notice 253B   build/esm/make-pkg.js.map                                                         
npm notice 1.6kB  build/esm/middleware.d.ts                                                         
npm notice 7.5kB  build/esm/middleware.js                                                           
npm notice 3.0kB  build/esm/middleware.js.map                                                       
npm notice 57B    build/esm/utils.d.ts                                                              
npm notice 125B   build/esm/utils.js                                                                
npm notice 198B   build/esm/utils.js.map                                                            
npm notice 910B   build/esm/wrapper.d.ts                                                            
npm notice 5.5kB  build/esm/wrapper.js                                                              
npm notice 1.2kB  build/esm/wrapper.js.map                                                          
npm notice 25B    build/package.json                                                                
npm notice 11.4kB ios/RNAnalytics.xcodeproj/project.pbxproj                                         
npm notice 135B   ios/RNAnalytics.xcodeproj/project.xcworkspace/contents.xcworkspacedata            
npm notice 347B   ios/RNAnalytics/RNAnalytics.h                                                     
npm notice 4.6kB  ios/RNAnalytics/RNAnalytics.m                                                     
npm notice 243B   src/__mocks__/bridge.ts                                                           
npm notice 2.9kB  src/__tests__/analytics.spec.ts                                                   
npm notice 534B   src/__tests__/bridge.spec.ts                                                      
npm notice 1.7kB  src/__tests__/configuration.spec.ts                                               
npm notice 198B   src/__tests__/index.spec.ts                                                       
npm notice 10.9kB src/analytics.ts                                                                  
npm notice 1.3kB  src/bridge.ts                                                                     
npm notice 1.1kB  src/configuration.ts                                                              
npm notice 150B   src/index.ts                                                                      
npm notice 93B    src/make-pkg.ts                                                                   
npm notice 3.8kB  src/middleware.ts                                                                 
npm notice 54B    src/modules.d.ts                                                                  
npm notice 95B    src/utils.ts                                                                      
npm notice 1.3kB  src/wrapper.ts                                                                    
npm notice === Tarball Details === 
npm notice name:          @segment/analytics-react-native         
npm notice version:       1.0.1                                   
npm notice package size:  52.5 kB                                 
npm notice unpacked size: 242.6 kB                                
npm notice shasum:        a170f95290a04ab1f0f2ec1677053d19e76f9ded
npm notice integrity:     sha512-u0TeFN5RYwb7+[...]96rcTCTByElug==
npm notice total files:   105                                     
npm notice 
+ @segment/analytics-react-native@1.0.1
```


---

Ref: https://segment.atlassian.net/browse/LIB-1088