### PR TITLE
Fix android test-app CI failure

### DIFF
--- a/packages/test-app/seed/android/app/build.gradle
+++ b/packages/test-app/seed/android/app/build.gradle
@@ -143,7 +143,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
+    implementation 'androidx.appcompat:appcompat:${rootProject.ext.supportLibVersion}'
     implementation "com.facebook.react:react-native:+"  // From node_modules
 }
 

--- a/packages/test-app/seed/android/app/src/main/AndroidManifest.xml
+++ b/packages/test-app/seed/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
-<manifest 
+<manifest
   xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.testapp" 
-  xmlns:tools="http://schemas.android.com/tools">
+  package="com.testapp">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
@@ -11,8 +10,7 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
-      android:theme="@style/AppTheme"
-      tools:replace="android:appComponentFactory">
+      android:theme="@style/AppTheme">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/packages/test-app/seed/android/app/src/main/AndroidManifest.xml
+++ b/packages/test-app/seed/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+      tools:replace="android:appComponentFactory">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/packages/test-app/seed/android/app/src/main/AndroidManifest.xml
+++ b/packages/test-app/seed/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.testapp">
+<manifest 
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.testapp" 
+  xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/packages/test-app/seed/android/build.gradle
+++ b/packages/test-app/seed/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         minSdkVersion = 16
         compileSdkVersion = 28
         targetSdkVersion = 28
-        supportLibVersion = "28.0.0"
+        supportLibVersion = "1.0.2"
         kotlinVersion = "1.3.0"
         detoxKotlinVersion = kotlinVersion
     }

--- a/packages/test-app/seed/android/gradle.properties
+++ b/packages/test-app/seed/android/gradle.properties
@@ -16,3 +16,6 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
Android CI was failing silently due to manifest conflicts. We have now migrated to the new androidx libraries to resolve the issue. Closes #269 