### PR TITLE
Fix error when building on iOS with @segment/analytics-react-native-appsflyer 1.3.2

### DIFF
--- a/packages/integrations/patches/@segment/analytics-react-native-appsflyer/ios/main.m
+++ b/packages/integrations/patches/@segment/analytics-react-native-appsflyer/ios/main.m
@@ -8,8 +8,8 @@
 
 #import <React/RCTBridgeModule.h>
 #import <RNAnalytics/RNAnalytics.h>
-#if defined(__has_include) && __has_include(<segment-appsflyer-ios/SEGAppsFlyerIntegrationFactory.h>)
-#import <segment-appsflyer-ios/SEGAppsFlyerIntegrationFactory.h>
+#if defined(__has_include) && __has_include(<segment_appsflyer_ios/SEGAppsFlyerIntegrationFactory.h>)
+#import <segment_appsflyer_ios/SEGAppsFlyerIntegrationFactory.h>
 #else
 #import <segment-appsflyer-ios/SEGAppsFlyerIntegrationFactory.h>
 #endif


### PR DESCRIPTION
This PR fixes the following error when building `@segment/analytics-react-native-appsflyer 1.3.2` on iOS.

```
/Users/jean/src/github.com/celo-org/celo-monorepo/node_modules/@segment/analytics-react-native-appsflyer/ios/main.m:14:9: fatal error: 'segment-appsflyer-ios/SEGAppsFlyerIntegrationFactory.h' file not found
#import <segment-appsflyer-ios/SEGAppsFlyerIntegrationFactory.h>
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

This probably only happens when `use_frameworks!` is used in the app's `Podfile`.