### PR TITLE
fix: detox ios simulator config

### DIFF
--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -45,7 +45,10 @@
         "binaryPath": "project/ios/build/Build/Products/Release-iphonesimulator/TestApp.app",
         "build": "export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -workspace project/ios/TestApp.xcworkspace -scheme TestApp -configuration Release -sdk iphonesimulator -derivedDataPath project/ios/build",
         "type": "ios.simulator",
-        "name": "iPhone 11"
+        "device": {
+          "name": "iPhone 11",
+          "os": "iOS 14.5"
+        }
       },
       "android": {
         "binaryPath": "project/android/app/build/outputs/apk/debug/app-debug.apk",


### PR DESCRIPTION
Setting an specific version of iOS Simulator to 14.5 as the current Detox version we use crashes with iOS 15﻿
