### PR TITLE
feat(ios): set trackAdvertising=true by default

### DIFF
--- a/packages/core/docs/classes/analytics.client.md
+++ b/packages/core/docs/classes/analytics.client.md
@@ -142,7 +142,7 @@ ___
 
 ▸ **getAnonymousId**(): `Promise`<`string`>
 
-*Defined in [analytics.ts:305](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L305)*
+*Defined in [analytics.ts:307](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L307)*
 
 Retrieve the anonymousId.
 

--- a/packages/core/src/__tests__/configuration.spec.ts
+++ b/packages/core/src/__tests__/configuration.spec.ts
@@ -26,7 +26,7 @@ it('uses the default configuration', async () => {
 				flushInterval: undefined
 			},
 			ios: {
-				trackAdvertising: false,
+				trackAdvertising: true,
 				trackDeepLinks: false
 			}
 		})

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -51,8 +51,8 @@ export module Analytics {
 		ios?: {
 			/**
 			 * Whether the analytics client should track advertisting info.
-			 * 
-			 * Disabled by default.
+			 *
+			 * Enabled by default.
 			 */
 			trackAdvertising?: boolean
 			/**

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -10,7 +10,7 @@ const defaults = {
 		flushInterval
 	}),
 	ios: ({
-		trackAdvertising = false,
+		trackAdvertising = true,
 		trackDeepLinks = false
 	}: Partial<Configuration['ios']>) => ({
 		trackAdvertising,


### PR DESCRIPTION
Update the React Native iOS configuration to enable tracking by default, same as the [native iOS library](https://github.com/segmentio/analytics-ios/blob/d1db92dab26b75ae7a8cba925604d41c464b0051/Analytics/Classes/SEGAnalyticsConfiguration.m#L55).