### PR TITLE
Support Lifecycle Tracking

### DIFF
--- a/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
+++ b/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
@@ -163,6 +163,10 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
             builder.logLevel(Analytics.LogLevel.VERBOSE)
         }
 
+        if(options.getBoolean("trackAppLifecycleEvents")) {
+            builder.trackApplicationLifecycleEvents()
+        }
+
         try {
             Analytics.setSingletonInstance(
                 RNAnalytics.buildWithIntegrations(builder)


### PR DESCRIPTION
Previously the track application call was set on the builder after it was passed to the build with integrations call. We want to call it before ensuring the boolean is set when the builder creates the Analytics singleton.