### PR TITLE
chore(dep): fix include for analytics-ios 3.x vs 4.x

### DIFF
--- a/packages/core/ios/RNAnalytics/RNAnalytics.m
+++ b/packages/core/ios/RNAnalytics/RNAnalytics.m
@@ -7,7 +7,12 @@
 
 #import "RNAnalytics.h"
 
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGAnalytics.h>
+#else
+#import <Segment/SEGAnalytics.h>
+#endif
+
 #import <React/RCTBridge.h>
 
 static NSMutableSet* RNAnalyticsIntegrations = nil;


### PR DESCRIPTION
- Fixes issue with the header import compatibility for analytics-ios 3.x vs 4.x