### PR TITLE
Improve installation section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you are part of a new startup  (&lt;$5M raised, &lt;2 years since founding), 
 
 ```bash
 $ yarn add @segment/analytics-react-native
-$ yarn react-native link
+$ cd ios && pod install && cd .. # CocoaPods on iOS needs this extra step
 ```
 
 ## Usage


### PR DESCRIPTION
Given the requirement in the readme of RN 0.62, it's better to replace the link command with the pod install step, as required by the [autolinking cli documentation](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).

(in fact, the link command doesn't do the pod install so the installation would be incomplete without it)