### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/packages/core/RNAnalytics.podspec
+++ b/packages/core/RNAnalytics.podspec
@@ -21,6 +21,6 @@ Pod::Spec.new do |s|
   s.static_framework    = true
 
   s.dependency          'Analytics', '~> 4.1'
-  s.dependency          'React'
+  s.dependency          'React-Core'
 end
 


### PR DESCRIPTION
### Summary
Latest Xcode 12 fails to build while without a module to depend on React-Core directly hence this change is necessary for all native modules on iOS. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116

### Test Plan
Use this branch to install with an app running on Xcode 12.