### PR TITLE
Fix user-supplied context

### DIFF
--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -213,7 +213,7 @@ export module Analytics {
 		 * @param options A dictionary of options, e.g. integrations (thigh analytics integration to forward the event to)
 		 */
 		public async track(event: string, properties: JsonMap = {}, options: Options = {}) {
-			await this.middlewares.run('track', { event, properties, integrations: options.integrations || {} })
+			await this.middlewares.run('track', { event, properties, integrations: options.integrations || {} }, options.context || {})
 		}
 
 		/**
@@ -231,7 +231,7 @@ export module Analytics {
 		 * If the event was 'Added to Shopping Cart', it might have properties like price, productType, etc.
 		 */
 		public async screen(name: string, properties: JsonMap = {}, options: Options = {}) {
-			await this.middlewares.run('screen', { name, properties, integrations: options.integrations || {} })
+			await this.middlewares.run('screen', { name, properties, integrations: options.integrations || {} }, options.context || {})
 		}
 
 		/**
@@ -246,7 +246,7 @@ export module Analytics {
 		 * @param options A dictionary of options, e.g. integrations (thigh analytics integration to forward the event to)
 		 */
 		public async identify(user: string, traits: JsonMap = {}, options: Options = {}) {
-			await this.middlewares.run('identify', { user, traits, integrations: options.integrations || {} })
+			await this.middlewares.run('identify', { user, traits, integrations: options.integrations || {} }, options.context || {})
 		}
 
 		/**
@@ -259,7 +259,7 @@ export module Analytics {
 		 * @param options A dictionary of options, e.g. integrations (thigh analytics integration to forward the event to)
 		 */
 		public async group(groupId: string, traits: JsonMap = {}, options: Options = {}) {
-			await this.middlewares.run('group', { groupId, traits, integrations: options.integrations || {} })
+			await this.middlewares.run('group', { groupId, traits, integrations: options.integrations || {} }, options.context || {})
 		}
 
 		/**
@@ -272,7 +272,7 @@ export module Analytics {
 		 * The existing ID will be either the previousId if you have called identify, or the anonymous ID.
 		 */
 		public async alias(newId: string, options: Options = {}) {
-			await this.middlewares.run('alias', { newId, integrations: options.integrations || {} })
+			await this.middlewares.run('alias', { newId, integrations: options.integrations || {} }, options.context || {})
 		}
 
 		/**

--- a/packages/core/src/middleware.ts
+++ b/packages/core/src/middleware.ts
@@ -81,9 +81,11 @@ export class MiddlewareChain {
 
 	public async run<T extends Payload['type'], P extends PayloadFromType<T>>(
 		type: T,
-		data: P['data']
+		data: P['data'],
+		context: JsonMap
 	) {
 		const ctx: Context = {
+			...context,
 			library: {
 				name: 'analytics-react-native',
 				version: require('../package.json').version
@@ -91,11 +93,6 @@ export class MiddlewareChain {
 		}
 
 		const payload: Payload = await this.exec(type, ctx, data)
-
-		const opts: Options = {
-			context: payload.context,
-			integrations: payload.data.integrations
-		}
 
 		switch (payload.type) {
 			case 'alias':


### PR DESCRIPTION
## Summary
User supplied is not being utilised, this PR fixes that by setting it alongside the default context

## Tests
Single test to ensure context is added before sending across the bridge
