### PR TITLE
Fix crash when using proxy on iOS 12

### DIFF
--- a/packages/core/ios/RNAnalytics/RNAnalytics.m
+++ b/packages/core/ios/RNAnalytics/RNAnalytics.m
@@ -76,11 +76,11 @@ RCT_EXPORT_METHOD(
             NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
 
             if ([proxyOptions valueForKey:@"scheme"]) {
-                components.scheme = [proxyOptions[@"scheme"] stringValue];
+                components.scheme = proxyOptions[@"scheme"];
             }
 
             if ([proxyOptions valueForKey:@"host"]) {
-                components.host = [proxyOptions[@"host"] stringValue];
+                components.host = proxyOptions[@"host"];
             }
 
             if ([proxyOptions valueForKey:@"port"]) {
@@ -88,7 +88,7 @@ RCT_EXPORT_METHOD(
             }
 
             if ([proxyOptions valueForKey:@"path"]) {
-                components.path = [[proxyOptions[@"path"] stringValue] stringByAppendingString:components.path];
+                components.path = [proxyOptions[@"path"] stringByAppendingString:components.path];
             }
 
             NSURL *transformedURL = components.URL;


### PR DESCRIPTION
`proxyOptions[@"scheme"]` is already a string. Calling `stringValue` on `NSString` causes the following runtime crash on iOS <=12. 

```
NSInvalidArgumentException
-[NSTaggedPointerString stringValue]: unrecognized selector sent to instance 0xa000073707474685
```

Debugger says it's invalid:

![image](https://user-images.githubusercontent.com/648142/104011534-28735480-51a6-11eb-8ea6-20a63a0af36e.png)
