### PR TITLE
fix: correct import of Segment_Facebook_App_Events

### DIFF
--- a/packages/integrations/patches/@segment/analytics-react-native-facebook-app-events-ios/ios/main.m
+++ b/packages/integrations/patches/@segment/analytics-react-native-facebook-app-events-ios/ios/main.m
@@ -12,6 +12,8 @@
 #import <Segment_FacebookAppEvents/SEGFacebookAppEventsIntegrationFactory.h>
 #elif defined(__has_include) && __has_include(<Segment-Facebook-App-Events/SEGFacebookAppEventsIntegrationFactory.h>)
 #import <Segment-Facebook-App-Events/SEGFacebookAppEventsIntegrationFactory.h>
+#elif defined(__has_include) && __has_include(<Segment_Facebook_App_Events/SEGFacebookAppEventsIntegrationFactory.h>)
+#import <Segment_Facebook_App_Events/SEGFacebookAppEventsIntegrationFactory.h>
 #else
 #import <Segment-FacebookAppEvents/SEGFacebookAppEventsIntegrationFactory.h>
 #endif


### PR DESCRIPTION
we had the problem, that the import file import <Segment-FacebookAppEvents/SEGFacebookAppEventsIntegrationFactory.h> could not be found, which caused our build to break. After digging around we found the solution that manually adding `Segment_Facebook_App_Events.framework` to the linked Libraries in xcode and adjusting the import fixes this.