### PR TITLE
fix(android): register setIDFA function correctly for native bridge

### DIFF
--- a/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalytics.kt
+++ b/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalytics.kt
@@ -31,10 +31,6 @@ object RNAnalytics {
     private val integrations = mutableSetOf<Integration.Factory>()
     private val onReadyCallbacks = mutableMapOf<String, Analytics.Callback<Any?>>()
 
-    fun setIDFA(idfa: String) {
-        // do nothing; iOS only.
-    }
-    
     fun addIntegration(integration: Integration.Factory) {
         integrations.add(integration)
     }

--- a/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
+++ b/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
@@ -284,6 +284,11 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
     @ReactMethod
     fun getAnonymousId(promise: Promise) =
             promise.resolve(analytics.getAnalyticsContext().traits().anonymousId())
+
+    @ReactMethod
+    fun setIDFA(idfa: String) {
+        // do nothing; iOS only.
+    }
 }
 
 private fun optionsFrom(context: ReadableMap?, integrations: ReadableMap?): Options {


### PR DESCRIPTION
Fix for #210 function call to `analytics.setIDFA` on Android devices