### PR TITLE
fix: iOS losing integrations on Setup

### DIFF
--- a/packages/integrations/template/ios/main.m
+++ b/packages/integrations/template/ios/main.m
@@ -21,8 +21,10 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(setup) {
+RCT_EXPORT_METHOD(setup: (RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
     [RNAnalytics addIntegration:{{{factory_class_name}}}.instance];
+    resolve(nil);
 }
 
 @end


### PR DESCRIPTION
## Issue

Sometimes, mainly on iOS, I'm losing the integration with some libs, like AppsFlyer or Firebase.
We set up as described on [device-mode doc](https://segment.com/docs/connections/sources/catalog/libraries/mobile/react-native/#packaging-destinations-using-device-mode) but sometimes the received payload on Segment was missing some of the defined integrations.
example of a correct payload passing `using: [AppsFlyer, Firebase]`: 
```
"integrations": {
    "AppsFlyer": false,
    "Firebase": false
  }
```
As described on the issue #61 those event informations were being lost and I could find the root cause of the problem.

## Wrong Behavior 

Debugging I found some intermittent behaviour in this part of the [code](https://github.com/segmentio/analytics-react-native/blob/40683c7c70d4a750d947fe7117962b0c09cb1936/packages/core/ios/RNAnalytics/RNAnalytics.m#L105)

This code is using the [RNAnalyticsIntegrations](https://github.com/segmentio/analytics-react-native/blob/40683c7c70d4a750d947fe7117962b0c09cb1936/packages/core/ios/RNAnalytics/RNAnalytics.m#L18) to add on integration factories to `SEGAnalyticsConfiguration`. 

This is a `static NSMutableSet` and it is updated when this integrations are setup.
https://github.com/segmentio/analytics-react-native/blob/40683c7c70d4a750d947fe7117962b0c09cb1936/packages/core/ios/RNAnalytics/RNAnalytics.m#L18

**Setup Method Examples**
[AppsFlyer](https://github.com/segmentio/analytics-react-native/blob/f0febdbf229533137c64091e460f530448339cec/packages/integrations/patches/%40segment/analytics-react-native-appsflyer/ios/main.m#L27)
[Facebook](https://github.com/segmentio/analytics-react-native/blob/6ec053b1e2c5fcb1e7276c64ade9752c0417a615/packages/integrations/patches/%40segment/analytics-react-native-facebook-app-events-ios/ios/main.m#L27)

However, sometimes the method [RNAnalytics.setup](https://github.com/segmentio/analytics-react-native/blob/40683c7c70d4a750d947fe7117962b0c09cb1936/packages/core/ios/RNAnalytics/RNAnalytics.m#L105) is called before RNAnalyticsIntegrations being updated.

I put out some logs while debugging the code and could find that this happens:

```
2021-03-30 18:23:30.648295-0300 nomad_mobile_app[27521:152492] AF_TEST addIntegration: SEGFirebaseIntegrationFactory
2021-03-30 18:23:30.648317-0300 nomad_mobile_app[27521:152488] AF_TEST addIntegration: BNCBranchIntegrationFactory
2021-03-30 18:23:30.648639-0300 nomad_mobile_app[27521:152503] AF_TEST start USE {(
    <SEGFirebaseIntegrationFactory: 0x600003b9c460>,
    <BNCBranchIntegrationFactory: 0x600003b84830>
)}
2021-03-30 18:23:30.648843-0300 nomad_mobile_app[27521:152461] AF_TEST addIntegration: SEGAppsFlyerIntegrationFactory
```

Logs added:

RNAnalytics.m, ln 24
```
+(void)addIntegration:(id)factory {
    NSLog(@"AF_TEST addIntegration: %@", [factory class]);
    [RNAnalyticsIntegrationsLock lock];
    [RNAnalyticsIntegrations addObject:factory];
    [RNAnalyticsIntegrationsLock unlock];
} 
```
RNAnalytics.m, ln 105
```
    NSLog(@"AF_TEST start USE %@", RNAnalyticsIntegrations);
    for(id factory in RNAnalyticsIntegrations) {
        [config use:factory];
    }
```

## Hypothesis

My hypothesis was that the following part of the RN code is not waiting correctly for all integrations to be called.
https://github.com/segmentio/analytics-react-native/blob/e522f6ef0eddd30c7a2952fe9dc9ee860bda81cb/packages/core/src/configuration.ts#L36-L40

I confirmed it putting a sleep on Firebase setup and could check that the code wasn't waiting for all promises to be resolved to continue the execution, so causing the bug.

## Fix 

Looking on React Native doc I found something about **ReactModules** and **Promises**, I made this change on iOS and start to working well. I tested with `5 seconds` on Firebase setup and still working.
https://reactnative.dev/docs/0.62/native-modules-ios#promises

## Android

I made the change just for iOS because It's our main problem and I'm more comfortable to test. 
But it is easy to do the same thing on Android side. Just follow this doc: https://reactnative.dev/docs/native-modules-android#promises