### PR TITLE
Fix build issue with integrations

### DIFF
--- a/packages/integrations/template/android/build.gradle
+++ b/packages/integrations/template/android/build.gradle
@@ -41,7 +41,7 @@ repositories {
 
 
 dependencies {
-    api project(":@segment/analytics-react-native")
+    api project(":@segment_analytics-react-native")
     api('{{{dependency}}}') {
         transitive = true
     }


### PR DESCRIPTION
When Android running builds I'm getting the following issue:

```* Where:
Build file '/Users/.../node_modules/@segment/analytics-react-native-adjust/android/build.gradle' line: 41

* What went wrong:
A problem occurred evaluating project ':@segment_analytics-react-native-adjust'.
> Project with path ':@segment/analytics-react-native' could not be found in project ':@segment_analytics-react-native-adjust'.
```

Above change seems to fix.