### PR TITLE
chore: refactor redux store access

### DIFF
--- a/packages/core/src/__mocks__/context.ts
+++ b/packages/core/src/__mocks__/context.ts
@@ -1,0 +1,35 @@
+export const getContext = jest.fn().mockResolvedValue({
+  app: {
+    build: '1',
+    name: 'Segment Example',
+    namespace: 'com.segment.example.analytics',
+    version: '1.0',
+  },
+  device: {
+    id: '123-456-789',
+    manufacturer: 'Apple',
+    model: 'x86_64',
+    name: 'iPhone',
+    type: 'phone',
+  },
+  library: {
+    name: '@segment/analytics-react-native',
+    version: '2.0.0-pilot.1',
+  },
+  locale: 'en_US',
+  network: {
+    cellular: false,
+    wifi: true,
+  },
+  os: {
+    name: 'iOS',
+    version: '14.1',
+  },
+  screen: {
+    density: 2.625,
+    height: 800,
+    width: 600,
+  },
+  timezone: 'Europe/London',
+  traits: {},
+});

--- a/packages/core/src/__mocks__/react-native.ts
+++ b/packages/core/src/__mocks__/react-native.ts
@@ -1,0 +1,33 @@
+export const AppState = {
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+};
+
+export const Linking = {
+  getInitialURL: jest.fn(),
+  addEventListener: jest.fn(),
+};
+
+export const NativeModules = {
+  AnalyticsReactNative: {
+    getContextInfo: jest.fn().mockResolvedValue({
+      appName: 'Segment Example',
+      appVersion: '1.0',
+      buildNumber: '1',
+      bundleId: 'com.segment.example.analytics',
+      locale: 'en_US',
+      networkType: 'wifi',
+      osName: 'iOS',
+      osVersion: '14.1',
+      screenHeight: 800,
+      screenWidth: 600,
+      screenDensity: 2.625,
+      timezone: 'Europe/London',
+      manufacturer: 'Apple',
+      model: 'x86_64',
+      deviceName: 'iPhone',
+      deviceId: '123-456-789',
+      deviceType: 'phone',
+    }),
+  },
+};

--- a/packages/core/src/__mocks__/uuid.ts
+++ b/packages/core/src/__mocks__/uuid.ts
@@ -1,0 +1,1 @@
+export const getUUID = () => 'mocked-uuid';

--- a/packages/core/src/__tests__/__helpers__/getTestClient.ts
+++ b/packages/core/src/__tests__/__helpers__/getTestClient.ts
@@ -1,0 +1,97 @@
+import type { Persistor } from 'redux-persist';
+import { SegmentClient } from '../../analytics';
+import { Logger } from '../../logger';
+import type { MainState } from '../../store/main';
+import { ReduxStorage } from '../../storage';
+import type { SystemState } from '../../store/system';
+import type { UserInfoState } from '../../store/userInfo';
+import type { Config } from '../../types';
+import { mockPersistor } from './mockPersistor';
+
+jest.mock('../../context');
+jest.mock('react-native');
+
+const getMockLogger = () => {
+  const logger = new Logger();
+  logger.disable();
+  logger.info = jest.fn();
+  logger.warn = jest.fn();
+  logger.error = jest.fn();
+  return logger;
+};
+
+// We set the persistor to initialized
+mockPersistor.getState = jest.fn().mockReturnValue({
+  bootstrapped: true,
+});
+
+/**
+ * Creates a Redux Store compliant with the SegmentStore interface that can be used for testing in jest
+ * @param state State to return from the Redux Store, defaults to a valid empty state
+ * @returns a Redux Store instance
+ */
+export const getMockReduxStorage = (
+  state?: Partial<{
+    main: MainState;
+    system: SystemState;
+    userInfo: UserInfoState;
+  }>
+) => {
+  return new ReduxStorage(
+    {
+      subscribe: jest.fn(),
+      dispatch: jest.fn(),
+      // @ts-ignore Ignore the type cause ReduxToolkit state type has a bunch of internals we don't need
+      getState: () => ({
+        userInfo: {
+          anonymousId: 'my-id',
+          userId: 'user-id',
+        },
+        main: {
+          events: [],
+          eventsToRetry: [],
+          context: {
+            app: {
+              build: '1',
+              version: '1.2',
+            },
+          },
+        },
+        system: {
+          settings: {
+            integrations: {},
+          },
+        },
+        ...state,
+      }),
+    },
+    mockPersistor
+  );
+};
+
+/**
+ * Creates a segment client with default settings that can be used for testing in jest
+ * @param configOverride overrides any of the params in SegmentClient constructor
+ * @returns a SegmentClient instance for testing
+ */
+export const getTestClient = (
+  configOverride?: Partial<{
+    config: Config;
+    logger: Logger;
+    store: any;
+    persistor: Persistor;
+  }>
+) => {
+  const clientArgs = {
+    config: {
+      writeKey: 'SEGMENT_KEY',
+      flushAt: 10,
+      retryInterval: 40,
+    },
+    logger: getMockLogger(),
+    persistor: mockPersistor,
+    store: getMockReduxStorage(),
+    ...configOverride,
+  };
+  return new SegmentClient(clientArgs);
+};

--- a/packages/core/src/__tests__/__helpers__/mockSegmentStore.ts
+++ b/packages/core/src/__tests__/__helpers__/mockSegmentStore.ts
@@ -1,0 +1,157 @@
+import type { Storage } from '../../storage';
+import type { UserInfoState } from '../../store/userInfo';
+import type {
+  Context,
+  DeepPartial,
+  IntegrationSettings,
+  SegmentAPIIntegrations,
+  SegmentEvent,
+} from '../../types';
+
+type Data = {
+  isReady: boolean;
+  events: SegmentEvent[];
+  eventsToRetry: SegmentEvent[];
+  context?: DeepPartial<Context>;
+  settings: SegmentAPIIntegrations;
+  userInfo: UserInfoState;
+};
+
+const INITIAL_VALUES: Data = {
+  isReady: true,
+  events: [],
+  eventsToRetry: [],
+  context: undefined,
+  settings: {},
+  userInfo: {
+    anonymousId: 'anonymousId',
+    userId: undefined,
+    traits: undefined,
+  },
+};
+
+export class MockSegmentStore implements Storage {
+  private data: Data;
+  private initialData: Data;
+
+  reset = () => {
+    this.data = JSON.parse(JSON.stringify(this.initialData));
+  };
+
+  constructor(initialData?: Partial<Data>) {
+    this.data = { ...INITIAL_VALUES, ...initialData };
+    this.initialData = { ...INITIAL_VALUES, ...initialData };
+  }
+
+  // Callbacks
+  private createCallbackManager = <V, R = void>() => {
+    type Callback = (value: V) => R;
+    const callbacks: Callback[] = [];
+
+    const deregister = (callback: Callback) => {
+      callbacks.splice(callbacks.indexOf(callback), 1);
+    };
+
+    const register = (callback: Callback) => {
+      callbacks.push(callback);
+      return () => {
+        deregister(callback);
+      };
+    };
+
+    const run = (value: V) => {
+      callbacks.forEach((callback) => callback(value));
+    };
+
+    return { register, deregister, run };
+  };
+
+  private callbacks = {
+    context: this.createCallbackManager<DeepPartial<Context> | undefined>(),
+    settings: this.createCallbackManager<SegmentAPIIntegrations>(),
+    events: this.createCallbackManager<SegmentEvent[]>(),
+    eventsToRetry: this.createCallbackManager<SegmentEvent[]>(),
+    userInfo: this.createCallbackManager<UserInfoState>(),
+  };
+
+  readonly isReady = {
+    get: () => {
+      return this.data.isReady;
+    },
+    onChange: (_callback: (value: boolean) => void) => {
+      // Not doing anything cause this mock store is always ready, this is just legacy from the redux persistor
+      return () => {};
+    },
+  };
+
+  readonly context = {
+    get: () => ({ ...this.data.context }),
+    onChange: (callback: (value?: DeepPartial<Context>) => void) =>
+      this.callbacks.context.register(callback),
+    set: (value: DeepPartial<Context>) => {
+      this.data.context = { ...value };
+      this.callbacks.context.run(value);
+    },
+  };
+
+  readonly settings = {
+    get: () => this.data.settings,
+    onChange: (
+      callback: (value?: SegmentAPIIntegrations | undefined) => void
+    ) => this.callbacks.settings.register(callback),
+    set: (value: SegmentAPIIntegrations) => {
+      this.data.settings = value;
+      this.callbacks.settings.run(value);
+    },
+    add: (key: string, value: IntegrationSettings) => {
+      this.data.settings[key] = value;
+      this.callbacks.settings.run(this.data.settings);
+    },
+  };
+
+  readonly events = {
+    get: () => this.data.events,
+    onChange: (callback: (value: SegmentEvent[]) => void) =>
+      this.callbacks.events.register(callback),
+    add: (event: SegmentEvent | SegmentEvent[]) => {
+      const eventsToAdd = Array.isArray(event) ? event : [event];
+      this.data.events.push(...eventsToAdd);
+      this.callbacks.events.run(this.data.events);
+    },
+    remove: (event: SegmentEvent | SegmentEvent[]) => {
+      const eventsToRemove = Array.isArray(event) ? event : [event];
+      const setToRemove = new Set(eventsToRemove);
+      this.data.events = this.data.events.filter(
+        (callback) => !setToRemove.has(callback)
+      );
+      this.callbacks.events.run(this.data.events);
+    },
+  };
+
+  readonly eventsToRetry = {
+    get: () => this.data.eventsToRetry,
+    onChange: (callback: (value: SegmentEvent[]) => void) =>
+      this.callbacks.eventsToRetry.register(callback),
+    add: (events: SegmentEvent[]) => {
+      this.data.eventsToRetry.push(...events);
+      this.callbacks.eventsToRetry.run(this.data.eventsToRetry);
+    },
+    remove: (events: SegmentEvent[]) => {
+      const setToRemove = new Set(events);
+      this.data.eventsToRetry = this.data.eventsToRetry.filter(
+        (callback) => !setToRemove.has(callback)
+      );
+      this.callbacks.eventsToRetry.run(this.data.eventsToRetry);
+    },
+  };
+
+  readonly userInfo = {
+    get: () => this.data.userInfo,
+    onChange: (callback: (value: UserInfoState) => void) =>
+      this.callbacks.userInfo.register(callback),
+    set: (value: UserInfoState) => {
+      this.data.userInfo = value;
+      this.callbacks.userInfo.run(value);
+    },
+  };
+}

--- a/packages/core/src/__tests__/analytics.test.ts
+++ b/packages/core/src/__tests__/analytics.test.ts
@@ -1,54 +1,27 @@
-import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import type { AppStateStatus } from 'react-native';
-import * as ReactNative from 'react-native';
+import { AppState } from 'react-native';
 import { EventType, IdentifyEventType } from '..';
 import { SegmentClient } from '../analytics';
-import { Logger } from '../logger';
-import { actions, Store } from '../store';
-import mainSlice from '../store/main';
-import systemSlice from '../store/system';
-import userInfo from '../store/userInfo';
-import { getMockStore } from './__helpers__/mockStore';
+import { getMockReduxStorage } from './__helpers__/getTestClient';
+import { getMockLogger } from './__helpers__/mockLogger';
+import { mockPersistor } from './__helpers__/mockPersistor';
+import { MockSegmentStore } from './__helpers__/mockSegmentStore';
 
-jest.mock('redux-persist', () => {
-  const real = jest.requireActual('redux-persist');
-  return {
-    ...real,
-    persistStore: jest.fn().mockImplementation((newStore) => newStore),
-    persistReducer: jest.fn().mockImplementation((_, reducers) => reducers),
-  };
-});
+jest.mock('react-native');
+jest.mock('../uuid');
 
-jest.mock('../uuid', () => ({
-  getUUID: () => 'mocked-uuid',
-}));
-
-const getMockLogger = () => {
-  const logger = new Logger();
-  logger.disable();
-  logger.info = jest.fn();
-  logger.warn = jest.fn();
-  logger.error = jest.fn();
-  return logger;
-};
-
-describe('SegmentClient initialise', () => {
+describe('SegmentClient', () => {
+  const ReduxStorage = getMockReduxStorage();
   const clientArgs = {
     config: {
       writeKey: 'SEGMENT_KEY',
       flushAt: 10,
       retryInterval: 40,
+      trackAppLifecycleEvents: true,
     },
     logger: getMockLogger(),
-    persistor: { subscribe: jest.fn() } as any,
-    store: getMockStore(),
-    actions: {
-      addEvent: jest.fn(),
-      setUserId: jest.fn(),
-      addUserTraits: jest.fn(),
-      reset: jest.fn(),
-      updateContext: jest.fn(),
-    },
+    persistor: mockPersistor,
+    store: ReduxStorage,
   };
 
   beforeEach(() => {
@@ -56,177 +29,124 @@ describe('SegmentClient initialise', () => {
   });
 
   describe('when initializing a new client', () => {
-    it('creates the client with default values', () => {
+    it('creates the client with default values', async () => {
+      const segmentClient = new SegmentClient(clientArgs);
+      expect(segmentClient.getConfig()).toEqual(clientArgs.config);
+    });
+  });
+
+  describe('#setupInterval', () => {
+    beforeEach(() => {
+      // Using the legacy timers of jest to track calls
+      jest.useFakeTimers('legacy');
+    });
+
+    afterEach(() => {
+      jest.clearAllTimers();
+    });
+
+    it('resets the interval and creates a new one when initialised', async () => {
+      const segmentClient = new SegmentClient({
+        ...clientArgs,
+        config: { ...clientArgs.config, flushInterval: 10 },
+      });
+      await segmentClient.init();
+
+      const flush = jest.spyOn(segmentClient, 'flush');
+      // An interval should be set to check each second
+      expect(setInterval).toHaveBeenLastCalledWith(expect.any(Function), 1000);
+
+      // Wait 10 secs for the flush interval to happen
+      jest.advanceTimersByTime(10 * 1000);
+
+      // Flush should have been called at flushInterval
+      expect(flush).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('#setupLifecycleEvents', () => {
+    it('subscribes to the app state update events', async () => {
+      let updateCallback = (_val: AppStateStatus) => {};
+
+      const addSpy = jest
+        .spyOn(AppState, 'addEventListener')
+        .mockImplementation((_action, callback) => {
+          updateCallback = callback;
+          return { remove: jest.fn() };
+        });
+
       const segmentClient = new SegmentClient(clientArgs);
 
-      expect(segmentClient.getConfig()).toEqual(clientArgs.config);
-      // Legacy checks,
-      // TODO: Remove these as they test private
       // @ts-ignore
-      expect(segmentClient.config).toStrictEqual(clientArgs.config);
+      jest.spyOn(segmentClient, 'handleAppStateChange');
+      await segmentClient.init();
+
+      expect(addSpy).toHaveBeenCalledTimes(1);
+      expect(addSpy).toHaveBeenCalledWith('change', expect.any(Function));
+
       // @ts-ignore
-      expect(segmentClient.store).toStrictEqual(clientArgs.store);
+      expect(segmentClient.handleAppStateChange).not.toHaveBeenCalled();
+
+      updateCallback('active');
+
       // @ts-ignore
-      expect(segmentClient.actions).toStrictEqual(clientArgs.actions);
+      expect(segmentClient.handleAppStateChange).toHaveBeenCalledTimes(1);
       // @ts-ignore
-      expect(segmentClient.persistor).toStrictEqual(clientArgs.persistor);
-      // @ts-ignore
-      expect(segmentClient.secondsElapsed).toStrictEqual(0);
-      // @ts-ignore
-      expect(segmentClient.appState).toStrictEqual('unknown');
+      expect(segmentClient.handleAppStateChange).toHaveBeenCalledWith('active');
     });
   });
 
-  describe('internal setup methods', () => {
-    describe('#setupInterval', () => {
-      beforeEach(() => {
-        // Using the legacy timers of jest to track calls
-        jest.useFakeTimers('legacy');
-      });
+  describe('#cleanup', () => {
+    it('clears all subscriptions and timers', async () => {
+      const segmentClient = new SegmentClient(clientArgs);
+      await segmentClient.init();
 
-      afterEach(() => {
-        jest.clearAllTimers();
-      });
-
-      it('resets the interval and creates a new one when initialised', () => {
-        const segmentClient = new SegmentClient(clientArgs);
-
+      jest.spyOn(
         // @ts-ignore
-        expect(segmentClient.interval).toBe(null);
+        segmentClient.appStateSubscription,
+        'remove'
+      );
 
-        // @ts-ignore value is irrelevant
-        segmentClient.interval = 'TEST';
-
-        segmentClient.setupInterval();
-
-        // TODO: Jest recommends not to test for checking interval as they are an implementation detail but test the side effect, refactor these in the future
-        expect(clearInterval).toHaveBeenCalledTimes(1);
-        expect(clearInterval).toHaveBeenCalledWith('TEST');
-        expect(setInterval).toHaveBeenLastCalledWith(
-          expect.any(Function),
-          1000
-        );
-        // @ts-ignore
-        expect(segmentClient.interval).not.toBe('TEST');
-      });
-    });
-
-    describe('#setupStoreSubscribe', () => {
-      it('subscribes to the redux store', () => {
-        const segmentClient = new SegmentClient(clientArgs);
-
-        segmentClient.setupStoreSubscribe();
-
-        // Each watcher generates a subscription so we just check that it has subscribed at least once
-        expect(clientArgs.store.subscribe).toHaveBeenCalled();
-      });
-    });
-
-    describe('#setupLifecycleEvents', () => {
-      it('subscribes to the app state update events', () => {
-        let updateCallback = (_val: AppStateStatus) => {};
-
-        const addSpy = jest
-          .spyOn(ReactNative.AppState, 'addEventListener')
-          .mockImplementation((_action, callback) => {
-            updateCallback = callback;
-            return { remove: jest.fn() };
-          });
-
-        const segmentClient = new SegmentClient(clientArgs);
-        jest.spyOn(segmentClient, 'handleAppStateChange');
-        segmentClient.setupLifecycleEvents();
-
-        expect(addSpy).toHaveBeenCalledTimes(1);
-        expect(addSpy).toHaveBeenCalledWith('change', expect.any(Function));
-
-        expect(segmentClient.handleAppStateChange).not.toHaveBeenCalled();
-
-        updateCallback('active');
-
-        expect(segmentClient.handleAppStateChange).toHaveBeenCalledTimes(1);
-        expect(segmentClient.handleAppStateChange).toHaveBeenCalledWith(
-          'active'
-        );
-      });
-    });
-
-    describe('#cleanup', () => {
-      it('clears all subscriptions and timers', () => {
-        const segmentClient = new SegmentClient(clientArgs);
-        // @ts-ignore actual value is irrelevant
-        segmentClient.interval = 'INTERVAL';
-        const unsubscribe = jest.fn();
-        // @ts-ignore
-        segmentClient.watchers = [unsubscribe];
-        // @ts-ignore actual value is irrelevant
-        segmentClient.refreshTimeout = 'TIMEOUT';
-        // @ts-ignore
-        segmentClient.appStateSubscription = {
-          remove: jest.fn(),
-        };
-
-        segmentClient.cleanup();
-        // @ts-ignore
-        expect(segmentClient.destroyed).toBe(true);
-        expect(clearInterval).toHaveBeenCalledTimes(1);
-        expect(clearInterval).toHaveBeenCalledWith('INTERVAL');
-        expect(unsubscribe).toHaveBeenCalledTimes(1);
-        expect(clearTimeout).toHaveBeenCalledTimes(1);
-        expect(clearTimeout).toHaveBeenCalledWith('TIMEOUT');
-        // @ts-ignore
-        expect(segmentClient.appStateSubscription.remove).toHaveBeenCalledTimes(
-          1
-        );
-      });
+      segmentClient.cleanup();
+      // @ts-ignore
+      expect(segmentClient.destroyed).toBe(true);
+      expect(clearInterval).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).toHaveBeenCalledTimes(1);
+      // @ts-ignore
+      expect(segmentClient.appStateSubscription.remove).toHaveBeenCalledTimes(
+        1
+      );
     });
   });
-});
 
-describe('SegmentClient #reset', () => {
-  const clientArgs = {
-    config: {
-      writeKey: 'SEGMENT_KEY',
-      flushAt: 10,
-      retryInterval: 40,
-    },
-    logger: getMockLogger(),
-    persistor: { subscribe: jest.fn() } as any,
-    store: getMockStore(),
-    actions: {
-      userInfo: {
-        reset: jest.fn(),
-      },
-    },
-  };
+  describe('#reset', () => {
+    it('resets user data, identity, traits', () => {
+      const client = new SegmentClient(clientArgs);
+      const setUserInfo = jest.spyOn(ReduxStorage.userInfo, 'set');
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+      client.reset();
 
-  it('resets user data, identity, traits', () => {
-    const client = new SegmentClient(clientArgs);
-
-    client.reset();
-
-    // @ts-ignore
-    expect(client.store.dispatch).toHaveBeenCalledWith(
-      clientArgs.actions.userInfo.reset()
-    );
+      expect(setUserInfo).toHaveBeenCalledWith({
+        anonymousId: 'mocked-uuid',
+        userId: undefined,
+        traits: undefined,
+      });
+    });
   });
 });
 
 describe('SegmentClient #onUpdateStore', () => {
+  const store = new MockSegmentStore();
   const clientArgs = {
     config: {
       writeKey: 'SEGMENT_KEY',
       flushAt: 10,
       retryInterval: 40,
+      trackAppLifecycleEvents: true,
     },
     logger: getMockLogger(),
-    persistor: { subscribe: jest.fn() } as any,
-    store: getMockStore(),
-    actions: {},
+    persistor: mockPersistor,
+    store: store,
   };
 
   const sampleEvent: IdentifyEventType = {
@@ -241,17 +161,9 @@ describe('SegmentClient #onUpdateStore', () => {
     messageId: 'iDMkR2-I7c2_LCsPPlvwH',
   };
 
-  const rootReducer = combineReducers({
-    main: mainSlice.reducer,
-    system: systemSlice.reducer,
-    userInfo: userInfo.reducer,
-  });
-  let mockStore = configureStore({ reducer: rootReducer }) as Store;
-
   beforeEach(() => {
     jest.useFakeTimers();
-    // Reset the Redux store to a clean state
-    mockStore = configureStore({ reducer: rootReducer }) as Store;
+    store.reset();
   });
 
   afterEach(() => {
@@ -262,69 +174,57 @@ describe('SegmentClient #onUpdateStore', () => {
   /**
    * Creates a client wired up with store subscriptions and flush mocks for testing automatic flushes
    */
-  const setupClient = (flushAt: number): SegmentClient => {
+  const setupClient = async (flushAt: number): Promise<SegmentClient> => {
     const args = {
       ...clientArgs,
       config: {
         ...clientArgs.config,
         flushAt,
+        retryInterval: 1,
       },
-      store: mockStore,
-      actions: actions,
     };
     const client = new SegmentClient(args);
+    await client.init();
     // It is important to setup the flush spy before setting up the subscriptions so that it tracks the calls in the closure
     jest.spyOn(client, 'flush').mockResolvedValueOnce();
     jest.spyOn(client, 'flushRetry').mockResolvedValueOnce();
-    client.setupStoreSubscribe();
     return client;
   };
 
-  it('calls flush when there are unsent events', () => {
-    const client = setupClient(1);
-    mockStore.dispatch(mainSlice.actions.addEvent({ event: sampleEvent }));
+  it('calls flush when there are unsent events', async () => {
+    const client = await setupClient(1);
+    store.events.add(sampleEvent);
     expect(client.flush).toHaveBeenCalledTimes(1);
   });
 
-  it('does not flush when number of events does not exceed the flush threshold', () => {
-    const client = setupClient(2);
-    mockStore.dispatch(mainSlice.actions.addEvent({ event: sampleEvent }));
+  it('does not flush when number of events does not exceed the flush threshold', async () => {
+    const client = await setupClient(5);
+    store.events.add(sampleEvent);
     expect(client.flush).not.toHaveBeenCalled();
   });
 
-  it('does not call flush when there are no events to send', () => {
-    const client = setupClient(1);
+  it('does not call flush when there are no events to send', async () => {
+    const client = await setupClient(1);
     expect(client.flush).not.toHaveBeenCalled();
     expect(client.flushRetry).not.toHaveBeenCalled();
   });
 
-  it('flushes retry queue when it is non-empty', () => {
-    const client = setupClient(2);
-
-    mockStore.dispatch(
-      mainSlice.actions.addEventsToRetry({
-        events: [sampleEvent],
-        config: { ...clientArgs.config },
-      })
-    );
-
+  it('flushes retry queue when it is non-empty', async () => {
+    const client = await setupClient(2);
+    store.eventsToRetry.add([sampleEvent]);
     expect(client.flushRetry).toHaveBeenCalledTimes(1);
   });
 
-  it('does not flush the retry queue when the refreshTimeout is not null', () => {
-    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
-
-    const client = setupClient(2);
-    // @ts-ignore
-    client.refreshTimeout = jest.fn() as any;
-
-    mockStore.dispatch(
-      mainSlice.actions.addEventsToRetry({
-        events: [sampleEvent],
-        config: { ...clientArgs.config },
-      })
-    );
-
+  it('does not flush the retry queue when the refreshTimeout is not null', async () => {
+    // Mock the timeout to prevent it from releasing the lock
+    const setTimeoutSpy = jest
+      .spyOn(global, 'setTimeout')
+      .mockImplementationOnce(jest.fn());
+    await setupClient(2);
+    store.eventsToRetry.add([sampleEvent]);
+    jest.advanceTimersByTime(10);
+    jest.resetAllMocks();
+    store.eventsToRetry.add([sampleEvent]);
     expect(setTimeoutSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/__tests__/internal/checkInstalledVersion.test.ts
+++ b/packages/core/src/__tests__/internal/checkInstalledVersion.test.ts
@@ -1,12 +1,9 @@
 import { SegmentClient } from '../../analytics';
 import { getMockLogger } from '../__helpers__/mockLogger';
-import { Context, EventType } from '../../types';
 import * as context from '../../context';
 import { mockPersistor } from '../__helpers__/mockPersistor';
-
-jest.mock('../../uuid', () => ({
-  getUUID: () => 'mocked-uuid',
-}));
+import { MockSegmentStore } from '../__helpers__/mockSegmentStore';
+import { Context, EventType } from '../../types';
 
 jest
   .spyOn(Date.prototype, 'toISOString')
@@ -19,87 +16,57 @@ const currentContext = {
   },
 } as Context;
 
-const defaultClientConfig = {
-  config: {
-    writeKey: 'mock-write-key',
-    trackAppLifecycleEvents: false,
-  },
-  logger: getMockLogger(),
-  store: {
-    dispatch: jest.fn() as jest.MockedFunction<any>,
-    getState: () => ({
-      main: {
-        context: currentContext,
-      },
-      userInfo: {
-        anonymousId: 'very-anonymous',
-      },
-    }),
-  },
-  persistor: mockPersistor,
-  actions: {
-    main: {
-      updateContext: jest.fn() as jest.MockedFunction<any>,
-    },
-  },
-};
-
 describe('internal #checkInstalledVersion', () => {
+  const store = new MockSegmentStore();
+  const clientArgs = {
+    config: {
+      writeKey: 'mock-write-key',
+      trackAppLifecycleEvents: false,
+    },
+    logger: getMockLogger(),
+    persistor: mockPersistor,
+    store: store,
+  };
+
+  beforeEach(() => {
+    store.reset();
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   it('updates the context with the new value', async () => {
-    const client = new SegmentClient(defaultClientConfig);
+    const client = new SegmentClient(clientArgs);
     jest.spyOn(context, 'getContext').mockResolvedValueOnce(currentContext);
-
-    await client.checkInstalledVersion();
-
-    // @ts-ignore
-    expect(client.store.dispatch).toHaveBeenCalledTimes(1);
-    // @ts-ignore
-    expect(client.actions.main.updateContext).toHaveBeenCalledTimes(1);
-    // @ts-ignore
-    expect(client.actions.main.updateContext).toHaveBeenCalledWith({
-      context: currentContext,
-    });
+    await client.init();
+    expect(store.context.get()).toEqual(currentContext);
   });
 
   it('does not send any events when trackAppLifecycleEvents is false', async () => {
-    const client = new SegmentClient(defaultClientConfig);
+    const client = new SegmentClient(clientArgs);
 
     jest.spyOn(context, 'getContext').mockResolvedValueOnce(currentContext);
     const processSpy = jest.spyOn(client, 'process');
 
-    await client.checkInstalledVersion();
+    await client.init();
 
     expect(processSpy).not.toHaveBeenCalled();
   });
 
   it('calls the application installed and opened events when there is no previous context', async () => {
     const client = new SegmentClient({
-      ...defaultClientConfig,
+      ...clientArgs,
       config: {
-        writeKey: 'mock-write-key',
+        ...clientArgs.config,
         trackAppLifecycleEvents: true,
-      },
-      store: {
-        ...defaultClientConfig.store,
-        getState: () => ({
-          main: {
-            context: undefined,
-          },
-          userInfo: {
-            anonymousId: 'very-anonymous',
-          },
-        }),
       },
     });
 
     jest.spyOn(context, 'getContext').mockResolvedValueOnce(currentContext);
     const processSpy = jest.spyOn(client, 'process');
 
-    await client.checkInstalledVersion();
+    await client.init();
 
     expect(processSpy).toHaveBeenCalledTimes(2);
     expect(processSpy).toHaveBeenCalledWith({
@@ -122,35 +89,26 @@ describe('internal #checkInstalledVersion', () => {
   });
 
   it('calls the application updated and opened events when the previous version is different from current', async () => {
-    const savedContext = {
-      app: {
-        version: '2.0',
-        build: '2',
-      },
-    };
     const client = new SegmentClient({
-      ...defaultClientConfig,
+      ...clientArgs,
       config: {
-        writeKey: 'mock-write-key',
+        ...clientArgs.config,
         trackAppLifecycleEvents: true,
       },
-      store: {
-        ...defaultClientConfig.store,
-        getState: () => ({
-          main: {
-            context: savedContext,
+      store: new MockSegmentStore({
+        context: {
+          app: {
+            version: '2.0',
+            build: '2',
           },
-          userInfo: {
-            anonymousId: 'very-anonymous',
-          },
-        }),
-      },
+        },
+      }),
     });
 
     jest.spyOn(context, 'getContext').mockResolvedValueOnce(currentContext);
     const processSpy = jest.spyOn(client, 'process');
 
-    await client.checkInstalledVersion();
+    await client.init();
 
     expect(processSpy).toHaveBeenCalledTimes(2);
     expect(processSpy).toHaveBeenCalledWith({
@@ -177,17 +135,20 @@ describe('internal #checkInstalledVersion', () => {
 
   it('only sends the app opened event when the versions match', async () => {
     const client = new SegmentClient({
-      ...defaultClientConfig,
+      ...clientArgs,
       config: {
-        writeKey: 'mock-write-key',
+        ...clientArgs.config,
         trackAppLifecycleEvents: true,
       },
+      store: new MockSegmentStore({
+        context: { ...currentContext },
+      }),
     });
 
     jest.spyOn(context, 'getContext').mockResolvedValueOnce(currentContext);
     const processSpy = jest.spyOn(client, 'process');
 
-    await client.checkInstalledVersion();
+    await client.init();
 
     expect(processSpy).toHaveBeenCalledTimes(1);
     expect(processSpy).toHaveBeenCalledWith({

--- a/packages/core/src/__tests__/internal/checkInstalledVersion.test.ts
+++ b/packages/core/src/__tests__/internal/checkInstalledVersion.test.ts
@@ -27,6 +27,7 @@ describe('internal #checkInstalledVersion', () => {
     persistor: mockPersistor,
     store: store,
   };
+  let client: SegmentClient;
 
   beforeEach(() => {
     store.reset();
@@ -34,17 +35,18 @@ describe('internal #checkInstalledVersion', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    client.cleanup();
   });
 
   it('updates the context with the new value', async () => {
-    const client = new SegmentClient(clientArgs);
+    client = new SegmentClient(clientArgs);
     jest.spyOn(context, 'getContext').mockResolvedValueOnce(currentContext);
     await client.init();
     expect(store.context.get()).toEqual(currentContext);
   });
 
   it('does not send any events when trackAppLifecycleEvents is false', async () => {
-    const client = new SegmentClient(clientArgs);
+    client = new SegmentClient(clientArgs);
 
     jest.spyOn(context, 'getContext').mockResolvedValueOnce(currentContext);
     const processSpy = jest.spyOn(client, 'process');
@@ -55,7 +57,7 @@ describe('internal #checkInstalledVersion', () => {
   });
 
   it('calls the application installed and opened events when there is no previous context', async () => {
-    const client = new SegmentClient({
+    client = new SegmentClient({
       ...clientArgs,
       config: {
         ...clientArgs.config,
@@ -89,7 +91,7 @@ describe('internal #checkInstalledVersion', () => {
   });
 
   it('calls the application updated and opened events when the previous version is different from current', async () => {
-    const client = new SegmentClient({
+    client = new SegmentClient({
       ...clientArgs,
       config: {
         ...clientArgs.config,
@@ -134,7 +136,7 @@ describe('internal #checkInstalledVersion', () => {
   });
 
   it('only sends the app opened event when the versions match', async () => {
-    const client = new SegmentClient({
+    client = new SegmentClient({
       ...clientArgs,
       config: {
         ...clientArgs.config,

--- a/packages/core/src/__tests__/internal/flushRetry.test.ts
+++ b/packages/core/src/__tests__/internal/flushRetry.test.ts
@@ -3,6 +3,7 @@ import { getMockLogger } from '../__helpers__/mockLogger';
 import * as api from '../../api';
 import type { SegmentEvent } from '../../types';
 import { mockPersistor } from '../__helpers__/mockPersistor';
+import { MockSegmentStore } from '../__helpers__/mockSegmentStore';
 
 const defaultClientConfig = {
   config: {
@@ -10,18 +11,12 @@ const defaultClientConfig = {
     maxBatchSize: 10,
   },
   logger: getMockLogger(),
-  store: {
-    dispatch: jest.fn() as jest.MockedFunction<any>,
-    getState: () => ({
-      main: {
-        events: [] as SegmentEvent[],
-        eventsToRetry: [
-          { messageId: 'message-1' },
-          { messageId: 'message-2' },
-        ] as SegmentEvent[],
-      },
-    }),
-  },
+  store: new MockSegmentStore({
+    eventsToRetry: [
+      { messageId: 'message-1' },
+      { messageId: 'message-2' },
+    ] as SegmentEvent[],
+  }),
   persistor: mockPersistor,
   actions: {},
 };
@@ -50,15 +45,9 @@ describe('internal #flushRetry', () => {
   it('does not send any events when there are no eventsToRetry in the state ', async () => {
     const client = new SegmentClient({
       ...defaultClientConfig,
-      store: {
-        dispatch: jest.fn() as jest.MockedFunction<any>,
-        getState: () => ({
-          main: {
-            events: [] as SegmentEvent[],
-            eventsToRetry: [] as SegmentEvent[],
-          },
-        }),
-      },
+      store: new MockSegmentStore({
+        eventsToRetry: [],
+      }),
     });
 
     const sendEventsSpy = jest.spyOn(api, 'sendEvents').mockResolvedValue();

--- a/packages/core/src/__tests__/internal/handleAppStateChange.test.ts
+++ b/packages/core/src/__tests__/internal/handleAppStateChange.test.ts
@@ -1,85 +1,92 @@
+import { AppState, AppStateStatus } from 'react-native';
 import { SegmentClient } from '../../analytics';
 import { EventType } from '../../types';
 import { getMockLogger } from '../__helpers__/mockLogger';
 import { mockPersistor } from '../__helpers__/mockPersistor';
+import { MockSegmentStore } from '../__helpers__/mockSegmentStore';
 
-jest.mock('../../uuid', () => ({
-  getUUID: () => 'mocked-uuid',
-}));
+jest.mock('../../uuid');
+jest.mock('../../context');
+jest.mock('react-native');
 
-const defaultClientConfig = {
-  config: {
-    writeKey: '',
-    trackAppLifecycleEvents: false,
-  },
-  logger: getMockLogger(),
-  store: {
-    dispatch: jest.fn() as jest.MockedFunction<any>,
-    getState: () => ({
-      userInfo: {
-        anonymousId: 'my-id',
-        userId: 'user-id',
-      },
-      main: {
-        context: {
-          app: {
-            build: '1',
-            version: '1.2',
-          },
-        },
-      },
-    }),
-  },
-  actions: {
-    main: {
-      addEvent: jest.fn() as jest.MockedFunction<any>,
-    },
-  },
-  persistor: mockPersistor,
-};
+jest
+  .spyOn(Date.prototype, 'toISOString')
+  .mockReturnValue('2010-01-01T00:00:00.000Z');
 
 describe('SegmentClient #handleAppStateChange', () => {
+  const store = new MockSegmentStore();
+
+  const clientArgs = {
+    config: {
+      writeKey: 'mock-write-key',
+      trackAppLifecycleEvents: true,
+    },
+    logger: getMockLogger(),
+    persistor: mockPersistor,
+    store: store,
+  };
+
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   beforeEach(() => {
-    jest
-      .spyOn(Date.prototype, 'toISOString')
-      .mockReturnValueOnce('2010-01-01T00:00:00.000Z');
+    store.reset();
   });
 
-  it('does not send events when trackAppLifecycleEvents is not enabled', () => {
-    let segmentClient = new SegmentClient(defaultClientConfig);
-    segmentClient.handleAppStateChange('background');
-
+  const setupTest = async (
+    client: SegmentClient,
+    from: AppStateStatus,
+    to: AppStateStatus
+  ) => {
     // @ts-ignore
-    expect(segmentClient.store.dispatch).not.toHaveBeenCalled();
-    // @ts-ignore
-    expect(segmentClient.appState).toBe('background');
-  });
+    client.appState = from;
 
-  it('sends an event when inactive => active', () => {
+    let appStateChangeListener: ((state: AppStateStatus) => void) | undefined;
+    AppState.addEventListener = jest
+      .fn()
+      .mockImplementation(
+        (_type: String, listener: (state: AppStateStatus) => void) => {
+          appStateChangeListener = listener;
+        }
+      );
+
+    await client.init();
+    const clientProcess = jest.spyOn(client, 'process');
+
+    expect(appStateChangeListener).toBeDefined();
+
+    appStateChangeListener!(to);
+    return clientProcess;
+  };
+
+  it('does not send events when trackAppLifecycleEvents is not enabled', async () => {
     let client = new SegmentClient({
-      ...defaultClientConfig,
+      ...clientArgs,
       config: {
-        writeKey: '',
-        trackAppLifecycleEvents: true,
+        writeKey: 'mock-write-key',
+        trackAppLifecycleEvents: false,
       },
     });
+    const processSpy = await setupTest(client, 'active', 'background');
+
+    expect(processSpy).not.toHaveBeenCalled();
+
     // @ts-ignore
-    client.appState = 'inactive';
+    expect(client.appState).toBe('background');
+  });
 
-    const clientProcess = jest.spyOn(client, 'process');
-    client.handleAppStateChange('active');
+  it('sends an event when inactive => active', async () => {
+    let client = new SegmentClient(clientArgs);
+    const processSpy = await setupTest(client, 'inactive', 'active');
 
-    expect(clientProcess).toHaveBeenCalledTimes(1);
-    expect(clientProcess).toHaveBeenCalledWith({
+    expect(processSpy).toHaveBeenCalledTimes(1);
+    expect(processSpy).toHaveBeenCalledWith({
       event: 'Application Opened',
       properties: {
         from_background: true,
-        build: '1',
-        version: '1.2',
+        build: store.context.get().app?.build,
+        version: store.context.get().app?.version,
       },
       type: EventType.TrackEvent,
     });
@@ -87,27 +94,17 @@ describe('SegmentClient #handleAppStateChange', () => {
     expect(client.appState).toBe('active');
   });
 
-  it('sends an event when background => active', () => {
-    let client = new SegmentClient({
-      ...defaultClientConfig,
-      config: {
-        writeKey: '',
-        trackAppLifecycleEvents: true,
-      },
-    });
-    // @ts-ignore
-    client.appState = 'background';
+  it('sends an event when background => active', async () => {
+    let client = new SegmentClient(clientArgs);
+    const processSpy = await setupTest(client, 'background', 'active');
 
-    const clientProcess = jest.spyOn(client, 'process');
-    client.handleAppStateChange('active');
-
-    expect(clientProcess).toHaveBeenCalledTimes(1);
-    expect(clientProcess).toHaveBeenCalledWith({
+    expect(processSpy).toHaveBeenCalledTimes(1);
+    expect(processSpy).toHaveBeenCalledWith({
       event: 'Application Opened',
       properties: {
         from_background: true,
-        build: '1',
-        version: '1.2',
+        build: store.context.get().app?.build,
+        version: store.context.get().app?.version,
       },
       type: EventType.TrackEvent,
     });
@@ -115,112 +112,57 @@ describe('SegmentClient #handleAppStateChange', () => {
     expect(client.appState).toBe('active');
   });
 
-  it('sends an event when active => inactive', () => {
-    let client = new SegmentClient({
-      ...defaultClientConfig,
-      config: {
-        writeKey: '',
-        trackAppLifecycleEvents: true,
-      },
-    });
-    // @ts-ignore
-    client.appState = 'active';
+  it('sends an event when active => inactive', async () => {
+    let client = new SegmentClient(clientArgs);
+    const processSpy = await setupTest(client, 'active', 'inactive');
 
-    const clientProcess = jest.spyOn(client, 'process');
-
-    client.handleAppStateChange('inactive');
-
-    expect(clientProcess).toHaveBeenCalledTimes(1);
-    expect(clientProcess).toHaveBeenCalledWith({
+    expect(processSpy).toHaveBeenCalledTimes(1);
+    expect(processSpy).toHaveBeenCalledWith({
       event: 'Application Backgrounded',
-      type: EventType.TrackEvent,
       properties: {},
+      type: EventType.TrackEvent,
     });
     // @ts-ignore
     expect(client.appState).toBe('inactive');
   });
 
-  it('sends an event when active => background', () => {
-    let client = new SegmentClient({
-      ...defaultClientConfig,
-      config: {
-        writeKey: '',
-        trackAppLifecycleEvents: true,
-      },
-    });
-    // @ts-ignore
-    client.appState = 'active';
+  it('sends an event when active => background', async () => {
+    let client = new SegmentClient(clientArgs);
+    const processSpy = await setupTest(client, 'active', 'background');
 
-    const clientProcess = jest.spyOn(client, 'process');
-
-    client.handleAppStateChange('background');
-
-    expect(clientProcess).toHaveBeenCalledTimes(1);
-    expect(clientProcess).toHaveBeenCalledWith({
+    expect(processSpy).toHaveBeenCalledTimes(1);
+    expect(processSpy).toHaveBeenCalledWith({
       event: 'Application Backgrounded',
-      type: EventType.TrackEvent,
       properties: {},
+      type: EventType.TrackEvent,
     });
     // @ts-ignore
     expect(client.appState).toBe('background');
   });
 
-  it('does not send an event when unknown => active', () => {
-    let client = new SegmentClient({
-      ...defaultClientConfig,
-      config: {
-        writeKey: '',
-        trackAppLifecycleEvents: true,
-      },
-    });
-    // @ts-ignore
-    client.appState = 'unknown';
+  it('does not send an event when unknown => active', async () => {
+    let client = new SegmentClient(clientArgs);
+    const processSpy = await setupTest(client, 'unknown', 'active');
 
-    const clientProcess = jest.spyOn(client, 'process');
-
-    client.handleAppStateChange('active');
-
-    expect(clientProcess).not.toHaveBeenCalled();
+    expect(processSpy).not.toHaveBeenCalled();
     // @ts-ignore
     expect(client.appState).toBe('active');
   });
 
-  it('does not send an event when unknown => background', () => {
-    let client = new SegmentClient({
-      ...defaultClientConfig,
-      config: {
-        writeKey: '',
-        trackAppLifecycleEvents: true,
-      },
-    });
-    // @ts-ignore
-    client.appState = 'unknown';
+  it('does not send an event when unknown => background', async () => {
+    let client = new SegmentClient(clientArgs);
+    const processSpy = await setupTest(client, 'unknown', 'background');
 
-    const clientProcess = jest.spyOn(client, 'process');
-
-    client.handleAppStateChange('background');
-
-    expect(clientProcess).not.toHaveBeenCalled();
+    expect(processSpy).not.toHaveBeenCalled();
     // @ts-ignore
     expect(client.appState).toBe('background');
   });
 
-  it('does not send an event when unknown => inactive', () => {
-    let client = new SegmentClient({
-      ...defaultClientConfig,
-      config: {
-        writeKey: '',
-        trackAppLifecycleEvents: true,
-      },
-    });
-    // @ts-ignore
-    client.appState = 'unknown';
+  it('does not send an event when unknown => inactive', async () => {
+    let client = new SegmentClient(clientArgs);
+    const processSpy = await setupTest(client, 'unknown', 'inactive');
 
-    const clientProcess = jest.spyOn(client, 'process');
-
-    client.handleAppStateChange('inactive');
-
-    expect(clientProcess).not.toHaveBeenCalled();
+    expect(processSpy).not.toHaveBeenCalled();
     // @ts-ignore
     expect(client.appState).toBe('inactive');
   });

--- a/packages/core/src/__tests__/internal/handleAppStateChange.test.ts
+++ b/packages/core/src/__tests__/internal/handleAppStateChange.test.ts
@@ -26,8 +26,11 @@ describe('SegmentClient #handleAppStateChange', () => {
     store: store,
   };
 
+  let client: SegmentClient;
+
   afterEach(() => {
     jest.clearAllMocks();
+    client.cleanup();
   });
 
   beforeEach(() => {
@@ -35,12 +38,12 @@ describe('SegmentClient #handleAppStateChange', () => {
   });
 
   const setupTest = async (
-    client: SegmentClient,
+    segmentClient: SegmentClient,
     from: AppStateStatus,
     to: AppStateStatus
   ) => {
     // @ts-ignore
-    client.appState = from;
+    segmentClient.appState = from;
 
     let appStateChangeListener: ((state: AppStateStatus) => void) | undefined;
     AppState.addEventListener = jest
@@ -51,8 +54,8 @@ describe('SegmentClient #handleAppStateChange', () => {
         }
       );
 
-    await client.init();
-    const clientProcess = jest.spyOn(client, 'process');
+    await segmentClient.init();
+    const clientProcess = jest.spyOn(segmentClient, 'process');
 
     expect(appStateChangeListener).toBeDefined();
 
@@ -61,7 +64,7 @@ describe('SegmentClient #handleAppStateChange', () => {
   };
 
   it('does not send events when trackAppLifecycleEvents is not enabled', async () => {
-    let client = new SegmentClient({
+    client = new SegmentClient({
       ...clientArgs,
       config: {
         writeKey: 'mock-write-key',
@@ -77,7 +80,7 @@ describe('SegmentClient #handleAppStateChange', () => {
   });
 
   it('sends an event when inactive => active', async () => {
-    let client = new SegmentClient(clientArgs);
+    client = new SegmentClient(clientArgs);
     const processSpy = await setupTest(client, 'inactive', 'active');
 
     expect(processSpy).toHaveBeenCalledTimes(1);
@@ -95,7 +98,7 @@ describe('SegmentClient #handleAppStateChange', () => {
   });
 
   it('sends an event when background => active', async () => {
-    let client = new SegmentClient(clientArgs);
+    client = new SegmentClient(clientArgs);
     const processSpy = await setupTest(client, 'background', 'active');
 
     expect(processSpy).toHaveBeenCalledTimes(1);
@@ -113,7 +116,7 @@ describe('SegmentClient #handleAppStateChange', () => {
   });
 
   it('sends an event when active => inactive', async () => {
-    let client = new SegmentClient(clientArgs);
+    client = new SegmentClient(clientArgs);
     const processSpy = await setupTest(client, 'active', 'inactive');
 
     expect(processSpy).toHaveBeenCalledTimes(1);
@@ -127,7 +130,7 @@ describe('SegmentClient #handleAppStateChange', () => {
   });
 
   it('sends an event when active => background', async () => {
-    let client = new SegmentClient(clientArgs);
+    client = new SegmentClient(clientArgs);
     const processSpy = await setupTest(client, 'active', 'background');
 
     expect(processSpy).toHaveBeenCalledTimes(1);
@@ -141,7 +144,7 @@ describe('SegmentClient #handleAppStateChange', () => {
   });
 
   it('does not send an event when unknown => active', async () => {
-    let client = new SegmentClient(clientArgs);
+    client = new SegmentClient(clientArgs);
     const processSpy = await setupTest(client, 'unknown', 'active');
 
     expect(processSpy).not.toHaveBeenCalled();
@@ -150,7 +153,7 @@ describe('SegmentClient #handleAppStateChange', () => {
   });
 
   it('does not send an event when unknown => background', async () => {
-    let client = new SegmentClient(clientArgs);
+    client = new SegmentClient(clientArgs);
     const processSpy = await setupTest(client, 'unknown', 'background');
 
     expect(processSpy).not.toHaveBeenCalled();
@@ -159,7 +162,7 @@ describe('SegmentClient #handleAppStateChange', () => {
   });
 
   it('does not send an event when unknown => inactive', async () => {
-    let client = new SegmentClient(clientArgs);
+    client = new SegmentClient(clientArgs);
     const processSpy = await setupTest(client, 'unknown', 'inactive');
 
     expect(processSpy).not.toHaveBeenCalled();

--- a/packages/core/src/__tests__/internal/trackDeepLinks.test.ts
+++ b/packages/core/src/__tests__/internal/trackDeepLinks.test.ts
@@ -3,54 +3,45 @@ import { getMockLogger } from '../__helpers__/mockLogger';
 import * as ReactNative from 'react-native';
 import { EventType } from '../../types';
 import { mockPersistor } from '../__helpers__/mockPersistor';
+import { MockSegmentStore } from '../__helpers__/mockSegmentStore';
 
-jest.mock('../../uuid', () => ({
-  getUUID: () => 'mocked-uuid',
-}));
-
-const defaultClientConfig = {
-  config: {
-    writeKey: 'mock-write-key',
-    trackDeepLinks: true,
-  },
-  logger: getMockLogger(),
-  store: {
-    dispatch: jest.fn() as jest.MockedFunction<any>,
-    getState: () => ({
-      main: {
-        context: {
-          app: {
-            version: '1.0',
-            build: '1',
-          },
-        },
-      },
-      userInfo: {
-        userId: 'user-1',
-        anonymousId: 'secret-user-1',
-      },
-    }),
-  },
-  persistor: mockPersistor,
-  actions: {},
-};
+jest
+  .spyOn(Date.prototype, 'toISOString')
+  .mockReturnValue('2000-01-01T00:00:00.000Z');
 
 describe('#trackDeepLinks', () => {
+  const store = new MockSegmentStore({
+    context: {
+      app: {
+        name: 'test',
+        version: '1.0',
+        build: '1',
+      },
+    },
+  });
+  const clientArgs = {
+    config: {
+      writeKey: 'mock-write-key',
+      trackDeepLinks: true,
+    },
+    logger: getMockLogger(),
+    persistor: mockPersistor,
+    store: store,
+  };
+
   beforeEach(() => {
-    jest
-      .spyOn(Date.prototype, 'toISOString')
-      .mockReturnValueOnce('2000-01-01T00:00:00.000Z');
+    store.reset();
   });
 
   it('sends a track event when trackDeepLinks is enabled and the app was opened from a link', async () => {
-    const client = new SegmentClient(defaultClientConfig);
+    const client = new SegmentClient(clientArgs);
     jest.spyOn(client, 'process');
 
     jest
       .spyOn(ReactNative.Linking, 'getInitialURL')
       .mockResolvedValueOnce('myapp://open');
 
-    await client.trackDeepLinks();
+    await client.init();
 
     expect(client.process).toHaveBeenCalledTimes(1);
     expect(client.process).toHaveBeenCalledWith({
@@ -64,7 +55,7 @@ describe('#trackDeepLinks', () => {
 
   it('does not send a track event when trackDeepLinks is not enabled', async () => {
     const client = new SegmentClient({
-      ...defaultClientConfig,
+      ...clientArgs,
       config: {
         writeKey: 'mock-write-key',
         trackDeepLinks: false,
@@ -76,26 +67,20 @@ describe('#trackDeepLinks', () => {
       .spyOn(ReactNative.Linking, 'getInitialURL')
       .mockResolvedValueOnce('myapp://open');
 
-    await client.trackDeepLinks();
+    await client.init();
 
     expect(client.process).not.toHaveBeenCalled();
   });
 
   it('does not send a track event when trackDeepLinks is enabled, but the app was not opened via deep link', async () => {
-    const client = new SegmentClient({
-      ...defaultClientConfig,
-      config: {
-        writeKey: 'mock-write-key',
-        trackDeepLinks: true,
-      },
-    });
+    const client = new SegmentClient(clientArgs);
     jest.spyOn(client, 'process');
 
     jest
       .spyOn(ReactNative.Linking, 'getInitialURL')
       .mockResolvedValueOnce(null);
 
-    await client.trackDeepLinks();
+    await client.init();
 
     expect(client.process).not.toHaveBeenCalled();
   });

--- a/packages/core/src/__tests__/internal/trackDeepLinks.test.ts
+++ b/packages/core/src/__tests__/internal/trackDeepLinks.test.ts
@@ -28,13 +28,18 @@ describe('#trackDeepLinks', () => {
     persistor: mockPersistor,
     store: store,
   };
+  let client: SegmentClient;
 
   beforeEach(() => {
     store.reset();
   });
 
+  afterEach(() => {
+    client.cleanup();
+  });
+
   it('sends a track event when trackDeepLinks is enabled and the app was opened from a link', async () => {
-    const client = new SegmentClient(clientArgs);
+    client = new SegmentClient(clientArgs);
     jest.spyOn(client, 'process');
 
     jest
@@ -54,7 +59,7 @@ describe('#trackDeepLinks', () => {
   });
 
   it('does not send a track event when trackDeepLinks is not enabled', async () => {
-    const client = new SegmentClient({
+    client = new SegmentClient({
       ...clientArgs,
       config: {
         writeKey: 'mock-write-key',
@@ -70,10 +75,12 @@ describe('#trackDeepLinks', () => {
     await client.init();
 
     expect(client.process).not.toHaveBeenCalled();
+
+    client.cleanup();
   });
 
   it('does not send a track event when trackDeepLinks is enabled, but the app was not opened via deep link', async () => {
-    const client = new SegmentClient(clientArgs);
+    client = new SegmentClient(clientArgs);
     jest.spyOn(client, 'process');
 
     jest
@@ -83,5 +90,7 @@ describe('#trackDeepLinks', () => {
     await client.init();
 
     expect(client.process).not.toHaveBeenCalled();
+
+    client.cleanup();
   });
 });

--- a/packages/core/src/__tests__/methods/alias.test.ts
+++ b/packages/core/src/__tests__/methods/alias.test.ts
@@ -1,44 +1,39 @@
 import { SegmentClient } from '../../analytics';
 import { getMockLogger } from '../__helpers__/mockLogger';
 import { mockPersistor } from '../__helpers__/mockPersistor';
+import { MockSegmentStore } from '../__helpers__/mockSegmentStore';
 
-jest.mock('../../uuid', () => ({
-  getUUID: () => 'mocked-uuid',
-}));
+jest.mock('../../uuid');
 
-const defaultClientConfig = {
-  config: {
-    writeKey: 'mock-write-key',
-  },
-  logger: getMockLogger(),
-  store: {
-    dispatch: jest.fn() as jest.MockedFunction<any>,
-    getState: () => ({
-      userInfo: {
-        userId: 'current-user-id',
-        anonymousId: 'very-anonymous',
-      },
-    }),
-  },
-  persistor: mockPersistor,
-  actions: {
-    userInfo: {
-      setUserId: ({ userId }: { userId: string }) =>
-        `action with ${userId}` as jest.MockedFunction<any>,
-    },
-  },
-};
+jest
+  .spyOn(Date.prototype, 'toISOString')
+  .mockReturnValue('2010-01-01T00:00:00.000Z');
 
 describe('methods #alias', () => {
+  const store = new MockSegmentStore({
+    userInfo: {
+      anonymousId: 'anonymousId',
+      userId: 'current-user-id',
+    },
+  });
+
+  const clientArgs = {
+    config: {
+      writeKey: '123-456',
+    },
+    logger: getMockLogger(),
+    persistor: mockPersistor,
+    store: store,
+  };
+
   beforeEach(() => {
-    jest
-      .spyOn(Date.prototype, 'toISOString')
-      .mockReturnValueOnce('2010-01-01T00:00:00.000Z');
+    store.reset();
     jest.clearAllMocks();
   });
 
   it('adds the alias event correctly', () => {
-    const client = new SegmentClient(defaultClientConfig);
+    const client = new SegmentClient(clientArgs);
+
     jest.spyOn(client, 'process');
 
     client.alias('new-user-id');
@@ -52,34 +47,29 @@ describe('methods #alias', () => {
     expect(client.process).toHaveBeenCalledTimes(1);
     expect(client.process).toHaveBeenCalledWith(expectedEvent);
 
-    // @ts-ignore
-    expect(client.store.dispatch).not.toHaveBeenCalled();
-
-    expect(client.logger.info).toHaveBeenCalledTimes(1);
-    expect(client.logger.info).toHaveBeenCalledWith(
-      'ALIAS event saved',
-      expectedEvent
-    );
+    expect(client.userInfo.get()).toEqual({
+      anonymousId: 'anonymousId',
+      userId: 'new-user-id',
+      traits: undefined,
+    });
   });
 
   it('uses anonymousId in event if no userId in store', () => {
     const client = new SegmentClient({
-      ...defaultClientConfig,
-      store: {
-        dispatch: jest.fn() as jest.MockedFunction<any>,
-        getState: () => ({
-          userInfo: {
-            anonymousId: 'very-anonymous',
-          },
-        }),
-      },
+      ...clientArgs,
+      store: new MockSegmentStore({
+        userInfo: {
+          anonymousId: 'anonymousId',
+          userId: undefined,
+        },
+      }),
     });
     jest.spyOn(client, 'process');
 
     client.alias('new-user-id');
 
     const expectedEvent = {
-      previousId: 'very-anonymous',
+      previousId: 'anonymousId',
       type: 'alias',
       userId: 'new-user-id',
     };
@@ -87,13 +77,10 @@ describe('methods #alias', () => {
     expect(client.process).toHaveBeenCalledTimes(1);
     expect(client.process).toHaveBeenCalledWith(expectedEvent);
 
-    // @ts-ignore
-    expect(client.store.dispatch).not.toHaveBeenCalled();
-
-    expect(client.logger.info).toHaveBeenCalledTimes(1);
-    expect(client.logger.info).toHaveBeenCalledWith(
-      'ALIAS event saved',
-      expectedEvent
-    );
+    expect(client.userInfo.get()).toEqual({
+      anonymousId: 'anonymousId',
+      userId: 'new-user-id',
+      traits: undefined,
+    });
   });
 });

--- a/packages/core/src/__tests__/methods/flush.test.ts
+++ b/packages/core/src/__tests__/methods/flush.test.ts
@@ -1,40 +1,40 @@
 import { SegmentClient } from '../../analytics';
 import { getMockLogger } from '../__helpers__/mockLogger';
-// import * as api from '../../api';
 import { PluginType, SegmentEvent } from '../../types';
 import { getMockTimeline } from '../__helpers__/mockTimeline';
 import type { DestinationPlugin } from '../../plugin';
 import { mockPersistor } from '../__helpers__/mockPersistor';
+import { MockSegmentStore } from '../__helpers__/mockSegmentStore';
 
-const defaultClientSettings = {
-  logger: getMockLogger(),
-  store: {
-    dispatch: jest.fn() as jest.MockedFunction<any>,
-    getState: () => ({
-      main: {
-        events: [
-          { messageId: 'message-1' },
-          { messageId: 'message-2' },
-          { messageId: 'message-3' },
-          { messageId: 'message-4' },
-        ] as SegmentEvent[],
-      },
-    }),
-  },
-  config: {
-    writeKey: 'mock-write-key',
-  },
-  persistor: mockPersistor,
-  actions: {},
-};
+jest.mock('react-native');
+jest.mock('../../uuid');
 
 describe('methods #flush', () => {
+  const store = new MockSegmentStore({
+    events: [
+      { messageId: 'message-1' },
+      { messageId: 'message-2' },
+      { messageId: 'message-3' },
+      { messageId: 'message-4' },
+    ] as SegmentEvent[],
+  });
+
+  const clientArgs = {
+    config: {
+      writeKey: '123-456',
+    },
+    logger: getMockLogger(),
+    persistor: mockPersistor,
+    store: store,
+  };
+
   afterEach(() => {
+    store.reset();
     jest.clearAllMocks();
   });
 
   it('does not send any events when the client is destroyed', async () => {
-    const client = new SegmentClient(defaultClientSettings);
+    const client = new SegmentClient(clientArgs);
 
     // @ts-ignore
     client.timeline = getMockTimeline();
@@ -47,40 +47,10 @@ describe('methods #flush', () => {
     expect(mockDestinationPlugin.flush).not.toHaveBeenCalled();
   });
 
-  it('sets secondsElapsed to 0 ', async () => {
-    const client = new SegmentClient({
-      ...defaultClientSettings,
-      store: {
-        dispatch: jest.fn() as jest.MockedFunction<any>,
-        getState: () => ({
-          main: {
-            events: [] as SegmentEvent[],
-          },
-        }),
-      },
-    });
-
-    // @ts-ignore
-    client.timeline = getMockTimeline();
-    // @ts-ignore
-    client.secondsElapsed = 10;
-
-    await client.flush();
-    // @ts-ignore
-    expect(client.secondsElapsed).toBe(0);
-  });
-
   it('does not dispatch any actions when there are no events to be sent', async () => {
     const client = new SegmentClient({
-      ...defaultClientSettings,
-      store: {
-        dispatch: jest.fn() as jest.MockedFunction<any>,
-        getState: () => ({
-          main: {
-            events: [] as SegmentEvent[],
-          },
-        }),
-      },
+      ...clientArgs,
+      store: new MockSegmentStore({ events: [] }),
     });
 
     // @ts-ignore
@@ -94,36 +64,22 @@ describe('methods #flush', () => {
   });
 
   it('sends the events correctly', async () => {
-    const state = {
-      userInfo: {
-        anonymousId: '123-456',
-        traits: {
-          name: 'Mary',
-        },
-      },
-      main: {
-        events: [
-          { messageId: 'message-1' },
-          { messageId: 'message-2' },
-        ] as SegmentEvent[],
-        eventsToRetry: [] as SegmentEvent[],
-      },
-      system: {
-        settings: {},
-      },
-    };
+    const events = [
+      { messageId: 'message-1' },
+      { messageId: 'message-2' },
+    ] as SegmentEvent[];
 
     const client = new SegmentClient({
-      ...defaultClientSettings,
-      store: {
-        dispatch: jest.fn() as jest.MockedFunction<any>,
-        getState: () => state,
-      },
-      actions: {
-        main: {
-          deleteEventsByMessageId: jest.fn() as jest.MockedFunction<any>,
+      ...clientArgs,
+      store: new MockSegmentStore({
+        userInfo: {
+          anonymousId: '123-456',
+          traits: {
+            name: 'Mary',
+          },
         },
-      },
+        events: events,
+      }),
     });
     // @ts-ignore
     client.timeline = getMockTimeline();
@@ -134,72 +90,9 @@ describe('methods #flush', () => {
     await client.flush();
 
     expect(mockDestinationPlugin.flush).toHaveBeenCalledTimes(1);
+    expect(client.events.get()).toHaveLength(2);
+    expect(client.events.get()).toEqual(events);
   });
-
-  // it('chunks the events correctly', async () => {
-  //   const state = {
-  //     anonymousId: '123-456',
-  //     events: [
-  //       { messageId: 'message-1' },
-  //       { messageId: 'message-2' },
-  //       { messageId: 'message-3' },
-  //       { messageId: 'message-4' },
-  //     ] as SegmentEvent[],
-  //     eventsToRetry: [] as SegmentEvent[],
-  //     userTraits: {
-  //       name: 'Mary',
-  //     },
-  //     settings: {},
-  //   };
-  //   const clientContext = {
-  //     key: 'segment-key',
-  //     config: { maxBatchSize: 2 },
-  //     secondsElapsed: 10,
-  //     logger: getMockLogger(),
-  //     store: {
-  //       dispatch: jest.fn() as jest.MockedFunction<any>,
-  //       getState: () => state,
-  //     },
-  //     actions: {
-  //       deleteEventsByMessageId: jest.fn() as jest.MockedFunction<any>,
-  //     },
-  //     timeline: getMockTimeline(),
-  //   } as SegmentClientContext;
-
-  //   const sendEventsSpy = jest.spyOn(api, 'sendEvents').mockResolvedValue();
-
-  //   await flush.bind(clientContext)();
-
-  //   expect(sendEventsSpy).toHaveBeenCalledTimes(2);
-  //   expect(sendEventsSpy).toHaveBeenCalledWith({
-  //     config: {
-  //       maxBatchSize: 2,
-  //     },
-  //     events: [state.events[0], state.events[1]],
-  //     writeKey: 'segment-key',
-  //     traits: state.userTraits,
-  //   });
-
-  //   expect(clientContext.store.dispatch).toHaveBeenCalledTimes(1);
-
-  //   expect(clientContext.actions.main.deleteEventsByMessageId).toHaveBeenCalledTimes(
-  //     1
-  //   );
-  //   expect(clientContext.actions.main.deleteEventsByMessageId).toHaveBeenCalledWith({
-  //     ids: ['message-1', 'message-2', 'message-3', 'message-4'],
-  //   });
-
-  //   expect(sendEventsSpy).toHaveBeenCalledWith({
-  //     config: {
-  //       maxBatchSize: 2,
-  //     },
-  //     events: [state.events[2], state.events[3]],
-  //     writeKey: 'segment-key',
-  //     traits: state.userTraits,
-  //   });
-  //   expect(clientContext.logger.warn).toHaveBeenCalledTimes(1);
-  //   expect(clientContext.logger.warn).toHaveBeenCalledWith('Sent 4 events');
-  // });
 
   // it('handles errors in posting an event', async () => {
   //   const state = {

--- a/packages/core/src/__tests__/methods/group.test.ts
+++ b/packages/core/src/__tests__/methods/group.test.ts
@@ -1,39 +1,37 @@
 import { SegmentClient } from '../../analytics';
 import { getMockLogger } from '../__helpers__/mockLogger';
 import { mockPersistor } from '../__helpers__/mockPersistor';
+import { MockSegmentStore } from '../__helpers__/mockSegmentStore';
 
-jest.mock('../../uuid', () => ({
-  getUUID: () => 'mocked-uuid',
-}));
+jest.mock('../../uuid');
 
-const defaultClientSettings = {
-  logger: getMockLogger(),
-  store: {
-    dispatch: jest.fn() as jest.MockedFunction<any>,
-    getState: () => ({
-      userInfo: {
-        userId: 'current-user-id',
-        anonymousId: 'very-anonymous',
-      },
-    }),
-  },
-  config: {
-    writeKey: 'mock-write-key',
-  },
-  persistor: mockPersistor,
-  actions: {},
-};
+jest
+  .spyOn(Date.prototype, 'toISOString')
+  .mockReturnValue('2010-01-01T00:00:00.000Z');
 
 describe('methods #group', () => {
+  const store = new MockSegmentStore({
+    userInfo: {
+      userId: 'current-user-id',
+      anonymousId: 'very-anonymous',
+    },
+  });
+
+  const clientArgs = {
+    config: {
+      writeKey: 'mock-write-key',
+    },
+    logger: getMockLogger(),
+    persistor: mockPersistor,
+    store: store,
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
-    jest
-      .spyOn(Date.prototype, 'toISOString')
-      .mockReturnValueOnce('2010-01-01T00:00:00.000Z');
   });
 
   it('adds the alias event correctly', () => {
-    const client = new SegmentClient(defaultClientSettings);
+    const client = new SegmentClient(clientArgs);
     jest.spyOn(client, 'process');
 
     client.group('new-group-id', { name: 'Best Group Ever' });
@@ -48,11 +46,5 @@ describe('methods #group', () => {
 
     expect(client.process).toHaveBeenCalledTimes(1);
     expect(client.process).toHaveBeenCalledWith(expectedEvent);
-
-    expect(client.logger.info).toHaveBeenCalledTimes(1);
-    expect(client.logger.info).toHaveBeenCalledWith(
-      'GROUP event saved',
-      expectedEvent
-    );
   });
 });

--- a/packages/core/src/__tests__/methods/identify.test.ts
+++ b/packages/core/src/__tests__/methods/identify.test.ts
@@ -1,62 +1,46 @@
 import { SegmentClient } from '../../analytics';
-import type { UserTraits } from '../../types';
 import { getMockLogger } from '../__helpers__/mockLogger';
 import { mockPersistor } from '../__helpers__/mockPersistor';
+import { MockSegmentStore } from '../__helpers__/mockSegmentStore';
 
-jest.mock('../../uuid', () => ({
-  getUUID: () => 'mocked-uuid',
-}));
+jest.mock('../../uuid');
 
-const defaultClientSettings = {
-  config: {
-    writeKey: 'mock-write-key',
-  },
-  logger: getMockLogger(),
-  process: jest.fn() as jest.MockedFunction<any>,
-  store: {
-    dispatch: jest.fn() as jest.MockedFunction<any>,
-    getState: () => ({
-      userInfo: {
-        traits: {
-          name: 'Stacy',
-          age: 30,
-        },
-        userId: 'current-user-id',
-        anonymousId: 'very-anonymous',
-      },
-    }),
-  },
-  persistor: mockPersistor,
-  actions: {
-    userInfo: {
-      setUserId: jest
-        .fn()
-        .mockImplementation(
-          ({ userId }: { userId: string }) => `setUserId action with ${userId}`
-        ) as jest.MockedFunction<any>,
-      setTraits: jest
-        .fn()
-        .mockImplementation(
-          ({ traits }: { traits: UserTraits }) =>
-            `setTraits action with ${JSON.stringify(traits)}`
-        ) as jest.MockedFunction<any>,
-    },
-  },
-};
+jest
+  .spyOn(Date.prototype, 'toISOString')
+  .mockReturnValue('2010-01-01T00:00:00.000Z');
 
 describe('methods #identify', () => {
+  const initialUserInfo = {
+    traits: {
+      name: 'Stacy',
+      age: 30,
+    },
+    userId: 'current-user-id',
+    anonymousId: 'very-anonymous',
+  };
+  const store = new MockSegmentStore({
+    userInfo: initialUserInfo,
+  });
+
+  const clientArgs = {
+    config: {
+      writeKey: 'mock-write-key',
+    },
+    logger: getMockLogger(),
+    persistor: mockPersistor,
+    store: store,
+  };
+
   beforeEach(() => {
+    store.reset();
     jest.clearAllMocks();
-    jest
-      .spyOn(Date.prototype, 'toISOString')
-      .mockReturnValueOnce('2010-01-01T00:00:00.000Z');
   });
 
   it('adds the identify event correctly', () => {
-    const client = new SegmentClient(defaultClientSettings);
+    const client = new SegmentClient(clientArgs);
     jest.spyOn(client, 'process');
 
-    client.identify('new-user-id', { name: 'Mary' });
+    client.identify('new-user-id', { name: 'Mary', age: 30 });
 
     const expectedEvent = {
       traits: {
@@ -69,47 +53,30 @@ describe('methods #identify', () => {
     expect(client.process).toHaveBeenCalledTimes(1);
     expect(client.process).toHaveBeenCalledWith(expectedEvent);
 
-    // @ts-ignore
-    expect(client.store.dispatch).toHaveBeenCalledTimes(2);
-    // @ts-ignore
-    expect(client.store.dispatch).toHaveBeenCalledWith(
-      'setUserId action with new-user-id'
-    );
-    // @ts-ignore
-    expect(client.store.dispatch).toHaveBeenCalledWith(
-      'setTraits action with {"name":"Mary"}'
-    );
-
-    // @ts-ignore
-    expect(client.actions.userInfo.setUserId).toHaveBeenCalledTimes(1);
-    // @ts-ignore
-    expect(client.actions.userInfo.setUserId).toHaveBeenCalledWith({
+    expect(client.userInfo.get()).toEqual({
+      ...initialUserInfo,
       userId: 'new-user-id',
+      traits: expectedEvent.traits,
     });
-
-    // @ts-ignore
-    expect(client.actions.userInfo.setTraits).toHaveBeenCalledTimes(1);
-    // @ts-ignore
-    expect(client.actions.userInfo.setTraits).toHaveBeenCalledWith({
-      traits: { name: 'Mary' },
-    });
-
-    expect(client.logger.info).toHaveBeenCalledTimes(1);
-    expect(client.logger.info).toHaveBeenCalledWith(
-      'IDENTIFY event saved',
-      expectedEvent
-    );
   });
 
   it('does not update user traits when there are no new ones provided', () => {
-    const client = new SegmentClient(defaultClientSettings);
+    const client = new SegmentClient(clientArgs);
     jest.spyOn(client, 'process');
 
     client.identify('new-user-id');
 
-    // @ts-ignore
-    expect(client.store.dispatch).toHaveBeenCalledTimes(1);
-    // @ts-ignore
-    expect(client.actions.userInfo.setTraits).not.toHaveBeenCalled();
+    const expectedEvent = {
+      traits: initialUserInfo.traits,
+      type: 'identify',
+    };
+
+    expect(client.process).toHaveBeenCalledTimes(1);
+    expect(client.process).toHaveBeenCalledWith(expectedEvent);
+
+    expect(client.userInfo.get()).toEqual({
+      ...initialUserInfo,
+      userId: 'new-user-id',
+    });
   });
 });

--- a/packages/core/src/__tests__/methods/screen.test.ts
+++ b/packages/core/src/__tests__/methods/screen.test.ts
@@ -1,43 +1,37 @@
 import { SegmentClient } from '../../analytics';
 import { getMockLogger } from '../__helpers__/mockLogger';
 import { mockPersistor } from '../__helpers__/mockPersistor';
+import { MockSegmentStore } from '../__helpers__/mockSegmentStore';
 
-jest.mock('../../uuid', () => ({
-  getUUID: () => 'mocked-uuid',
-}));
+jest.mock('../../uuid');
 
-const defaultClientConfig = {
-  config: {
-    writeKey: 'mock-write-key',
-  },
-  logger: getMockLogger(),
-  store: {
-    dispatch: jest.fn() as jest.MockedFunction<any>,
-    getState: () => ({
-      userInfo: {
-        userId: 'current-user-id',
-        anonymousId: 'very-anonymous',
-      },
-    }),
-  },
-  persistor: mockPersistor,
-  actions: {
-    userInfo: {
-      setUserId: ({ userId }: { userId: string }) =>
-        `action with ${userId}` as jest.MockedFunction<any>,
-    },
-  },
-};
+jest
+  .spyOn(Date.prototype, 'toISOString')
+  .mockReturnValue('2010-01-01T00:00:00.000Z');
 
 describe('methods #screen', () => {
+  const store = new MockSegmentStore({
+    userInfo: {
+      userId: 'current-user-id',
+      anonymousId: 'very-anonymous',
+    },
+  });
+
+  const clientArgs = {
+    config: {
+      writeKey: 'mock-write-key',
+    },
+    logger: getMockLogger(),
+    persistor: mockPersistor,
+    store: store,
+  };
+
   beforeEach(() => {
-    jest
-      .spyOn(Date.prototype, 'toISOString')
-      .mockReturnValueOnce('2010-01-01T00:00:00.000Z');
+    jest.clearAllMocks();
   });
 
   it('adds the screen event correctly', () => {
-    const client = new SegmentClient(defaultClientConfig);
+    const client = new SegmentClient(clientArgs);
     jest.spyOn(client, 'process');
 
     client.screen('Home Screen', { id: 1 });
@@ -52,11 +46,5 @@ describe('methods #screen', () => {
 
     expect(client.process).toHaveBeenCalledTimes(1);
     expect(client.process).toHaveBeenCalledWith(expectedEvent);
-
-    expect(client.logger.info).toHaveBeenCalledTimes(1);
-    expect(client.logger.info).toHaveBeenCalledWith(
-      'SCREEN event saved',
-      expectedEvent
-    );
   });
 });

--- a/packages/core/src/__tests__/methods/track.test.ts
+++ b/packages/core/src/__tests__/methods/track.test.ts
@@ -3,39 +3,37 @@ import { EventType } from '../../types';
 
 import { getMockLogger } from '../__helpers__/mockLogger';
 import { mockPersistor } from '../__helpers__/mockPersistor';
+import { MockSegmentStore } from '../__helpers__/mockSegmentStore';
 
-jest.mock('../../uuid', () => ({
-  getUUID: () => 'mocked-uuid',
-}));
+jest.mock('../../uuid');
 
-const defaultClientSettings = {
-  logger: getMockLogger(),
-  store: {
-    dispatch: jest.fn() as jest.MockedFunction<any>,
-    getState: () => ({
-      userInfo: {
-        userId: 'current-user-id',
-        anonymousId: 'very-anonymous',
-      },
-    }),
-  },
-  config: {
-    writeKey: 'mock-write-key',
-  },
-  persistor: mockPersistor,
-  actions: {},
-};
+jest
+  .spyOn(Date.prototype, 'toISOString')
+  .mockReturnValue('2010-01-01T00:00:00.000Z');
 
 describe('methods #track', () => {
+  const store = new MockSegmentStore({
+    userInfo: {
+      userId: 'current-user-id',
+      anonymousId: 'very-anonymous',
+    },
+  });
+
+  const clientArgs = {
+    config: {
+      writeKey: 'mock-write-key',
+    },
+    logger: getMockLogger(),
+    persistor: mockPersistor,
+    store: store,
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
-    jest
-      .spyOn(Date.prototype, 'toISOString')
-      .mockReturnValueOnce('2010-01-01T00:00:00.000Z');
   });
 
   it('adds the track event correctly', () => {
-    const client = new SegmentClient(defaultClientSettings);
+    const client = new SegmentClient(clientArgs);
     jest.spyOn(client, 'process');
 
     client.track('Some Event', { id: 1 });
@@ -50,11 +48,5 @@ describe('methods #track', () => {
 
     expect(client.process).toHaveBeenCalledTimes(1);
     expect(client.process).toHaveBeenCalledWith(expectedEvent);
-
-    expect(client.logger.info).toHaveBeenCalledTimes(1);
-    expect(client.logger.info).toHaveBeenCalledWith(
-      'TRACK event saved',
-      expectedEvent
-    );
   });
 });

--- a/packages/core/src/__tests__/store.test.ts
+++ b/packages/core/src/__tests__/store.test.ts
@@ -147,33 +147,6 @@ describe('#initializeStore', () => {
       });
     });
 
-    it('merges new user traits with existing ones', () => {
-      const { store } = initializeStore('test-key');
-      store.dispatch(
-        actions.userInfo.setTraits({
-          traits: {
-            firstName: 'Kitty',
-          },
-        })
-      );
-
-      store.dispatch(
-        actions.userInfo.setTraits({
-          traits: {
-            lastName: 'Cat',
-          },
-        })
-      );
-
-      expect(store.getState().userInfo).toEqual({
-        ...initialState.userInfo,
-        traits: {
-          firstName: 'Kitty',
-          lastName: 'Cat',
-        },
-      });
-    });
-
     it('overwrites existing user traits with new ones', () => {
       const { store } = initializeStore('test-key');
       store.dispatch(
@@ -298,9 +271,6 @@ describe('#initializeStore', () => {
       store.dispatch(
         actions.main.addEventsToRetry({
           events: [event],
-          config: {
-            writeKey: '123-456',
-          },
         })
       );
       expect(store.getState().main).toEqual({
@@ -332,10 +302,7 @@ describe('#initializeStore', () => {
       store.dispatch(
         actions.main.addEventsToRetry({
           events: [event1, event2],
-          config: {
-            writeKey: '123-456',
-            maxEventsToRetry: 3,
-          },
+          maxEvents: 3,
         })
       );
 
@@ -352,10 +319,7 @@ describe('#initializeStore', () => {
       store.dispatch(
         actions.main.addEventsToRetry({
           events: [event3, event4],
-          config: {
-            writeKey: '123-456',
-            maxEventsToRetry: 3,
-          },
+          maxEvents: 3,
         })
       );
 
@@ -394,9 +358,6 @@ describe('#initializeStore', () => {
       store.dispatch(
         actions.main.addEventsToRetry({
           events: [event1, event2],
-          config: {
-            writeKey: '123-456',
-          },
         })
       );
 

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -1,6 +1,5 @@
 import { getUUID } from './uuid';
 
-import type { Store } from './store';
 import {
   GroupEventType,
   GroupTraits,
@@ -13,6 +12,7 @@ import {
   EventType,
   SegmentEvent,
 } from './types';
+import type { UserInfoState } from './store/userInfo';
 
 export const createTrackEvent = ({
   event,
@@ -78,9 +78,10 @@ export const createAliasEvent = ({
 const isAliasEvent = (event: SegmentEvent): event is AliasEventType =>
   event.type === EventType.AliasEvent;
 
-export const applyRawEventData = (event: SegmentEvent, store: Store) => {
-  const { userInfo } = store.getState();
-
+export const applyRawEventData = (
+  event: SegmentEvent,
+  userInfo: UserInfoState
+) => {
   return {
     ...event,
     anonymousId: userInfo.anonymousId,

--- a/packages/core/src/plugins/Context.ts
+++ b/packages/core/src/plugins/Context.ts
@@ -9,7 +9,7 @@ export class InjectContext extends PlatformPlugin {
       ...event,
       context: {
         ...event.context,
-        ...this.analytics!.getContext(),
+        ...this.analytics!.context.get(),
       },
     };
   }

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './reduxStorage';

--- a/packages/core/src/storage/reduxStorage.ts
+++ b/packages/core/src/storage/reduxStorage.ts
@@ -1,0 +1,143 @@
+import type { Persistor } from 'redux-persist';
+import type {
+  SegmentAPIIntegrations,
+  IntegrationSettings,
+  SegmentEvent,
+  DeepPartial,
+  Context,
+} from '..';
+import { getStoreWatcher, actions, Store } from '../store';
+import type { UserInfoState } from '../store/userInfo';
+import type { Storage } from './types';
+
+export class ReduxStorage implements Storage {
+  private redux: Store;
+  private persistor: Persistor;
+  /**
+   * Watches changes to redux store
+   */
+  private watchStore: ReturnType<typeof getStoreWatcher>;
+  /**
+   * Watches changes to the persistor state
+   */
+  private watchPersistor: ReturnType<typeof getStoreWatcher>;
+
+  private maxEventsToRetry?: number;
+
+  constructor(
+    store: Store,
+    persistor: Persistor,
+    config?: {
+      maxEventsToRetry?: number;
+    }
+  ) {
+    this.redux = store;
+    this.persistor = persistor;
+    this.watchStore = getStoreWatcher(this.redux);
+    this.watchPersistor = getStoreWatcher(this.persistor);
+    this.maxEventsToRetry = config?.maxEventsToRetry;
+  }
+
+  readonly isReady = {
+    get: () => this.persistor.getState().bootstrapped,
+    onChange: (callback: (value: boolean) => void) =>
+      this.watchPersistor((state) => state.bootstrapped, callback),
+  };
+
+  readonly context = {
+    get: () => this.redux.getState().main.context,
+    onChange: (callback: (value?: DeepPartial<Context>) => void) =>
+      this.watchStore((state) => state.main.context, callback),
+    set: (value: DeepPartial<Context>) => {
+      this.redux.dispatch(actions.main.updateContext({ context: value }));
+    },
+  };
+
+  readonly settings = {
+    get: () => this.redux.getState().system.settings,
+    onChange: (
+      callback: (value?: SegmentAPIIntegrations | undefined) => void
+    ) => this.watchStore((state) => state.system.settings, callback),
+    set: (value: SegmentAPIIntegrations) => {
+      this.redux.dispatch(
+        actions.system.updateSettings({ settings: { integrations: value } })
+      );
+    },
+    add: (key: string, value: IntegrationSettings) => {
+      this.redux.dispatch(
+        actions.system.addDestination({
+          destination: { key, settings: value },
+        })
+      );
+    },
+  };
+
+  readonly events = {
+    get: () => this.redux.getState().main.events,
+    onChange: (callback: (value: SegmentEvent[]) => void) =>
+      this.watchStore((state) => state.main.events, callback),
+    add: (event: SegmentEvent | SegmentEvent[]) => {
+      this.redux.dispatch(actions.main.addEvent({ event }));
+    },
+    remove: (event: SegmentEvent | SegmentEvent[]) => {
+      const eventsToRemove = Array.isArray(event) ? event : [event];
+      this.redux.dispatch(
+        actions.main.deleteEventsByMessageId({
+          ids: eventsToRemove
+            .filter((e) => e.messageId !== undefined)
+            .map((e) => e.messageId!),
+        })
+      );
+    },
+  };
+
+  readonly eventsToRetry = {
+    get: () => this.redux.getState().main.eventsToRetry,
+    onChange: (callback: (value: SegmentEvent[]) => void) =>
+      this.watchStore((state) => state.main.eventsToRetry, callback),
+    add: (events: SegmentEvent[]) => {
+      this.redux.dispatch(
+        actions.main.addEventsToRetry({
+          events,
+          maxEvents: this.maxEventsToRetry,
+        })
+      );
+    },
+    remove: (events: SegmentEvent[]) => {
+      this.redux.dispatch(
+        actions.main.deleteEventsToRetryByMessageId({
+          ids: events
+            .filter((event) => event.messageId !== undefined)
+            .map((event) => event.messageId!),
+        })
+      );
+    },
+  };
+
+  readonly userInfo = {
+    get: () => this.redux.getState().userInfo,
+    onChange: (callback: (value: UserInfoState) => void) =>
+      this.watchStore((state) => state.userInfo, callback),
+    set: (value: UserInfoState) => {
+      const { anonymousId, userId, traits } = this.redux.getState().userInfo;
+
+      if (value.anonymousId !== anonymousId) {
+        this.redux.dispatch(
+          actions.userInfo.setAnonymousId({ anonymousId: value.anonymousId })
+        );
+      }
+
+      if (value.userId !== userId) {
+        this.redux.dispatch(
+          actions.userInfo.setUserId({ userId: value.userId })
+        );
+      }
+
+      if (value.traits !== traits) {
+        this.redux.dispatch(
+          actions.userInfo.setTraits({ traits: value.traits })
+        );
+      }
+    },
+  };
+}

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -1,0 +1,79 @@
+import type { Unsubscribe } from '@reduxjs/toolkit';
+import type { SegmentEvent } from '..';
+import type {
+  Context,
+  DeepPartial,
+  IntegrationSettings,
+  SegmentAPIIntegrations,
+} from '../types';
+import type { UserInfoState } from '../store/userInfo';
+
+/**
+ * Implements a value that can be subscribed for changes
+ */
+export interface Watchable<T> {
+  /**
+   * Get current value
+   */
+  get: () => T;
+  /**
+   * Register a callback to be called when the value changes
+   * @returns a function to unsubscribe
+   */
+  onChange: (callback: (value: T) => void) => Unsubscribe;
+}
+
+/**
+ * Implements a value that can be set
+ */
+export interface Settable<T> {
+  set: (value: T) => void;
+}
+
+/**
+ * Implements a queue object
+ */
+export interface Queue<T> {
+  add: (value: T) => void;
+  remove: (value: T) => void;
+}
+
+/**
+ * Implements a map of key value pairs
+ */
+export interface Dictionary<K, T> {
+  add: (key: K, value: T) => void;
+}
+
+/**
+ * Interface for interacting with the storage layer of the client data
+ */
+export interface Storage {
+  readonly isReady: Watchable<boolean>;
+
+  readonly context: Watchable<DeepPartial<Context> | undefined> &
+    Settable<DeepPartial<Context>>;
+
+  readonly settings: Watchable<SegmentAPIIntegrations | undefined> &
+    Settable<SegmentAPIIntegrations> &
+    Dictionary<string, IntegrationSettings>;
+
+  readonly events: Watchable<SegmentEvent[]> &
+    Queue<SegmentEvent | SegmentEvent[]>;
+
+  readonly eventsToRetry: Watchable<SegmentEvent[]> & Queue<SegmentEvent[]>;
+
+  readonly userInfo: Watchable<UserInfoState> & Settable<UserInfoState>;
+}
+
+export interface WatchableStorage {
+  readonly context: Watchable<DeepPartial<Context> | undefined>;
+
+  readonly settings: Watchable<SegmentAPIIntegrations | undefined>;
+
+  readonly events: Watchable<SegmentEvent[]>;
+
+  readonly eventsToRetry: Watchable<SegmentEvent[]>;
+
+  readonly userInfo: Watchable<UserInfoState>;
+}

--- a/packages/core/src/store/main.ts
+++ b/packages/core/src/store/main.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import type { Config, Context, PartialContext, SegmentEvent } from '../types';
+import type { Context, PartialContext, SegmentEvent } from '../types';
 
-type MainState = {
+export type MainState = {
   events: SegmentEvent[];
   eventsToRetry: SegmentEvent[];
   context?: PartialContext;
@@ -20,10 +20,14 @@ export default createSlice({
     addEvent: (
       state,
       action: PayloadAction<{
-        event: SegmentEvent;
+        event: SegmentEvent | SegmentEvent[];
       }>
     ) => {
-      state.events.push(action.payload.event);
+      if (Array.isArray(action.payload.event)) {
+        state.events.push(...action.payload.event);
+      } else {
+        state.events.push(action.payload.event);
+      }
     },
     deleteEventsByMessageId: (
       state,
@@ -39,13 +43,13 @@ export default createSlice({
       state,
       action: PayloadAction<{
         events: SegmentEvent[];
-        config: Config;
+        maxEvents?: number;
       }>
     ) => {
       state.eventsToRetry = [
         ...state.eventsToRetry,
         ...action.payload.events,
-      ].slice(-action.payload.config.maxEventsToRetry!);
+      ].slice(-(action.payload.maxEvents ?? 0));
     },
     deleteEventsToRetryByMessageId: (
       state,

--- a/packages/core/src/store/system.ts
+++ b/packages/core/src/store/system.ts
@@ -1,23 +1,16 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { defaultConfig } from '../constants';
-import type { SegmentAPISettings, Config, IntegrationSettings } from '../types';
+import type { SegmentAPISettings, IntegrationSettings } from '../types';
 
-type SystemState = {
-  configuration: Config;
+export type SystemState = {
   settings?: SegmentAPISettings;
 };
 
-export const initialState: SystemState = {
-  configuration: defaultConfig,
-};
+export const initialState: SystemState = {};
 
 export default createSlice({
   name: 'system',
   initialState,
   reducers: {
-    init: (state, action: PayloadAction<{ configuration: Config }>) => {
-      state.configuration = action.payload.configuration;
-    },
     updateSettings: (
       state,
       action: PayloadAction<{ settings: SegmentAPISettings }>

--- a/packages/core/src/store/userInfo.ts
+++ b/packages/core/src/store/userInfo.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { UserTraits } from '../types';
 import { getUUID } from '../uuid';
 
-type UserInfoState = {
+export type UserInfoState = {
   anonymousId: string;
   userId?: string;
   traits?: UserTraits;
@@ -21,21 +21,13 @@ export default createSlice({
       userId: undefined,
       traits: undefined,
     }),
-    setUserId: (state, action: PayloadAction<{ userId: string }>) => {
+    setUserId: (state, action: PayloadAction<{ userId?: string }>) => {
       state.userId = action.payload.userId;
     },
     setTraits: (state, action: PayloadAction<{ traits?: UserTraits }>) => {
       state.traits = {
-        ...state.traits,
         ...action.payload.traits,
       };
-    },
-    setUserIdAndTraits: (
-      state,
-      action: PayloadAction<{ userId: string; traits?: UserTraits }>
-    ) => {
-      state.userId = action.payload.userId;
-      state.traits = action.payload.traits;
     },
     setAnonymousId: (state, action: PayloadAction<{ anonymousId: string }>) => {
       state.anonymousId = action.payload.anonymousId;

--- a/packages/core/src/store/watcher.ts
+++ b/packages/core/src/store/watcher.ts
@@ -1,4 +1,4 @@
-import type { Store } from '.';
+type Unsubscribe = () => void;
 
 /**
  * Creates a watcher that subscribes to the store and tracks
@@ -6,7 +6,10 @@ import type { Store } from '.';
  * @param store Store to subscribe to
  * @returns a function to subscribe actions for
  */
-export const getStoreWatcher = (store: Store) => {
+export const getStoreWatcher = (store: {
+  getState: () => any;
+  subscribe: (callback: () => any) => Unsubscribe;
+}) => {
   return <T>(
     selector: (state: ReturnType<typeof store.getState>) => T,
     onChange: (value: T) => void

--- a/packages/core/src/timeline.ts
+++ b/packages/core/src/timeline.ts
@@ -25,9 +25,9 @@ export class Timeline {
     } else {
       this.plugins[type] = [plugin];
     }
-    const settings = plugin.analytics?.getSettings();
+    const settings = plugin.analytics?.settings.get();
     if (settings) {
-      plugin.update(settings, UpdateType.initial);
+      plugin.update({ integrations: settings }, UpdateType.initial);
     }
   }
 
@@ -52,7 +52,7 @@ export class Timeline {
       event: incomingEvent,
     });
 
-    if (incomingEvent === undefined) {
+    if (beforeResult === undefined) {
       return;
     }
     // .enrichment here is akin to source middleware in the old analytics-ios.

--- a/packages/plugins/plugin-facebook-app-events/src/FacebookAppEventsPlugin.ts
+++ b/packages/plugins/plugin-facebook-app-events/src/FacebookAppEventsPlugin.ts
@@ -32,16 +32,11 @@ export class FacebookAppEventsPlugin extends DestinationPlugin {
 
   async configure(analytics: SegmentClient) {
     this.analytics = analytics;
-    let adTrackingEnabled =
-      this.analytics?.getContext().device?.adTrackingEnabled;
+    let adTrackingEnabled = this.analytics?.adTrackingEnabled.get();
 
-    this.analytics.watch(
-      (state): boolean =>
-        state.main.context?.device?.adTrackingEnabled ?? false,
-      (value) => {
-        Settings.setAdvertiserTrackingEnabled(value);
-      }
-    );
+    this.analytics.adTrackingEnabled.onChange((value) => {
+      Settings.setAdvertiserTrackingEnabled(value);
+    });
 
     //you will likely need consent first
     //this example assumes consentManager plugin is used

--- a/packages/plugins/plugin-idfa/src/IdfaPlugin.tsx
+++ b/packages/plugins/plugin-idfa/src/IdfaPlugin.tsx
@@ -25,7 +25,7 @@ export class IdfaPlugin extends Plugin {
   getTrackingStatus() {
     getTrackingAuthorizationStatus().then((idfa: IdfaData) => {
       // update our context (in Redux) with the idfa data
-      this.analytics?.updateContext({ device: { ...idfa } });
+      this.analytics?.context.set({ device: { ...idfa } });
     });
   }
 }


### PR DESCRIPTION
- Refactors the access of the Redux store using a common interface to explore different storages (`Storage`)
- Fixes a bunch of the tests to use the new interface for mocking the storage of the client
- Removes checking internals implementation from tests
- Implements `Watchable` properties in the client
