### PR TITLE
[Android] opt-out of new lifecycle methods

### DIFF
--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -39,7 +39,7 @@ repositories {
 }
 
 dependencies {
-    api 'com.segment.analytics.android:analytics:4.9.0'
+    api 'com.segment.analytics.android:analytics:4.9.1-beta'
 
     api 'com.facebook.react:react-native:+'
     api "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.has("kotlinVersion") ? rootProject.ext.get("kotlinVersion") : defaultKotlinVersion}"

--- a/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
+++ b/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
@@ -139,6 +139,9 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
             if(androidOptions.hasKey("collectDeviceId")) {
                 builder.collectDeviceId(androidOptions.getBoolean("collectDeviceId"))
             }
+            if(androidOptions.hasKey("experimentalUseNewLifecycleMethods")) {
+                builder.experimentalUseNewLifecycleMethods(androidOptions.getBoolean("experimentalUseNewLifecycleMethods"))
+            }
         }
 
         if(options.getBoolean("debug")) {

--- a/packages/core/docs/classes/analytics.client.md
+++ b/packages/core/docs/classes/analytics.client.md
@@ -40,7 +40,7 @@
 
 **● ready**: *`false`* = false
 
-*Defined in [analytics.ts:146](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L146)*
+*Defined in [analytics.ts:152](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L152)*
 
 Whether the client is ready to send events to Segment.
 
@@ -56,7 +56,7 @@ ___
 
 ▸ **alias**(newId: *`string`*, options?: *[Options]()*): `Promise`<`void`>
 
-*Defined in [analytics.ts:324](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L324)*
+*Defined in [analytics.ts:330](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L330)*
 
 Merge two user identities, effectively connecting two sets of user data as one. This may not be supported by all integrations.
 
@@ -78,7 +78,7 @@ ___
 
 ▸ **catch**(handler: *[ErrorHandler]()*): `this`
 
-*Defined in [analytics.ts:161](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L161)*
+*Defined in [analytics.ts:167](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L167)*
 
 Catch React-Native bridge errors
 
@@ -99,7 +99,7 @@ ___
 
 ▸ **disable**(): `Promise`<`void`>
 
-*Defined in [analytics.ts:363](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L363)*
+*Defined in [analytics.ts:369](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L369)*
 
 Completely disable the sending of any analytics data.
 
@@ -114,7 +114,7 @@ ___
 
 ▸ **enable**(): `Promise`<`void`>
 
-*Defined in [analytics.ts:353](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L353)*
+*Defined in [analytics.ts:359](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L359)*
 
 Enable the sending of analytics data. Enabled by default.
 
@@ -129,7 +129,7 @@ ___
 
 ▸ **flush**(): `Promise`<`void`>
 
-*Defined in [analytics.ts:344](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L344)*
+*Defined in [analytics.ts:350](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L350)*
 
 Trigger an upload of all queued events.
 
@@ -144,7 +144,7 @@ ___
 
 ▸ **getAnonymousId**(): `Promise`<`string`>
 
-*Defined in [analytics.ts:368](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L368)*
+*Defined in [analytics.ts:374](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L374)*
 
 Retrieve the anonymousId.
 
@@ -157,7 +157,7 @@ ___
 
 ▸ **group**(groupId: *`string`*, traits?: *[JsonMap]()*, options?: *[Options]()*): `Promise`<`void`>
 
-*Defined in [analytics.ts:311](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L311)*
+*Defined in [analytics.ts:317](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L317)*
 
 Associate a user with a group, organization, company, project, or w/e _you_ call them.
 
@@ -180,7 +180,7 @@ ___
 
 ▸ **identify**(user: *`string`*, traits?: *[JsonMap]()*, options?: *[Options]()*): `Promise`<`void`>
 
-*Defined in [analytics.ts:298](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L298)*
+*Defined in [analytics.ts:304](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L304)*
 
 Associate a user with their unique ID and record traits about them.
 
@@ -203,7 +203,7 @@ ___
 
 ▸ **middleware**(middleware: *[Middleware]()*): `this`
 
-*Defined in [analytics.ts:207](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L207)*
+*Defined in [analytics.ts:213](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L213)*
 
 Append a new middleware to the middleware chain.
 
@@ -241,7 +241,7 @@ ___
 
 ▸ **reset**(): `Promise`<`void`>
 
-*Defined in [analytics.ts:334](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L334)*
+*Defined in [analytics.ts:340](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L340)*
 
 Reset any user state that is cached on the device.
 
@@ -256,7 +256,7 @@ ___
 
 ▸ **screen**(name: *`string`*, properties?: *[JsonMap]()*, options?: *[Options]()*): `Promise`<`void`>
 
-*Defined in [analytics.ts:283](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L283)*
+*Defined in [analytics.ts:289](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L289)*
 
 Record the screens or views your users see.
 
@@ -279,7 +279,7 @@ ___
 
 ▸ **setIDFA**(idfa: *`string`*): `void`
 
-*Defined in [analytics.ts:171](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L171)*
+*Defined in [analytics.ts:177](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L177)*
 
 Sets the IDFA value on iOS. Customers are now responsible for collecting IDFA on their own.
 
@@ -298,7 +298,7 @@ ___
 
 ▸ **setup**(writeKey: *`string`*, configuration?: *[Configuration](../interfaces/analytics.configuration.md)*): `Promise`<`void`>
 
-*Defined in [analytics.ts:246](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L246)*
+*Defined in [analytics.ts:252](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L252)*
 
 Setup the Analytics module. All calls made before are queued and only executed if the configuration was successful.
 
@@ -328,7 +328,7 @@ ___
 
 ▸ **track**(event: *`string`*, properties?: *[JsonMap]()*, options?: *[Options]()*): `Promise`<`void`>
 
-*Defined in [analytics.ts:265](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L265)*
+*Defined in [analytics.ts:271](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L271)*
 
 Record the actions your users perform.
 
@@ -351,7 +351,7 @@ ___
 
 ▸ **useNativeConfiguration**(): `this`
 
-*Defined in [analytics.ts:219](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L219)*
+*Defined in [analytics.ts:225](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/analytics.ts#L225)*
 
 Use the native configuration.
 

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -133,8 +133,14 @@ export module Analytics {
 			 * Enabled by default.
 			 */
 			collectDeviceId?: boolean
-		}
-	}
+
+      /**
+       * Whether the analytics client should use the new lifecycle methods. This option is enabled by default.
+       * If the new lifecycle methods cause issue, you should disable this config option
+       */
+      experimentalUseNewLifecycleMethods?: boolean
+    }
+  }
 
 	export class Client {
 		/**


### PR DESCRIPTION
Closes https://github.com/segmentio/analytics-react-native/issues/255
As outlined in https://github.com/segmentio/analytics-android/issues/725, we are adding the builder `experimentalUseNewLifecycleMethods(bool)` to react-native to disable the use of the new lifecycle methods. This flag is enabled by default and can be disabled on react-native like so
```js
analytics.setup(SEGMENT_WRITE_KEY, {
  ...
  android: {
  ...,
  experimentalUseNewLifecycleMethods: false
  },
});
```