### PR TITLE
fix(android): defaultKotlinVersion

### DIFF
--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -6,8 +6,8 @@ def safeExtGet(prop, fallback) {
 }
 
 buildscript {
-    def defaultKotlinVersion = '1.3.21'
-    
+    ext.defaultKotlinVersion = '1.3.21'
+
     repositories {
         jcenter()
         maven { url 'https://maven.google.com' }


### PR DESCRIPTION
Android builds might fail at the moment with following error message:

> FAILURE: Build failed with an exception.
> 
> * Where:
> Build file '…/node_modules/@segment/analytics-react-native/android/build.gradle' line: 45
> 
> * What went wrong:
> A problem occurred evaluating project ':@segment_analytics-react-native'.
> > Could not get unknown property 'defaultKotlinVersion' for object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.
> 

The scope of the variable `defaultKotlinVersion` was not correctly set in #157 and should be fixed with this PR. (This problem is also solved by #158 but this approach does not need to set the same variable twice.)