### PR TITLE
allow native and RN to share singleton instance

### DIFF
--- a/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
+++ b/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
@@ -171,6 +171,11 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
             Analytics.setSingletonInstance(
                 RNAnalytics.buildWithIntegrations(builder)
             )
+        } catch(e2: IllegalStateException) {
+            // pass if the error is due to calling setSingletonInstance multiple times
+
+            // if you created singleton in native code already,
+            // you need to promise.resolve for RN to properly operate
         } catch(e: Exception) {
             return promise.reject("E_SEGMENT_ERROR", e)
         }


### PR DESCRIPTION
Currently, if exception occurs when calling `setSingletonInstance` , we are rejecting it.

It prevents us using the singleton created at native side from RN.

If the exception is due to calling `setSingletonInstance` twice, we let the `setup` call resolve rather than reject so that RN can properly set itself up and use the singletonInstance created by native android.

This fixes https://github.com/segmentio/analytics-react-native/issues/95