### PR TITLE
fix(bridge): fix duplicated analytics client improving errors

### DIFF
--- a/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
+++ b/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
@@ -112,7 +112,13 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
                 return promise.resolve(null)
             }
             else {
-                return promise.reject("E_SEGMENT_RECONFIGURED", "Duplicate Analytics client")
+                if (BuildConfig.DEBUG) {
+                    return pomise.resolve(this)
+                } 
+                else {
+                    return promise.reject("E_SEGMENT_RECONFIGURED", "Segment Analytics Client was allocated multiple times, please check your environment.")
+                }
+                
             }
         }
 

--- a/packages/core/ios/RNAnalytics/RNAnalytics.m
+++ b/packages/core/ios/RNAnalytics/RNAnalytics.m
@@ -46,7 +46,11 @@ RCT_EXPORT_METHOD(
             return resolver(nil);
         }
         else {
-            return rejecter(@"E_SEGMENT_RECONFIGURED", @"Duplicate Analytics client", nil);
+            #if DEBUG
+                return resolver(self);
+            #else
+                return rejecter(@"E_SEGMENT_RECONFIGURED", @"Segment Analytics Client was allocated multiple times, please check your environment.", nil);
+            #endif
         }
     }
 
@@ -67,7 +71,7 @@ RCT_EXPORT_METHOD(
     @try {
         [SEGAnalytics setupWithConfiguration:config];
     }
-    @catch(NSException* error) {
+    @catch(NSError* error) {
         return rejecter(@"E_SEGMENT_ERROR", @"Unexpected native Analtyics error", error);
     }
     
@@ -85,7 +89,7 @@ RCT_EXPORT_METHOD(
     }
 
     singletonJsonConfig = json;
-    resolver(nil);
+    return resolver(nil);
 }
 
 - (NSDictionary*)withContextAndIntegrations :(NSDictionary*)context :(NSDictionary*)integrations {


### PR DESCRIPTION
LAPP-31
An error with a label "Duplicate Analytics client" is displayed following the next steeps.
1.- Install and build the app on a iOS simulator.
2.- Setup the analytics object inside the project (I'm following setup instructions on segment doc).
3.- After run the simulator, modify the setup variables and save, this will reload the app and crash.
4.- An error must be displayed.