### PR TITLE
fix: ci brew applesimutils

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
       - *attach
       - run: brew update-reset
       - run: brew tap wix/brew
-      - run: brew install wix/brew/applesimutils
+      - run: brew install applesimutils
       - run:
           name: Install dependencies
           command: |


### PR DESCRIPTION
Fixing the install command in circleCI to install applesimutils