### PR TITLE
fix(android): lifecycle option not forwarded

### DIFF
--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -18,6 +18,7 @@ export interface Configuration {
 	android: {
 		flushInterval?: number
 		collectDeviceId: boolean
+		experimentalUseNewLifecycleMethods: boolean
 	}
 	ios: {
 		trackAdvertising: boolean

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -4,9 +4,11 @@ import { Configuration } from './bridge'
 const defaults = {
 	android: ({
 		collectDeviceId = true,
+		experimentalUseNewLifecycleMethods = true,
 		flushInterval
 	}: Partial<Configuration['android']>) => ({
 		collectDeviceId,
+		experimentalUseNewLifecycleMethods,
 		flushInterval
 	}),
 	ios: ({


### PR DESCRIPTION
I'm hitting the issue in https://github.com/segmentio/analytics-react-native/issues/255 with the latest release, and followed the instructions in https://github.com/segmentio/analytics-react-native/pull/256 to attempt to resolve this but found out that the required option (`experimentalUseNewLifecycleMethods`) is not making its way to the native module `setup()` method.

It's unclear to me why there's typings in both the Bridge and the Analytics js modules, perhaps that's where the confusion lies?