### PR TITLE
feat(core): add method to put device token

### DIFF
--- a/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
+++ b/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
@@ -229,6 +229,10 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
     @ReactMethod
     fun getAnonymousId(promise: Promise) =
             promise.resolve(analytics.getAnalyticsContext().traits().anonymousId())
+
+    @ReactMethod
+    fun putDeviceToken(deviceToken: String) =
+            analytics.getAnalyticsContext().putDeviceToken(deviceToken)
 }
 
 private fun optionsFrom(context: ReadableMap?, integrations: ReadableMap?): Options {

--- a/packages/core/docs/classes/analytics.client.md
+++ b/packages/core/docs/classes/analytics.client.md
@@ -234,6 +234,25 @@ analytics.middleware(async ({next, context}) =>
 **Returns:** `this`
 
 ___
+<a id="putdevicetoken"></a>
+
+###  putDeviceToken
+
+▸ **putDeviceToken**(deviceToken: *`string`*): `Promise`<`void`>
+
+*Defined in analytics.ts:317*
+
+Set a device token.
+
+**Parameters:**
+
+| Name | Type |
+| ------ | ------ |
+| deviceToken | `string` |
+
+**Returns:** `Promise`<`void`>
+
+___
 <a id="reset"></a>
 
 ###  reset

--- a/packages/core/ios/RNAnalytics/RNAnalytics.m
+++ b/packages/core/ios/RNAnalytics/RNAnalytics.m
@@ -150,4 +150,9 @@ RCT_EXPORT_METHOD(
   resolver(anonymousId);
 }
 
+RCT_EXPORT_METHOD(putDeviceToken:(NSString*)deviceToken)
+{
+    [SEGAnalytics.sharedAnalytics putDeviceToken:deviceToken];
+}
+
 @end

--- a/packages/core/src/__mocks__/bridge.ts
+++ b/packages/core/src/__mocks__/bridge.ts
@@ -6,6 +6,7 @@ export default {
 	getAnonymousId: jest.fn(),
 	group: jest.fn(),
 	identify: jest.fn(),
+	putDeviceToken: jest.fn(),
 	reset: jest.fn(),
 	screen: jest.fn(),
 	setup: jest.fn(),

--- a/packages/core/src/__tests__/analytics.spec.ts
+++ b/packages/core/src/__tests__/analytics.spec.ts
@@ -81,6 +81,8 @@ it('does .disable()', testCall('disable'))
 
 it('does .getAnonymousId()', testCall('getAnonymousId'))
 
+it('does .putDeviceToken()', () => testCall('putDeviceToken')('d34db33f'))
+
 it('logs uncaught bridge errors', async () => {
 	const error = {
 		message: 'test-error'

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -313,6 +313,13 @@ export module Analytics {
 			return Bridge.getAnonymousId()
 		}
 
+		/** Set a device token. */
+		public async putDeviceToken(deviceToken: string) {
+			await this.wrapper.wait()
+
+			Bridge.putDeviceToken(deviceToken)
+		}
+
 		private handleError(error: Error) {
 			const { handlers } = this
 

--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -74,6 +74,7 @@ export interface Bridge {
 	enable(): Promise<void>
 	disable(): Promise<void>
 	getAnonymousId(): Promise<string>
+	putDeviceToken(deviceToken: string): Promise<void>
 }
 
 const bridge: Bridge = NativeModules.RNAnalytics


### PR DESCRIPTION
**What does this PR do?**
This PR adds a method to put device tokens which are utilized by some destinations (e.g. Customer.io). Setting device tokens (obtained from Firebase Cloud Messaging SDK) enables Customer.io to track devices via Segment which enables their push notification feature. I created two other pull requests (for the Android and iOS SDK) which needs to land before this could be merged: segmentio/analytics-android#655 segmentio/analytics-ios#881

**How should this be manually tested?**
Call `analytics.putDeviceToken('i-am-a-device-token')` and check in Segment’s event debugger if new events contain the `token` key within their `context/device` dictionary.

**Any background context you want to provide?**
We are using Firebase Cloud Messaging (via [React Native Firebase](https://rnfirebase.io/)). We want to use Customer.io to send out push notifications and they require the device type and token to be set in order to recognize devices.

**What are the relevant tickets?**
#144

**Questions:**
- Does the docs need an update?
  I added comments, but the Segment website ([Analytics for React Native](https://segment.com/docs/connections/sources/catalog/libraries/mobile/react-native/)) might also need one.
- Are there any security concerns?
  I don't think so.
- Do we need to update engineering / success?
  Maybe?

---

Before this lands the dependencies to the native SDKs need to be updated [[1](https://github.com/segmentio/analytics-react-native/blob/d9794dbb48787007cd52952606a5af2adb32c823/packages/core/android/build.gradle#L42)][[2](https://github.com/segmentio/analytics-react-native/blob/d9794dbb48787007cd52952606a5af2adb32c823/packages/core/RNAnalytics.podspec#L23)].
