### PR TITLE
[Android] Force integration:Adjust.onResume

### DIFF
--- a/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalytics.kt
+++ b/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalytics.kt
@@ -29,6 +29,7 @@ import com.segment.analytics.integrations.Integration
 
 object RNAnalytics {
     private val integrations = mutableSetOf<Integration.Factory>()
+    private val onReadyCallbacks = mutableMapOf<String, Analytics.Callback<Any?>>()
 
     fun addIntegration(integration: Integration.Factory) {
         integrations.add(integration)
@@ -41,4 +42,15 @@ object RNAnalytics {
 
         return builder.build()
     }
+
+    fun addOnReadyCallback(key: String, callback: Analytics.Callback<Any?>) {
+        onReadyCallbacks[key] = callback
+    }
+
+    fun setupCallbacks(analytics: Analytics) {
+        for(integration in RNAnalytics.onReadyCallbacks.keys) {
+            analytics.onIntegrationReady(integration, RNAnalytics.onReadyCallbacks[integration])
+        }
+    }
 }
+

--- a/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
+++ b/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
@@ -166,6 +166,8 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
             this.trackApplicationLifecycleEvents(writeKey)
         }
 
+        RNAnalytics.setupCallbacks(analytics)
+
         singletonJsonConfig = json
         promise.resolve(null)
     }

--- a/packages/core/docs/README.md
+++ b/packages/core/docs/README.md
@@ -24,7 +24,7 @@
 
 **Ƭ Integration**: *`function` \| `object`*
 
-*Defined in analytics.ts:8*
+*Defined in [analytics.ts:8](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L8)*
 
 ___
 

--- a/packages/core/docs/classes/analytics.client.md
+++ b/packages/core/docs/classes/analytics.client.md
@@ -39,7 +39,7 @@
 
 **● ready**: *`false`* = false
 
-*Defined in analytics.ts:96*
+*Defined in [analytics.ts:96](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L96)*
 
 Whether the client is ready to send events to Segment.
 
@@ -55,7 +55,7 @@ ___
 
 ▸ **alias**(newId: *`string`*, options?: *[Options]()*): `Promise`<`void`>
 
-*Defined in analytics.ts:266*
+*Defined in [analytics.ts:266](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L266)*
 
 Merge two user identities, effectively connecting two sets of user data as one. This may not be supported by all integrations.
 
@@ -77,7 +77,7 @@ ___
 
 ▸ **catch**(handler: *[ErrorHandler]()*): `this`
 
-*Defined in analytics.ts:111*
+*Defined in [analytics.ts:111](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L111)*
 
 Catch React-Native bridge errors
 
@@ -98,7 +98,7 @@ ___
 
 ▸ **disable**(): `Promise`<`void`>
 
-*Defined in analytics.ts:305*
+*Defined in [analytics.ts:305](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L305)*
 
 Completely disable the sending of any analytics data.
 
@@ -113,7 +113,7 @@ ___
 
 ▸ **enable**(): `Promise`<`void`>
 
-*Defined in analytics.ts:295*
+*Defined in [analytics.ts:295](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L295)*
 
 Enable the sending of analytics data. Enabled by default.
 
@@ -128,7 +128,7 @@ ___
 
 ▸ **flush**(): `Promise`<`void`>
 
-*Defined in analytics.ts:286*
+*Defined in [analytics.ts:286](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L286)*
 
 Trigger an upload of all queued events.
 
@@ -143,7 +143,7 @@ ___
 
 ▸ **getAnonymousId**(): `Promise`<`string`>
 
-*Defined in analytics.ts:310*
+*Defined in [analytics.ts:310](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L310)*
 
 Retrieve the anonymousId.
 
@@ -156,7 +156,7 @@ ___
 
 ▸ **group**(groupId: *`string`*, traits?: *[JsonMap]()*, options?: *[Options]()*): `Promise`<`void`>
 
-*Defined in analytics.ts:253*
+*Defined in [analytics.ts:253](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L253)*
 
 Associate a user with a group, organization, company, project, or w/e _you_ call them.
 
@@ -179,7 +179,7 @@ ___
 
 ▸ **identify**(user: *`string`*, traits?: *[JsonMap]()*, options?: *[Options]()*): `Promise`<`void`>
 
-*Defined in analytics.ts:240*
+*Defined in [analytics.ts:240](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L240)*
 
 Associate a user with their unique ID and record traits about them.
 
@@ -202,7 +202,7 @@ ___
 
 ▸ **middleware**(middleware: *[Middleware]()*): `this`
 
-*Defined in analytics.ts:149*
+*Defined in [analytics.ts:149](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L149)*
 
 Append a new middleware to the middleware chain.
 
@@ -240,7 +240,7 @@ ___
 
 ▸ **reset**(): `Promise`<`void`>
 
-*Defined in analytics.ts:276*
+*Defined in [analytics.ts:276](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L276)*
 
 Reset any user state that is cached on the device.
 
@@ -255,7 +255,7 @@ ___
 
 ▸ **screen**(name: *`string`*, properties?: *[JsonMap]()*, options?: *[Options]()*): `Promise`<`void`>
 
-*Defined in analytics.ts:225*
+*Defined in [analytics.ts:225](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L225)*
 
 Record the screens or views your users see.
 
@@ -278,7 +278,7 @@ ___
 
 ▸ **setup**(writeKey: *`string`*, configuration?: *[Configuration](../interfaces/analytics.configuration.md)*): `Promise`<`void`>
 
-*Defined in analytics.ts:188*
+*Defined in [analytics.ts:188](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L188)*
 
 Setup the Analytics module. All calls made before are queued and only executed if the configuration was successful.
 
@@ -308,7 +308,7 @@ ___
 
 ▸ **track**(event: *`string`*, properties?: *[JsonMap]()*, options?: *[Options]()*): `Promise`<`void`>
 
-*Defined in analytics.ts:207*
+*Defined in [analytics.ts:207](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L207)*
 
 Record the actions your users perform.
 
@@ -331,7 +331,7 @@ ___
 
 ▸ **useNativeConfiguration**(): `this`
 
-*Defined in analytics.ts:161*
+*Defined in [analytics.ts:161](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L161)*
 
 Use the native configuration.
 

--- a/packages/core/docs/interfaces/analytics.configuration.md
+++ b/packages/core/docs/interfaces/analytics.configuration.md
@@ -29,7 +29,7 @@
 
 **● android**: *`undefined` \| `object`*
 
-*Defined in analytics.ts:69*
+*Defined in [analytics.ts:69](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L69)*
 
 Android specific settings.
 
@@ -40,7 +40,7 @@ ___
 
 **● debug**: *`undefined` \| `false` \| `true`*
 
-*Defined in analytics.ts:38*
+*Defined in [analytics.ts:38](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L38)*
 
 ___
 <a id="flushat"></a>
@@ -49,7 +49,7 @@ ___
 
 **● flushAt**: *`undefined` \| `number`*
 
-*Defined in analytics.ts:46*
+*Defined in [analytics.ts:46](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L46)*
 
 The number of queued events that the analytics client should flush at. Setting this to `1` will not queue any events and will use more battery.
 
@@ -62,7 +62,7 @@ ___
 
 **● ios**: *`undefined` \| `object`*
 
-*Defined in analytics.ts:51*
+*Defined in [analytics.ts:51](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L51)*
 
 iOS specific settings.
 
@@ -73,7 +73,7 @@ ___
 
 **● recordScreenViews**: *`undefined` \| `false` \| `true`*
 
-*Defined in analytics.ts:19*
+*Defined in [analytics.ts:19](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L19)*
 
 Whether the analytics client should automatically make a screen call when a view controller is added to a view hierarchy. Because the iOS underlying implementation uses method swizzling, we recommend initializing the analytics client as early as possible.
 
@@ -86,7 +86,7 @@ ___
 
 **● trackAppLifecycleEvents**: *`undefined` \| `false` \| `true`*
 
-*Defined in analytics.ts:26*
+*Defined in [analytics.ts:26](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L26)*
 
 Whether the analytics client should automatically track application lifecycle events, such as "Application Installed", "Application Updated" and "Application Opened".
 
@@ -99,7 +99,7 @@ ___
 
 **● trackAttributionData**: *`undefined` \| `false` \| `true`*
 
-*Defined in analytics.ts:32*
+*Defined in [analytics.ts:32](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L32)*
 
 Whether the analytics client should automatically track attribution data from enabled providers using the mobile service.
 
@@ -112,7 +112,7 @@ ___
 
 **● using**: *[Integration](../#integration)[]*
 
-*Defined in analytics.ts:37*
+*Defined in [analytics.ts:37](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L37)*
 
 Register a set of integrations to be used with this Analytics instance.
 

--- a/packages/integrations/applyPatches.sh
+++ b/packages/integrations/applyPatches.sh
@@ -8,7 +8,7 @@
 #
 # Patches that are applied below should have a comment explaining why the patch is necessary.
 # The patch should also be very manual and targeted.  Any files needed for the patch should also
-# mimic the `build` directory that gets generated.  This patch application script will be run 
+# mimic the `build` directory that gets generated.  This patch application script will be run
 # after the integration generation phase.
 #
 # Please discuss with @bsneed either in person or in github before adding patches.
@@ -24,3 +24,13 @@
 #    the iOS file, main.m.
 
 cp "./patches/@segment/analytics-react-native-appsflyer/ios/main.m" "./build/@segment/analytics-react-native-appsflyer/ios/main.m"
+
+### Adjust patch
+#
+# Q: Why?
+#
+# A: This is an adjust integration specific feature, and should not be replicated for
+# another integration. Because of this, we copy in a version with the appropriate code
+# applied to the Android file, IntegrationModule.kt
+
+cp "./patches/@segment/analytics-react-native-adjust/android/src/main/java/com/segment/analytics/reactnative/integration/adjust/IntegrationModule.kt" "./build/@segment/analytics-react-native-adjust/android/src/main/java/com/segment/analytics/reactnative/integration/adjust/IntegrationModule.kt"

--- a/packages/integrations/patches/@segment/analytics-react-native-adjust/android/src/main/java/com/segment/analytics/reactnative/integration/adjust/IntegrationModule.kt
+++ b/packages/integrations/patches/@segment/analytics-react-native-adjust/android/src/main/java/com/segment/analytics/reactnative/integration/adjust/IntegrationModule.kt
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package {{{classpath}}}
+package com.segment.analytics.reactnative.integration.adjust
 
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
@@ -30,17 +30,19 @@ import com.facebook.react.bridge.ReactMethod
 import com.segment.analytics.reactnative.core.RNAnalytics
 import com.segment.analytics.Analytics
 import android.util.Log
-import {{{factoryImport}}}
+import com.segment.analytics.android.integrations.adjust.AdjustIntegration
 
-class {{{nativeModule}}}Module(context: ReactApplicationContext): ReactContextBaseJavaModule(context) {
-    override fun getName() = "{{{nativeModule}}}"
+class RNAnalyticsIntegration_AdjustModule(context: ReactApplicationContext): ReactContextBaseJavaModule(context) {
+    override fun getName() = "RNAnalyticsIntegration_Adjust"
 
     @ReactMethod
     fun setup() {
-        RNAnalytics.addIntegration({{{factoryClass}}}.FACTORY)
-
-        RNAnalytics.addOnReadyCallback("{{{slug}}}", Analytics.Callback { instance ->
-            Log.v("{{{nativeModule}}}", "{{{slug}}} integration ready.")
+        RNAnalytics.addIntegration(AdjustIntegration.FACTORY)
+        RNAnalytics.addOnReadyCallback("Adjust", Analytics.Callback { instance ->
+            Log.v("RNAnalyticsIntegration_Adjust", "Adjust integration ready.")
+            if (instance is com.adjust.sdk.AdjustInstance) {
+                instance.onResume()
+            }
         })
     }
 }

--- a/packages/integrations/src/gen-integrations.ts
+++ b/packages/integrations/src/gen-integrations.ts
@@ -51,7 +51,7 @@ async function prepareAndroid({
 		...['Module', 'Package'].map(name =>
 			template(
 				`${root}/java/com/segment/analytics/reactnative/integration/${name}.kt`,
-				{ nativeModule, classpath, factoryClass, factoryImport },
+				{ nativeModule, classpath, factoryClass, factoryImport, slug },
 				`${root}/java/${classpath.replace(/\./g, '/')}/Integration${name}.kt`
 			)
 		)

--- a/packages/integrations/template/android/src/main/java/com/segment/analytics/reactnative/integration/Module.kt
+++ b/packages/integrations/template/android/src/main/java/com/segment/analytics/reactnative/integration/Module.kt
@@ -28,6 +28,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.segment.analytics.reactnative.core.RNAnalytics
+import android.util.Log
 import {{{factoryImport}}}
 
 class {{{nativeModule}}}Module(context: ReactApplicationContext): ReactContextBaseJavaModule(context) {
@@ -36,5 +37,9 @@ class {{{nativeModule}}}Module(context: ReactApplicationContext): ReactContextBa
     @ReactMethod
     fun setup() {
         RNAnalytics.addIntegration({{{factoryClass}}}.FACTORY)
+
+        RNAnalytics.addOnReadyCallback("{{{slug}}}", Analytics.Callback { instance ->
+            Log.v("{{{nativeModule}}}", "{{{slug}}} integration ready.")
+        })
     }
 }


### PR DESCRIPTION
It has been noticed that the Adjust integration does not function as expected on RN Android, the reason being when the app is freshly installed the Android `onResume` lifecycle function is not intercepted and thus functionality implemented there is not executed.
This PR exposes the `onReadyIntegration` to all integrations within RN and implements an Adjust specific behavior allowing us to force call the `onResume` function