### PR TITLE
fix: #identify argument type

### DIFF
--- a/packages/core/src/__tests__/methods/identify.test.ts
+++ b/packages/core/src/__tests__/methods/identify.test.ts
@@ -79,4 +79,17 @@ describe('methods #identify', () => {
       userId: 'new-user-id',
     });
   });
+  it('does not update user id when user id is undefined', () => {
+    const client = new SegmentClient(defaultClientSettings);
+    jest.spyOn(client, 'process');
+
+    client.identify(undefined, { name: 'Mary' });
+
+    // @ts-ignore
+    expect(client.store.dispatch).toHaveBeenCalledTimes(1);
+    // @ts-ignore
+    expect(client.actions.userInfo.setUserId).not.toHaveBeenCalled();
+    // @ts-ignore
+    expect(client.actions.userInfo.setTraits).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/core/src/__tests__/methods/identify.test.ts
+++ b/packages/core/src/__tests__/methods/identify.test.ts
@@ -80,7 +80,7 @@ describe('methods #identify', () => {
     });
   });
   it('does not update user id when user id is undefined', () => {
-    const client = new SegmentClient(defaultClientSettings);
+    const client = new SegmentClient(clientArgs);
     jest.spyOn(client, 'process');
 
     client.identify(undefined, { name: 'Mary' });

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -502,7 +502,7 @@ export class SegmentClient {
 
     this.store.userInfo.set({
       ...userInfo,
-      userId: userId,
+      ...(userId !== undefined ? { userId } : {}),
       traits: mergedTraits,
     });
 

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -487,7 +487,7 @@ export class SegmentClient {
     this.logger.info('TRACK event saved', event);
   }
 
-  identify(userId: string, userTraits?: UserTraits) {
+  identify(userId?: string, userTraits?: UserTraits) {
     const userInfo = this.store.userInfo.get();
     const { traits: currentUserTraits } = userInfo;
 


### PR DESCRIPTION
Hello library maintainers 👋 ,

thanks for this lovely library! @alan-eu we are happily using your service but we came across an incoherence between your docs and your code which I attempt to fix in this PR.

I read your contributing guidelines but couldn't find a pull request template. I hope the format I chose is okay.

## Problem

In your [docs](https://segment.com/docs/connections/sources/catalog/libraries/mobile/react-native/#identify) you state for the `userId` argument of the `identify` method:

> The database ID for this user. If you don’t know who the user is yet, you can omit the `userId` and just record `traits`.

But with the current implementation Typescript won't allow us to omit a `userId`. We circumvent this issue by passing `undefined as any` but this is suboptimal.

## Solution

I tried to adjust the `identify` method's behaviour in a way that is in line with the existing logic, namely:

- `userId` can be `undefined`
- if `userId` is `undefined` the store is not updated

## Tests

I added a test case checking that only the user traits are updated when passing `undefined` as a `userId`. I tried to follow the preexisting unit test style.

As stated in the guidelines I ran all the scripts mentioned to check that tests, linting and the typescript compiler pass.

I'm looking forward to your comments!

Best,
Ramin