### PR TITLE
Feature/integrations

### DIFF
--- a/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
+++ b/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
@@ -67,7 +67,7 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
             val iterator = integrations.keySetIterator()
             while (iterator.hasNextKey()) {
                 val nextKey = iterator.nextKey()
-                options.setIntegration(iterator.nextKey(), integrations.getBoolean(nextKey))
+                options.setIntegration(nextKey, integrations.getBoolean(nextKey))
             }
         }
         return options;
@@ -171,20 +171,20 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
     }
 
     @ReactMethod
-    fun track(event: String, properties: ReadableMap, context: ReadableMap) =
-        analytics.track(event, Properties() from properties, this.getOptions(properties))
+    fun track(event: String, properties: ReadableMap, options: ReadableMap, context: ReadableMap) =
+        analytics.track(event, Properties() from properties, this.getOptions(options))
 
     @ReactMethod
     fun screen(name: String, properties: ReadableMap, context: ReadableMap) =
         analytics.screen(name, Properties() from properties)
 
     @ReactMethod
-    fun identify(userId: String, traits: ReadableMap, context: ReadableMap) =
-        analytics.identify(userId, Traits() from traits, this.getOptions(traits))
+    fun identify(userId: String, traits: ReadableMap, options: ReadableMap, context: ReadableMap) =
+        analytics.identify(userId, Traits() from traits, this.getOptions(options))
 
     @ReactMethod
-    fun group(groupId: String, traits: ReadableMap, context: ReadableMap) =
-        analytics.group(groupId, Traits() from traits, this.getOptions(traits))
+    fun group(groupId: String, traits: ReadableMap, options: ReadableMap, context: ReadableMap) =
+        analytics.group(groupId, Traits() from traits, this.getOptions(options))
 
     @ReactMethod
     fun alias(newId: String, context: ReadableMap) =

--- a/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
+++ b/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
@@ -59,15 +59,24 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
         }
     }
 
-    private fun getOptions(properties: ReadableMap?): Options {
+    /**
+     * Builds Options with integrations
+     * The format for the integrations variable is { String: Boolean | Map }
+     */
+    private fun getOptions(integrations: ReadableMap?): Options {
         var options = Options()
-        var integrations = properties?.getMap("integrations")
 
         if (integrations !== null) {
             val iterator = integrations.keySetIterator()
             while (iterator.hasNextKey()) {
                 val nextKey = iterator.nextKey()
-                options.setIntegration(nextKey, integrations.getBoolean(nextKey))
+                when (integrations.getType(nextKey)) {
+                    ReadableType.Boolean -> options.setIntegration(nextKey, integrations.getBoolean(nextKey))
+                    ReadableType.Map -> {
+                        options.setIntegration(nextKey, true)
+                        options.setIntegrationOptions(nextKey, integrations.getMap(nextKey)?.toHashMap())
+                    }
+                }
             }
         }
         return options;
@@ -171,20 +180,20 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
     }
 
     @ReactMethod
-    fun track(event: String, properties: ReadableMap, options: ReadableMap, context: ReadableMap) =
-        analytics.track(event, Properties() from properties, this.getOptions(options))
+    fun track(event: String, properties: ReadableMap, integrations: ReadableMap, context: ReadableMap) =
+        analytics.track(event, Properties() from properties, this.getOptions(integrations))
 
     @ReactMethod
     fun screen(name: String, properties: ReadableMap, context: ReadableMap) =
         analytics.screen(name, Properties() from properties)
 
     @ReactMethod
-    fun identify(userId: String, traits: ReadableMap, options: ReadableMap, context: ReadableMap) =
-        analytics.identify(userId, Traits() from traits, this.getOptions(options))
+    fun identify(userId: String, traits: ReadableMap, integrations: ReadableMap, context: ReadableMap) =
+        analytics.identify(userId, Traits() from traits, this.getOptions(integrations))
 
     @ReactMethod
-    fun group(groupId: String, traits: ReadableMap, options: ReadableMap, context: ReadableMap) =
-        analytics.group(groupId, Traits() from traits, this.getOptions(options))
+    fun group(groupId: String, traits: ReadableMap, integrations: ReadableMap, context: ReadableMap) =
+        analytics.group(groupId, Traits() from traits, this.getOptions(integrations))
 
     @ReactMethod
     fun alias(newId: String, context: ReadableMap) =

--- a/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
+++ b/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
@@ -79,7 +79,7 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
                 }
             }
         }
-        return options;
+        return options
     }
 
     /**

--- a/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
+++ b/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
@@ -184,8 +184,8 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
         analytics.track(event, Properties() from properties, this.getOptions(integrations))
 
     @ReactMethod
-    fun screen(name: String, properties: ReadableMap, context: ReadableMap) =
-        analytics.screen(name, Properties() from properties)
+    fun screen(name: String, properties: ReadableMap, integrations: ReadableMap, context: ReadableMap) =
+        analytics.screen(null, name, Properties() from properties, this.getOptions(integrations))
 
     @ReactMethod
     fun identify(userId: String, traits: ReadableMap, integrations: ReadableMap, context: ReadableMap) =
@@ -196,8 +196,8 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
         analytics.group(groupId, Traits() from traits, this.getOptions(integrations))
 
     @ReactMethod
-    fun alias(newId: String, context: ReadableMap) =
-        analytics.alias(newId)
+    fun alias(newId: String, context: ReadableMap, integrations: ReadableMap) =
+        analytics.alias(newId, this.getOptions(integrations))
 
     @ReactMethod
     fun reset() =

--- a/packages/core/docs/classes/analytics.client.md
+++ b/packages/core/docs/classes/analytics.client.md
@@ -53,7 +53,7 @@ ___
 
 ###  alias
 
-▸ **alias**(newId: *`string`*): `Promise`<`void`>
+▸ **alias**(newId: *`string`*, options?: *[Options]()*): `Promise`<`void`>
 
 *Defined in [analytics.ts:266](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L266)*
 
@@ -63,9 +63,10 @@ When you learn more about who the group is, you can record that information with
 
 **Parameters:**
 
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| newId | `string` |  The new ID you want to alias the existing ID to. The existing ID will be either the previousId if you have called identify, or the anonymous ID. |
+| Name | Type | Default value | Description |
+| ------ | ------ | ------ | ------ |
+| newId | `string` | - |  The new ID you want to alias the existing ID to. The existing ID will be either the previousId if you have called identify, or the anonymous ID. |
+| `Default value` options | [Options]() |  {} |
 
 **Returns:** `Promise`<`void`>
 
@@ -252,7 +253,7 @@ ___
 
 ###  screen
 
-▸ **screen**(name: *`string`*, properties?: *[JsonMap]()*): `Promise`<`void`>
+▸ **screen**(name: *`string`*, properties?: *[JsonMap]()*, options?: *[Options]()*): `Promise`<`void`>
 
 *Defined in [analytics.ts:225](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L225)*
 
@@ -266,6 +267,7 @@ When a user views a screen in your app, you'll want to record that here. For som
 | ------ | ------ | ------ | ------ |
 | name | `string` | - |  The title of the screen being viewed. We recommend using human-readable names like 'Photo Feed' or 'Completed Purchase Screen'. |
 | `Default value` properties | [JsonMap]() |  {} |  A dictionary of properties for the screen view event. If the event was 'Added to Shopping Cart', it might have properties like price, productType, etc. |
+| `Default value` options | [Options]() |  {} |
 
 **Returns:** `Promise`<`void`>
 

--- a/packages/core/docs/classes/analytics.client.md
+++ b/packages/core/docs/classes/analytics.client.md
@@ -55,7 +55,7 @@ ___
 
 ▸ **alias**(newId: *`string`*): `Promise`<`void`>
 
-*Defined in [analytics.ts:263](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L263)*
+*Defined in [analytics.ts:266](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L266)*
 
 Merge two user identities, effectively connecting two sets of user data as one. This may not be supported by all integrations.
 
@@ -97,7 +97,7 @@ ___
 
 ▸ **disable**(): `Promise`<`void`>
 
-*Defined in [analytics.ts:302](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L302)*
+*Defined in [analytics.ts:305](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L305)*
 
 Completely disable the sending of any analytics data.
 
@@ -112,7 +112,7 @@ ___
 
 ▸ **enable**(): `Promise`<`void`>
 
-*Defined in [analytics.ts:292](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L292)*
+*Defined in [analytics.ts:295](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L295)*
 
 Enable the sending of analytics data. Enabled by default.
 
@@ -127,7 +127,7 @@ ___
 
 ▸ **flush**(): `Promise`<`void`>
 
-*Defined in [analytics.ts:283](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L283)*
+*Defined in [analytics.ts:286](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L286)*
 
 Trigger an upload of all queued events.
 
@@ -142,7 +142,7 @@ ___
 
 ▸ **getAnonymousId**(): `Promise`<`string`>
 
-*Defined in [analytics.ts:307](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L307)*
+*Defined in [analytics.ts:310](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L310)*
 
 Retrieve the anonymousId.
 
@@ -153,9 +153,9 @@ ___
 
 ###  group
 
-▸ **group**(groupId: *`string`*, traits?: *[JsonMap]()*): `Promise`<`void`>
+▸ **group**(groupId: *`string`*, traits?: *[JsonMap]()*, options?: *[Options]()*): `Promise`<`void`>
 
-*Defined in [analytics.ts:250](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L250)*
+*Defined in [analytics.ts:253](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L253)*
 
 Associate a user with a group, organization, company, project, or w/e _you_ call them.
 
@@ -167,6 +167,7 @@ When you learn more about who the group is, you can record that information with
 | ------ | ------ | ------ | ------ |
 | groupId | `string` | - |  A database ID for this group. |
 | `Default value` traits | [JsonMap]() |  {} |  A dictionary of traits you know about the group. Things like: name, employees, etc. |
+| `Default value` options | [Options]() |  {} |  A dictionary of options, e.g. integrations (thigh analytics integration to forward the event to) |
 
 **Returns:** `Promise`<`void`>
 
@@ -175,9 +176,9 @@ ___
 
 ###  identify
 
-▸ **identify**(user: *`string`*, traits?: *[JsonMap]()*): `Promise`<`void`>
+▸ **identify**(user: *`string`*, traits?: *[JsonMap]()*, options?: *[Options]()*): `Promise`<`void`>
 
-*Defined in [analytics.ts:238](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L238)*
+*Defined in [analytics.ts:240](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L240)*
 
 Associate a user with their unique ID and record traits about them.
 
@@ -189,6 +190,7 @@ When you learn more about who your user is, you can record that information with
 | ------ | ------ | ------ | ------ |
 | user | `string` | - |  database ID (or email address) for this user. If you don't have a userId but want to record traits, you should pass nil. For more information on how we generate the UUID and Apple's policies on IDs, see [https://segment.io/libraries/ios#ids](https://segment.io/libraries/ios#ids) |
 | `Default value` traits | [JsonMap]() |  {} |  A dictionary of traits you know about the user. Things like: email, name, plan, etc. |
+| `Default value` options | [Options]() |  {} |  A dictionary of options, e.g. integrations (thigh analytics integration to forward the event to) |
 
 **Returns:** `Promise`<`void`>
 
@@ -237,7 +239,7 @@ ___
 
 ▸ **reset**(): `Promise`<`void`>
 
-*Defined in [analytics.ts:273](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L273)*
+*Defined in [analytics.ts:276](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L276)*
 
 Reset any user state that is cached on the device.
 
@@ -252,7 +254,7 @@ ___
 
 ▸ **screen**(name: *`string`*, properties?: *[JsonMap]()*): `Promise`<`void`>
 
-*Defined in [analytics.ts:224](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L224)*
+*Defined in [analytics.ts:225](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L225)*
 
 Record the screens or views your users see.
 
@@ -302,9 +304,9 @@ ___
 
 ###  track
 
-▸ **track**(event: *`string`*, properties?: *[JsonMap]()*): `Promise`<`void`>
+▸ **track**(event: *`string`*, properties?: *[JsonMap]()*, options?: *[Options]()*): `Promise`<`void`>
 
-*Defined in [analytics.ts:206](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L206)*
+*Defined in [analytics.ts:207](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L207)*
 
 Record the actions your users perform.
 
@@ -316,6 +318,7 @@ When a user performs an action in your app, you'll want to track that action for
 | ------ | ------ | ------ | ------ |
 | event | `string` | - |  The name of the event you're tracking. We recommend using human-readable names like \`Played a Song\` or \`Updated Status\`. |
 | `Default value` properties | [JsonMap]() |  {} |  A dictionary of properties for the event. If the event was 'Added to Shopping Cart', it might have properties like price, productType, etc. |
+| `Default value` options | [Options]() |  {} |  A dictionary of options, e.g. integrations (thigh analytics integration to forward the event to) |
 
 **Returns:** `Promise`<`void`>
 

--- a/packages/core/ios/RNAnalytics/RNAnalytics.m
+++ b/packages/core/ios/RNAnalytics/RNAnalytics.m
@@ -96,10 +96,10 @@ RCT_EXPORT_METHOD(
 }
 
 
-RCT_EXPORT_METHOD(track:(NSString*)name :(NSDictionary*)properties :(NSDictionary*)context) {
+RCT_EXPORT_METHOD(track:(NSString*)name :(NSDictionary*)properties :(NSDictionary*)options :(NSDictionary*)context) {
     [SEGAnalytics.sharedAnalytics track:name
                              properties:properties
-                                options:[self withContextAndIntegrations :context :properties]];
+                                options:[self withContextAndIntegrations :context :options]];
 }
 
 RCT_EXPORT_METHOD(screen:(NSString*)name :(NSDictionary*)properties :(NSDictionary*)context) {
@@ -108,16 +108,16 @@ RCT_EXPORT_METHOD(screen:(NSString*)name :(NSDictionary*)properties :(NSDictiona
                                  options:withContext(context)];
 }
 
-RCT_EXPORT_METHOD(identify:(NSString*)userId :(NSDictionary*)traits :(NSDictionary*)context) {
+RCT_EXPORT_METHOD(identify:(NSString*)userId :(NSDictionary*)traits :(NSDictionary*)options :(NSDictionary*)context) {
     [SEGAnalytics.sharedAnalytics identify:userId
                                     traits:traits
-                                   options:[self withContextAndIntegrations :context :traits]];
+                                   options:[self withContextAndIntegrations :context :options]];
 }
 
-RCT_EXPORT_METHOD(group:(NSString*)groupId :(NSDictionary*)traits :(NSDictionary*)context) {
+RCT_EXPORT_METHOD(group:(NSString*)groupId :(NSDictionary*)traits :(NSDictionary*)options :(NSDictionary*)context) {
     [SEGAnalytics.sharedAnalytics group:groupId
                                  traits:traits
-                                options:[self withContextAndIntegrations :context :traits]];
+                                options:[self withContextAndIntegrations :context :options]];
 }
 
 RCT_EXPORT_METHOD(alias:(NSString*)newId :(NSDictionary*)context) {

--- a/packages/core/ios/RNAnalytics/RNAnalytics.m
+++ b/packages/core/ios/RNAnalytics/RNAnalytics.m
@@ -90,10 +90,16 @@ RCT_EXPORT_METHOD(
 
 #define withContext(context) @{@"context": context}
 
+- (NSDictionary*)withContextAndIntegrations :(NSDictionary*)context :(NSDictionary*)properties {
+    NSDictionary* integrations = [properties objectForKey:@"integrations"];
+    return @{ @"context": context, @"interations": integrations ?: @{}};
+}
+
+
 RCT_EXPORT_METHOD(track:(NSString*)name :(NSDictionary*)properties :(NSDictionary*)context) {
     [SEGAnalytics.sharedAnalytics track:name
                              properties:properties
-                                options:withContext(context)];
+                                options:[self withContextAndIntegrations :context :properties]];
 }
 
 RCT_EXPORT_METHOD(screen:(NSString*)name :(NSDictionary*)properties :(NSDictionary*)context) {
@@ -105,13 +111,13 @@ RCT_EXPORT_METHOD(screen:(NSString*)name :(NSDictionary*)properties :(NSDictiona
 RCT_EXPORT_METHOD(identify:(NSString*)userId :(NSDictionary*)traits :(NSDictionary*)context) {
     [SEGAnalytics.sharedAnalytics identify:userId
                                     traits:traits
-                                   options:withContext(context)];
+                                   options:[self withContextAndIntegrations :context :traits]];
 }
 
 RCT_EXPORT_METHOD(group:(NSString*)groupId :(NSDictionary*)traits :(NSDictionary*)context) {
     [SEGAnalytics.sharedAnalytics group:groupId
                                  traits:traits
-                                options:withContext(context)];
+                                options:[self withContextAndIntegrations :context :traits]];
 }
 
 RCT_EXPORT_METHOD(alias:(NSString*)newId :(NSDictionary*)context) {

--- a/packages/core/ios/RNAnalytics/RNAnalytics.m
+++ b/packages/core/ios/RNAnalytics/RNAnalytics.m
@@ -92,7 +92,7 @@ RCT_EXPORT_METHOD(
 
 - (NSDictionary*)withContextAndIntegrations :(NSDictionary*)context :(NSDictionary*)properties {
     NSDictionary* integrations = [properties objectForKey:@"integrations"];
-    return @{ @"context": context, @"interations": integrations ?: @{}};
+    return @{ @"context": context, @"integrations": integrations ?: @{}};
 }
 
 

--- a/packages/core/ios/RNAnalytics/RNAnalytics.m
+++ b/packages/core/ios/RNAnalytics/RNAnalytics.m
@@ -88,8 +88,6 @@ RCT_EXPORT_METHOD(
     resolver(nil);
 }
 
-#define withContext(context) @{@"context": context}
-
 - (NSDictionary*)withContextAndIntegrations :(NSDictionary*)context :(NSDictionary*)integrations {
     return @{ @"context": context, @"integrations": integrations ?: @{}};
 }
@@ -101,10 +99,10 @@ RCT_EXPORT_METHOD(track:(NSString*)name :(NSDictionary*)properties :(NSDictionar
                                 options:[self withContextAndIntegrations :context :integrations]];
 }
 
-RCT_EXPORT_METHOD(screen:(NSString*)name :(NSDictionary*)properties :(NSDictionary*)context) {
+RCT_EXPORT_METHOD(screen:(NSString*)name :(NSDictionary*)properties :(NSDictionary*)integrations :(NSDictionary*)context) {
     [SEGAnalytics.sharedAnalytics screen:name
                               properties:properties
-                                 options:withContext(context)];
+                                 options:[self withContextAndIntegrations :context :integrations]];
 }
 
 RCT_EXPORT_METHOD(identify:(NSString*)userId :(NSDictionary*)traits :(NSDictionary*)integrations :(NSDictionary*)context) {
@@ -119,12 +117,10 @@ RCT_EXPORT_METHOD(group:(NSString*)groupId :(NSDictionary*)traits :(NSDictionary
                                 options:[self withContextAndIntegrations :context :integrations]];
 }
 
-RCT_EXPORT_METHOD(alias:(NSString*)newId :(NSDictionary*)context) {
+RCT_EXPORT_METHOD(alias:(NSString*)newId :(NSDictionary*)integrations :(NSDictionary*)context) {
     [SEGAnalytics.sharedAnalytics alias:newId
-                                options:withContext(context)];
+                                options:[self withContextAndIntegrations :context :integrations]];
 }
-
-#undef withContext
 
 RCT_EXPORT_METHOD(reset) {
     [SEGAnalytics.sharedAnalytics reset];

--- a/packages/core/ios/RNAnalytics/RNAnalytics.m
+++ b/packages/core/ios/RNAnalytics/RNAnalytics.m
@@ -90,16 +90,15 @@ RCT_EXPORT_METHOD(
 
 #define withContext(context) @{@"context": context}
 
-- (NSDictionary*)withContextAndIntegrations :(NSDictionary*)context :(NSDictionary*)properties {
-    NSDictionary* integrations = [properties objectForKey:@"integrations"];
+- (NSDictionary*)withContextAndIntegrations :(NSDictionary*)context :(NSDictionary*)integrations {
     return @{ @"context": context, @"integrations": integrations ?: @{}};
 }
 
 
-RCT_EXPORT_METHOD(track:(NSString*)name :(NSDictionary*)properties :(NSDictionary*)options :(NSDictionary*)context) {
+RCT_EXPORT_METHOD(track:(NSString*)name :(NSDictionary*)properties :(NSDictionary*)integrations :(NSDictionary*)context) {
     [SEGAnalytics.sharedAnalytics track:name
                              properties:properties
-                                options:[self withContextAndIntegrations :context :options]];
+                                options:[self withContextAndIntegrations :context :integrations]];
 }
 
 RCT_EXPORT_METHOD(screen:(NSString*)name :(NSDictionary*)properties :(NSDictionary*)context) {
@@ -108,16 +107,16 @@ RCT_EXPORT_METHOD(screen:(NSString*)name :(NSDictionary*)properties :(NSDictiona
                                  options:withContext(context)];
 }
 
-RCT_EXPORT_METHOD(identify:(NSString*)userId :(NSDictionary*)traits :(NSDictionary*)options :(NSDictionary*)context) {
+RCT_EXPORT_METHOD(identify:(NSString*)userId :(NSDictionary*)traits :(NSDictionary*)integrations :(NSDictionary*)context) {
     [SEGAnalytics.sharedAnalytics identify:userId
                                     traits:traits
-                                   options:[self withContextAndIntegrations :context :options]];
+                                   options:[self withContextAndIntegrations :context :integrations]];
 }
 
-RCT_EXPORT_METHOD(group:(NSString*)groupId :(NSDictionary*)traits :(NSDictionary*)options :(NSDictionary*)context) {
+RCT_EXPORT_METHOD(group:(NSString*)groupId :(NSDictionary*)traits :(NSDictionary*)integrations :(NSDictionary*)context) {
     [SEGAnalytics.sharedAnalytics group:groupId
                                  traits:traits
-                                options:[self withContextAndIntegrations :context :options]];
+                                options:[self withContextAndIntegrations :context :integrations]];
 }
 
 RCT_EXPORT_METHOD(alias:(NSString*)newId :(NSDictionary*)context) {

--- a/packages/core/src/__tests__/analytics.spec.ts
+++ b/packages/core/src/__tests__/analytics.spec.ts
@@ -48,7 +48,7 @@ it('catches bridge errors', async () => {
 	expect(onError).toHaveBeenCalledWith(error)
 })
 
-it('waits for .setup()', async () => {
+it.only('waits for .setup()', async () => {
 	const client = new Analytics.Client()
 
 	client.track('test 1')
@@ -57,8 +57,8 @@ it('waits for .setup()', async () => {
 	expect(Bridge.track).not.toHaveBeenCalled()
 	await client.setup('key')
 
-	expect(Bridge.track).toHaveBeenNthCalledWith(1, 'test 1', {}, ctx)
-	expect(Bridge.track).toHaveBeenNthCalledWith(2, 'test 2', {}, ctx)
+	expect(Bridge.track).toHaveBeenNthCalledWith(1, 'test 1', {}, {}, ctx)
+	expect(Bridge.track).toHaveBeenNthCalledWith(2, 'test 2', {}, {}, ctx)
 })
 
 it('does .track()', () =>

--- a/packages/core/src/__tests__/analytics.spec.ts
+++ b/packages/core/src/__tests__/analytics.spec.ts
@@ -62,15 +62,15 @@ it('waits for .setup()', async () => {
 })
 
 it('does .track()', () =>
-	testCall('track')('Added to cart', { productId: 'azertyuiop' }, ctx))
+	testCall('track')('Added to cart', { productId: 'azertyuiop' }, {}, ctx))
 
 it('does .screen()', () =>
 	testCall('screen')('Shopping cart', { from: 'Product page' }, ctx))
 
 it('does .identify()', () =>
-	testCall('identify')('sloth', { eats: 'leaves' }, ctx))
+	testCall('identify')('sloth', { eats: 'leaves' }, {}, ctx))
 
-it('does .group()', () => testCall('group')('bots', { humans: false }, ctx))
+it('does .group()', () => testCall('group')('bots', { humans: false }, {}, ctx))
 
 it('does .alias()', () => testCall('alias')('new alias', ctx))
 

--- a/packages/core/src/__tests__/analytics.spec.ts
+++ b/packages/core/src/__tests__/analytics.spec.ts
@@ -48,7 +48,7 @@ it('catches bridge errors', async () => {
 	expect(onError).toHaveBeenCalledWith(error)
 })
 
-it.only('waits for .setup()', async () => {
+it('waits for .setup()', async () => {
 	const client = new Analytics.Client()
 
 	client.track('test 1')

--- a/packages/core/src/__tests__/analytics.spec.ts
+++ b/packages/core/src/__tests__/analytics.spec.ts
@@ -106,8 +106,8 @@ function testCall<K extends keyof typeof Bridge>(name: K) {
 
 it('enables setting integrations from the middleware', async () => {
 	const integrations = {
-		Mixpanel: { foo: 'bar' },
-		'Google Analytics': false
+		'Google Analytics': false,
+		Mixpanel: { foo: 'bar' }
 	}
 
 	analytics.middleware(async ({ next, context, data, type }) => {

--- a/packages/core/src/__tests__/analytics.spec.ts
+++ b/packages/core/src/__tests__/analytics.spec.ts
@@ -111,7 +111,8 @@ it('enables setting integrations from the middleware', async () => {
 	}
 
 	analytics.middleware(async ({ next, context, data }) =>
-		next(context, { ...data, integrations, newId: '123' })
+		// @ts-ignore ts is expecting newId for some reasons
+		next(context, { ...data, integrations })
 	)
 
 	const trackSpy = jest.fn()

--- a/packages/core/src/__tests__/analytics.spec.ts
+++ b/packages/core/src/__tests__/analytics.spec.ts
@@ -65,14 +65,14 @@ it('does .track()', () =>
 	testCall('track')('Added to cart', { productId: 'azertyuiop' }, {}, ctx))
 
 it('does .screen()', () =>
-	testCall('screen')('Shopping cart', { from: 'Product page' }, ctx))
+	testCall('screen')('Shopping cart', { from: 'Product page' }, {}, ctx))
 
 it('does .identify()', () =>
 	testCall('identify')('sloth', { eats: 'leaves' }, {}, ctx))
 
 it('does .group()', () => testCall('group')('bots', { humans: false }, {}, ctx))
 
-it('does .alias()', () => testCall('alias')('new alias', ctx))
+it('does .alias()', () => testCall('alias')('new alias', {}, ctx))
 
 it('does .reset()', testCall('reset'))
 it('does .flush()', testCall('flush'))
@@ -110,17 +110,9 @@ it('enables setting integrations from the middleware', async () => {
 		Mixpanel: { foo: 'bar' }
 	}
 
-	analytics.middleware(async ({ next, context, data, type }) => {
-		switch (type) {
-			case 'track':
-			case 'identify':
-			case 'group':
-				// @ts-ignore ts says integrations is incompatible when type='alias'
-				return next(context, { ...data, integrations })
-			default:
-				return next(context)
-		}
-	})
+	analytics.middleware(async ({ next, context, data }) =>
+		next(context, { ...data, integrations, newId: '123' })
+	)
 
 	const trackSpy = jest.fn()
 	getBridgeStub('track').mockImplementationOnce(trackSpy)

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -1,4 +1,4 @@
-import Bridge, { JsonMap } from './bridge'
+import Bridge, { JsonMap, Options } from './bridge'
 import { configure } from './configuration'
 import { Middleware, MiddlewareChain } from './middleware'
 import { ErrorHandler, NativeWrapper } from './wrapper'
@@ -202,9 +202,10 @@ export module Analytics {
 		 * We recommend using human-readable names like `Played a Song` or `Updated Status`.
 		 * @param properties A dictionary of properties for the event.
 		 * If the event was 'Added to Shopping Cart', it might have properties like price, productType, etc.
+		 * @param options A dictionary of options, e.g. integrations (thigh analytics integration to forward the event to)
 		 */
-		public async track(event: string, properties: JsonMap = {}) {
-			await this.middlewares.run('track', { event, properties })
+		public async track(event: string, properties: JsonMap = {}, options: Options = {}) {
+			await this.middlewares.run('track', { event, properties, options })
 		}
 
 		/**
@@ -234,9 +235,10 @@ export module Analytics {
 		 * If you don't have a userId but want to record traits, you should pass nil.
 		 * For more information on how we generate the UUID and Apple's policies on IDs, see https://segment.io/libraries/ios#ids
 		 * @param traits A dictionary of traits you know about the user. Things like: email, name, plan, etc.
+		 * @param options A dictionary of options, e.g. integrations (thigh analytics integration to forward the event to)
 		 */
-		public async identify(user: string, traits: JsonMap = {}) {
-			await this.middlewares.run('identify', { user, traits })
+		public async identify(user: string, traits: JsonMap = {}, options: Options = {}) {
+			await this.middlewares.run('identify', { user, traits, options })
 		}
 
 		/**
@@ -246,9 +248,10 @@ export module Analytics {
 		 *
 		 * @param groupId A database ID for this group.
 		 * @param traits A dictionary of traits you know about the group. Things like: name, employees, etc.
+		 * @param options A dictionary of options, e.g. integrations (thigh analytics integration to forward the event to)
 		 */
-		public async group(groupId: string, traits: JsonMap = {}) {
-			await this.middlewares.run('group', { groupId, traits })
+		public async group(groupId: string, traits: JsonMap = {}, options: Options = {}) {
+			await this.middlewares.run('group', { groupId, traits, options })
 		}
 
 		/**

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -205,7 +205,7 @@ export module Analytics {
 		 * @param options A dictionary of options, e.g. integrations (thigh analytics integration to forward the event to)
 		 */
 		public async track(event: string, properties: JsonMap = {}, options: Options = {}) {
-			await this.middlewares.run('track', { event, properties, options })
+			await this.middlewares.run('track', { event, properties, integrations: options.integrations || {} })
 		}
 
 		/**
@@ -238,7 +238,7 @@ export module Analytics {
 		 * @param options A dictionary of options, e.g. integrations (thigh analytics integration to forward the event to)
 		 */
 		public async identify(user: string, traits: JsonMap = {}, options: Options = {}) {
-			await this.middlewares.run('identify', { user, traits, options })
+			await this.middlewares.run('identify', { user, traits, integrations: options.integrations || {} })
 		}
 
 		/**
@@ -251,7 +251,7 @@ export module Analytics {
 		 * @param options A dictionary of options, e.g. integrations (thigh analytics integration to forward the event to)
 		 */
 		public async group(groupId: string, traits: JsonMap = {}, options: Options = {}) {
-			await this.middlewares.run('group', { groupId, traits, options })
+			await this.middlewares.run('group', { groupId, traits, integrations: options.integrations || {} })
 		}
 
 		/**

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -222,8 +222,8 @@ export module Analytics {
 		 * @param properties A dictionary of properties for the screen view event.
 		 * If the event was 'Added to Shopping Cart', it might have properties like price, productType, etc.
 		 */
-		public async screen(name: string, properties: JsonMap = {}) {
-			await this.middlewares.run('screen', { name, properties })
+		public async screen(name: string, properties: JsonMap = {}, options: Options = {}) {
+			await this.middlewares.run('screen', { name, properties, integrations: options.integrations || {} })
 		}
 
 		/**
@@ -263,8 +263,8 @@ export module Analytics {
 		 * @param newId The new ID you want to alias the existing ID to.
 		 * The existing ID will be either the previousId if you have called identify, or the anonymous ID.
 		 */
-		public async alias(newId: string) {
-			await this.middlewares.run('alias', { newId })
+		public async alias(newId: string, options: Options = {}) {
+			await this.middlewares.run('alias', { newId, integrations: options.integrations || {} })
 		}
 
 		/**

--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -26,10 +26,12 @@ export interface JsonMap {
 }
 export interface JsonList extends Array<JsonValue> {}
 
+export interface Integrations {
+	[key: string]: boolean | JsonMap
+}
+
 export interface Options {
-	integrations?: {
-		[key: string]: boolean
-	}
+	integrations?: Integrations
 }
 
 export interface Bridge {

--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -48,14 +48,19 @@ export interface Bridge {
 		options: Options,
 		context: JsonMap
 	): Promise<void>
-	screen(name: string, properties: JsonMap, context: JsonMap): Promise<void>
+	screen(
+		name: string,
+		properties: JsonMap,
+		options: Options,
+		context: JsonMap
+	): Promise<void>
 	group(
 		groupId: string,
 		traits: JsonMap,
 		options: Options,
 		context: JsonMap
 	): Promise<void>
-	alias(alias: string, context: JsonMap): Promise<void>
+	alias(alias: string, options: Options, context: JsonMap): Promise<void>
 	reset(): Promise<void>
 	flush(): Promise<void>
 	enable(): Promise<void>

--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -26,12 +26,33 @@ export interface JsonMap {
 }
 export interface JsonList extends Array<JsonValue> {}
 
+export interface Options {
+	integrations?: {
+		[key: string]: boolean
+	}
+}
+
 export interface Bridge {
 	setup(configuration: Configuration): Promise<void>
-	track(event: string, properties: JsonMap, context: JsonMap): Promise<void>
-	identify(user: string, traits: JsonMap, context: JsonMap): Promise<void>
+	track(
+		event: string,
+		properties: JsonMap,
+		options: Options,
+		context: JsonMap
+	): Promise<void>
+	identify(
+		user: string,
+		traits: JsonMap,
+		options: Options,
+		context: JsonMap
+	): Promise<void>
 	screen(name: string, properties: JsonMap, context: JsonMap): Promise<void>
-	group(groupId: string, traits: JsonMap, context: JsonMap): Promise<void>
+	group(
+		groupId: string,
+		traits: JsonMap,
+		options: Options,
+		context: JsonMap
+	): Promise<void>
 	alias(alias: string, context: JsonMap): Promise<void>
 	reset(): Promise<void>
 	flush(): Promise<void>

--- a/packages/core/src/middleware.ts
+++ b/packages/core/src/middleware.ts
@@ -1,4 +1,4 @@
-import { JsonMap, Options } from './bridge'
+import { JsonMap, Integrations } from './bridge'
 import { assertNever } from './utils'
 import { NativeWrapper } from './wrapper'
 
@@ -17,7 +17,7 @@ export interface TrackPayload
 		{
 			event: string
 			properties: JsonMap
-			options: Options
+			integrations: Integrations
 		}
 	> {}
 
@@ -36,7 +36,7 @@ export interface IdentifyPayload
 		{
 			user: string
 			traits: JsonMap
-			options: Options
+			integrations: Integrations
 		}
 	> {}
 
@@ -46,7 +46,7 @@ export interface GroupPayload
 		{
 			groupId: string
 			traits: JsonMap
-			options: Options
+			integrations: Integrations
 		}
 	> {}
 
@@ -106,7 +106,7 @@ export class MiddlewareChain {
 					group(
 						payload.data.groupId,
 						payload.data.traits,
-						payload.data.options,
+						payload.data.integrations,
 						payload.context
 					)
 				)
@@ -115,7 +115,7 @@ export class MiddlewareChain {
 					identify(
 						payload.data.user,
 						payload.data.traits,
-						payload.data.options,
+						payload.data.integrations,
 						payload.context
 					)
 				)
@@ -128,7 +128,7 @@ export class MiddlewareChain {
 					track(
 						payload.data.event,
 						payload.data.properties,
-						payload.data.options,
+						payload.data.integrations,
 						payload.context
 					)
 				)

--- a/packages/core/src/middleware.ts
+++ b/packages/core/src/middleware.ts
@@ -1,4 +1,4 @@
-import { JsonMap, Integrations } from './bridge'
+import { Integrations, JsonMap } from './bridge'
 import { assertNever } from './utils'
 import { NativeWrapper } from './wrapper'
 

--- a/packages/core/src/middleware.ts
+++ b/packages/core/src/middleware.ts
@@ -27,6 +27,7 @@ export interface ScreenPayload
 		{
 			name: string
 			properties: JsonMap
+			integrations: Integrations
 		}
 	> {}
 
@@ -55,6 +56,7 @@ export interface AliasPayload
 		'alias',
 		{
 			newId: string
+			integrations: Integrations
 		}
 	> {}
 
@@ -99,7 +101,7 @@ export class MiddlewareChain {
 		switch (payload.type) {
 			case 'alias':
 				return this.wrapper.run('alias', alias =>
-					alias(payload.data.newId, payload.context)
+					alias(payload.data.newId, payload.data.integrations, payload.context)
 				)
 			case 'group':
 				return this.wrapper.run('group', group =>
@@ -121,7 +123,12 @@ export class MiddlewareChain {
 				)
 			case 'screen':
 				return this.wrapper.run('screen', screen =>
-					screen(payload.data.name, payload.data.properties, payload.context)
+					screen(
+						payload.data.name,
+						payload.data.properties,
+						payload.data.integrations,
+						payload.context
+					)
 				)
 			case 'track':
 				return this.wrapper.run('track', track =>

--- a/packages/core/src/middleware.ts
+++ b/packages/core/src/middleware.ts
@@ -1,4 +1,4 @@
-import { JsonMap } from './bridge'
+import { JsonMap, Options } from './bridge'
 import { assertNever } from './utils'
 import { NativeWrapper } from './wrapper'
 
@@ -17,6 +17,7 @@ export interface TrackPayload
 		{
 			event: string
 			properties: JsonMap
+			options: Options
 		}
 	> {}
 
@@ -35,6 +36,7 @@ export interface IdentifyPayload
 		{
 			user: string
 			traits: JsonMap
+			options: Options
 		}
 	> {}
 
@@ -44,6 +46,7 @@ export interface GroupPayload
 		{
 			groupId: string
 			traits: JsonMap
+			options: Options
 		}
 	> {}
 
@@ -100,11 +103,21 @@ export class MiddlewareChain {
 				)
 			case 'group':
 				return this.wrapper.run('group', group =>
-					group(payload.data.groupId, payload.data.traits, payload.context)
+					group(
+						payload.data.groupId,
+						payload.data.traits,
+						payload.data.options,
+						payload.context
+					)
 				)
 			case 'identify':
 				return this.wrapper.run('identify', identify =>
-					identify(payload.data.user, payload.data.traits, payload.context)
+					identify(
+						payload.data.user,
+						payload.data.traits,
+						payload.data.options,
+						payload.context
+					)
 				)
 			case 'screen':
 				return this.wrapper.run('screen', screen =>
@@ -112,7 +125,12 @@ export class MiddlewareChain {
 				)
 			case 'track':
 				return this.wrapper.run('track', track =>
-					track(payload.data.event, payload.data.properties, payload.context)
+					track(
+						payload.data.event,
+						payload.data.properties,
+						payload.data.options,
+						payload.context
+					)
 				)
 			default:
 				return assertNever(payload)


### PR DESCRIPTION
## Feature
Add the ability to pass in integration specific options

## API
Similarly to the native [iOS](https://segment.com/docs/sources/mobile/ios/#selecting-destinations) and [Android](https://segment.com/docs/sources/mobile/android/#selecting-destinations) implementations, the `integrationOptions` will be passed in as an object as a third argument to `track`, `identify` or `group`, e.g:

```js
analytics.track('Event Name', { foo: "bar" }, {
  integrations: { 
    Mixpanel: false,
    "Google Analytics": false
  }
});
```

All integrationOptions default to true unless configured otherwise. In the example above, the track event will not be sent to Mixpanel or Google Analytics, but will be sent to any other integrations if there are any more defined.

## Testing
### Android
_(Pixel 2 API 28)_
1. Sent the following events (the non-tracking one first!)
```js
// 1
analytics.track('Android - Google Analytics = false',
  { time: new Date().getTime(), platform: Platform.OS },
  { integrations: { 'Google Analytics': false } }
);

// 2
analytics.track('Android - Google Analytics = true',
  { time: new Date().getTime(), platform: Platform.OS },
  { integrations: { 'Google Analytics': true } }
);
```
2. Live Debugger output

![Screenshot 2019-06-13 at 11 23 49](https://user-images.githubusercontent.com/6534400/59425410-c6861980-8dcd-11e9-801b-da053430673f.png)

3. Google Analytics
![Screenshot 2019-06-13 at 11 25 59](https://user-images.githubusercontent.com/6534400/59425535-0a791e80-8dce-11e9-98e0-da6ecc69a096.png)

### iOS
_iPhone X_
1. Sent the following events (the non-tracking one first!)
```js
// 1
analytics.track('iOS - Google Analytics = false',
  { time: new Date().getTime(), platform: Platform.OS },
  { integrations: { 'Google Analytics': false } }
);

// 2
analytics.track('iOS - Google Analytics = true',
  { time: new Date().getTime(), platform: Platform.OS },
  { integrations: { 'Google Analytics': true } }
);
```
2. Live Debugger output
![Screenshot 2019-06-13 at 14 03 29](https://user-images.githubusercontent.com/6534400/59434754-12dc5400-8de4-11e9-86a9-4b1e4a07a33c.png)

3. Google Analytics
![Screenshot 2019-06-13 at 14 02 52](https://user-images.githubusercontent.com/6534400/59434702-fe985700-8de3-11e9-8247-7623561686fc.png)

### Not bundled
In the following examples, Google Analytics is bundled in the example app, and Mixpanel is not.
The expected behaviour is that Google Analytics will always be `false` and Mixpanel will have whatever value (boolean or object) that is passed in.
```js
analytics.track('Set to true', {  platform: Platform.OS },
  { integrations: { Mixpanel: true, "Google Analytics": true } }
);
```
#### Android
![Screenshot 2019-06-14 at 11 42 56](https://user-images.githubusercontent.com/6534400/59503949-973cde80-8e99-11e9-9a9b-d9c112471970.png)

#### iOS
![Screenshot 2019-06-14 at 12 13 29](https://user-images.githubusercontent.com/6534400/59505631-dec56980-8e9d-11e9-8c09-d8bbf7074f02.png)

```js
analytics.track('Set to false', {  platform: Platform.OS },
  { integrations: { Mixpanel: false, "Google Analytics": false } }
);
```
#### Android
![Screenshot 2019-06-14 at 11 46 51](https://user-images.githubusercontent.com/6534400/59504124-21854280-8e9a-11e9-8829-a59f57e002a2.png)

#### iOS
![Screenshot 2019-06-14 at 12 19 27](https://user-images.githubusercontent.com/6534400/59505927-c30e9300-8e9e-11e9-920a-db0ef4b36982.png)

```js
analytics.track('Additional parameters', {  platform: Platform.OS },
  { integrations: { Mixpanel: { foo: "bar" }, "Google Analytics": { foo: "bar" } }
);
```
#### Android
![Screenshot 2019-06-14 at 11 59 45](https://user-images.githubusercontent.com/6534400/59504902-f0a60d00-8e9b-11e9-8c7b-be52ae40a655.png)

#### iOS
![Screenshot 2019-06-14 at 12 21 36](https://user-images.githubusercontent.com/6534400/59506001-079a2e80-8e9f-11e9-9210-5bc648361973.png)
