### PR TITLE
fix(core): fix kotlin gradle version for integrations

### DIFF
--- a/packages/integrations/template/android/build.gradle
+++ b/packages/integrations/template/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.0'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.21'
     }
 }
 


### PR DESCRIPTION
- Fixes #90 
- Changed integration template to use Gradle 1.3.21