### PR TITLE
Put minimum deployment target to iOS 10.0

### DIFF
--- a/packages/core/RNAnalytics.podspec
+++ b/packages/core/RNAnalytics.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.author              = { 'Segment' => 'friends@segment.com' }
   s.source              = { :git => 'https://github.com/segmentio/analytics-react-native.git', :tag => s.version.to_s }
 
-  s.platform            = :ios, '11.0'
+  s.platform            = :ios, '10.0'
   s.source_files        = 'ios/**/*.{m,h}'
   s.static_framework    = true
 


### PR DESCRIPTION
Revert target changes made in https://github.com/segmentio/analytics-react-native/pull/206

If there is a reason for it to be iOS 11.0 please let us know as there is nothing about it in PR. As mentioned https://github.com/segmentio/analytics-react-native/pull/206#discussion_r481255148 here React Native still supports iOS 10.0

I did a test with iOS 10.3.1 and everything seemed to work fine.