### PR TITLE
Use KotlinVersion of root project if available 

### DIFF
--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -1,6 +1,11 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
+def defaultKotlinVersion = '1.3.21'
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 buildscript {
     repositories {
         jcenter()
@@ -8,12 +13,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.21'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet("kotlinVersion", defaultKotlinVersion)}"
     }
-}
-
-def safeExtGet(prop, fallback) {
-    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
 android {
@@ -41,5 +42,5 @@ dependencies {
     api 'com.segment.analytics.android:analytics:4.+'
 
     api 'com.facebook.react:react-native:+'
-    api 'org.jetbrains.kotlin:kotlin-stdlib:1.3.21'
+    api "org.jetbrains.kotlin:kotlin-stdlib:${safeExtGet("kotlinVersion", defaultKotlinVersion)}"
 }


### PR DESCRIPTION
### Description
After upgrading the gradle version of our project, `react-native` test task failed. 
This pull request is using Kotlin version from the root project if available to prevent android test task errors