### PR TITLE
add undefined to JsonValue type union

### DIFF
--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -26,7 +26,7 @@ export interface Configuration {
 	}
 }
 
-export type JsonValue = boolean | number | string | null | JsonList | JsonMap
+export type JsonValue = boolean | number | string | null | undefined | JsonList | JsonMap
 export interface JsonMap {
 	[key: string]: JsonValue
 	[index: number]: JsonValue


### PR DESCRIPTION
`JsonValue` should allow `undefined` for the optional chaining operator `?.` see https://github.com/segmentio/analytics-react-native/issues/204
AFAIK this should be typesafe because we're strictly increasing the leniency of the `JsonValue` type but curious what thoughts are on this