### PR TITLE
feat: add Taplytics Plugin

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -28,6 +28,9 @@ import { Logger } from './plugins/Logger';
 // import { FacebookAppEventsPlugin } from '@segment/analytics-react-native-plugin-facebook-app-events';
 
 // @ts-ignore
+// import { TaplyticsPlugin } from '@segment/analytics-react-native-plugin-taplytics';
+
+// @ts-ignore
 import { IdfaPlugin } from '@segment/analytics-react-native-plugin-idfa';
 // @ts-ignore
 import { AmplitudeSessionPlugin } from '@segment/analytics-react-native-plugin-amplitude-session';
@@ -53,6 +56,9 @@ segmentClient.add({ plugin: LoggerPlugin });
 
 // To test the Facebook App Events plugin make sure to add your Facebook App Id to Info.plist
 // segmentClient.add({ plugin: new FacebookAppEventsPlugin() });
+
+// To test the Taplytics plugin make sure to follow the instructions to setup taplytics-react-native
+// segmentClient.add({ plugin: new TaplyticsPlugin() });
 
 segmentClient.add({ plugin: new IdfaPlugin() });
 segmentClient.add({ plugin: new AmplitudeSessionPlugin() });

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -29,7 +29,7 @@ import {
   UserInfoState,
   UserTraits,
 } from './types';
-import { getPluginsWithFlush } from './util';
+import { getPluginsWithFlush, getPluginsWithReset } from './util';
 import { getUUID } from './uuid';
 
 export class SegmentClient {
@@ -662,6 +662,8 @@ export class SegmentClient {
       userId: undefined,
       traits: undefined,
     });
+
+    getPluginsWithReset(this.timeline).forEach((plugin) => plugin.reset());
 
     this.logger.info('Client has been reset');
   }

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -38,3 +38,18 @@ export const getPluginsWithFlush = (timeline: Timeline) => {
 
   return eventPlugins;
 };
+
+export const getPluginsWithReset = (timeline: Timeline) => {
+  if (!timeline) {
+    return [];
+  }
+
+  const allPlugins = getAllPlugins(timeline);
+
+  // checking for the existence of .reset()
+  const eventPlugins = allPlugins?.filter(
+    (f) => (f as EventPlugin).reset
+  ) as EventPlugin[];
+
+  return eventPlugins;
+};

--- a/packages/plugins/plugin-taplytics/LICENSE
+++ b/packages/plugins/plugin-taplytics/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Segment
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/plugins/plugin-taplytics/README.md
+++ b/packages/plugins/plugin-taplytics/README.md
@@ -1,0 +1,71 @@
+# @segment/analytics-react-native-plugin-taplytics
+
+`DestinationPlugin` for [Taplytics](https://taplytics.com/). Wraps [`taplytics-react-native`](https://github.com/taplytics/taplytics-react-native).
+
+## Installation
+
+You need to install the `@segment/analytics-react-native-plugin-taplytics` and the `taplytics-react-native` dependency.
+
+Using NPM:
+```bash
+npm install --save @segment/analytics-react-native-plugin-taplytics taplytics-react-native
+```
+
+Using Yarn:
+```bash
+yarn add @segment/analytics-react-native-plugin-taplytics taplytics-react-native
+```
+
+Run `pod install` after the installation to autolink the Firebase SDK.
+
+See [taplytics-react-native](https://docs.taplytics.com/docs/react-native-sdk#set-user-attributes) for more details of this dependency.
+## Usage
+
+Follow the [instructions for adding plugins](https://github.com/segmentio/analytics-react-native#adding-plugins) on the main Analytics client:
+
+In your code where you initialize the analytics client call the `.add(plugin)` method with a `TaplyticsPlugin` instance. 
+
+```ts
+import { createClient } from '@segment/analytics-react-native';
+
+import { TaplyticsPlugin } from '@segment/analytics-react-native-plugin-taplytics';
+
+const segmentClient = createClient({
+  writeKey: 'SEGMENT_KEY'
+});
+
+segmentClient.add({ plugin: new TaplyticsPlugin() });
+```
+
+## Support
+
+Please use Github issues, Pull Requests, or feel free to reach out to our [support team](https://segment.com/help/).
+
+## Integrating with Segment
+
+Interested in integrating your service with us? Check out our [Partners page](https://segment.com/partners/) for more details.
+
+## License
+```
+MIT License
+
+Copyright (c) 2021 Segment
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/packages/plugins/plugin-taplytics/babel.config.js
+++ b/packages/plugins/plugin-taplytics/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['module:metro-react-native-babel-preset'],
+};

--- a/packages/plugins/plugin-taplytics/jest.config.js
+++ b/packages/plugins/plugin-taplytics/jest.config.js
@@ -1,0 +1,16 @@
+const { pathsToModuleNameMapper } = require('ts-jest/utils');
+const { compilerOptions } = require('./tsconfig');
+
+module.exports = {
+  preset: 'react-native',
+  roots: ['<rootDir>'],
+  setupFiles: ['../../core/src/__tests__/__helpers__/setup.js'],
+  testPathIgnorePatterns: ['.../../core/src/__tests__/__helpers__/'],
+  modulePathIgnorePatterns: ['/lib/'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  modulePaths: [compilerOptions.baseUrl],
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths),
+};

--- a/packages/plugins/plugin-taplytics/package.json
+++ b/packages/plugins/plugin-taplytics/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@segment/analytics-react-native-plugin-taplytics",
+  "version": "0.2.1",
+  "description": "The hassle-free way to add Segment analytics to your React-Native app.",
+  "main": "lib/commonjs/index",
+  "scripts": {
+    "build": "bob build",
+    "test": "jest",
+    "typescript": "tsc --noEmit",
+    "clean": "rimraf lib node_modules"
+  },
+  "keywords": [
+    "segment",
+    "react-native",
+    "ios",
+    "android"
+  ],
+  "module": "lib/module/index",
+  "types": "lib/typescript/src/index.d.ts",
+  "react-native": "src/index",
+  "source": "src/index",
+  "files": [
+    "src",
+    "lib",
+    "android",
+    "ios",
+    "cpp",
+    "segment-analytics-react-native.podspec",
+    "package.json",
+    "!src/**/*.e2e.mock.js",
+    "!**/__tests__",
+    "!**/__fixtures__",
+    "!**/__mocks__"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/analytics-react-native.git",
+    "directory": "packages/core"
+  },
+  "author": "Segment <hello@segment.com> (https://segment.com/)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/segmentio/analytics-react-native/issues"
+  },
+  "homepage": "https://github.com/segmentio/analytics-react-native#readme",
+  "peerDependencies": {
+    "@segment/analytics-react-native": "*"
+  },
+  "devDependencies": {
+    "@types/jest": "^27.0.3",
+    "rimraf": "^3.0.2",
+    "ts-jest": "^27.0.7",
+    "typescript": "^4.4.4"
+  },
+  "react-native-builder-bob": {
+    "source": "src",
+    "output": "lib",
+    "targets": [
+      "commonjs",
+      "module",
+      "typescript"
+    ]
+  },
+  "engines": {
+    "node": ">=12"
+  },
+  "dependencies": {
+    "taplytics-react-native": "^3.0.0-rc.6"
+  }
+}

--- a/packages/plugins/plugin-taplytics/src/TaplyticsPlugin.tsx
+++ b/packages/plugins/plugin-taplytics/src/TaplyticsPlugin.tsx
@@ -1,0 +1,42 @@
+import {
+  DestinationPlugin,
+  GroupEventType,
+  IdentifyEventType,
+  PluginType,
+  ScreenEventType,
+  TrackEventType,
+} from '@segment/analytics-react-native';
+import group from './methods/group';
+import identify from './methods/identify';
+import reset from './methods/reset';
+import screen from './methods/screen';
+import track from './methods/track';
+
+export class TaplyticsPlugin extends DestinationPlugin {
+  type = PluginType.destination;
+  key = 'Taplytics';
+
+  track(event: TrackEventType) {
+    track(event);
+    return event;
+  }
+
+  screen(event: ScreenEventType) {
+    screen(event);
+    return event;
+  }
+
+  identify(event: IdentifyEventType) {
+    identify(event);
+    return event;
+  }
+
+  group(event: GroupEventType) {
+    group(event);
+    return event;
+  }
+
+  reset() {
+    reset();
+  }
+}

--- a/packages/plugins/plugin-taplytics/src/index.ts
+++ b/packages/plugins/plugin-taplytics/src/index.ts
@@ -1,0 +1,1 @@
+export * from './TaplyticsPlugin';

--- a/packages/plugins/plugin-taplytics/src/methods/__tests__/group.test.ts
+++ b/packages/plugins/plugin-taplytics/src/methods/__tests__/group.test.ts
@@ -1,0 +1,32 @@
+import type { GroupEventType } from '@segment/analytics-react-native/src';
+import group from '../group';
+import * as Taplytics from 'taplytics-react-native';
+
+jest.mock('taplytics-react-native', () => ({
+  logEvent: jest.fn(),
+}));
+
+describe('#group', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('logs a group event', () => {
+    const event = {
+      type: 'group',
+      groupId: 'testId',
+      traits: {
+        description: 'description',
+        email: 'test@test.com',
+      },
+    } as GroupEventType;
+
+    group(event);
+
+    expect(Taplytics.logEvent).toHaveBeenCalledTimes(1);
+    expect(Taplytics.logEvent).toHaveBeenCalledWith('GROUP event: testId', 0, {
+      description: 'description',
+      email: 'test@test.com',
+    });
+  });
+});

--- a/packages/plugins/plugin-taplytics/src/methods/__tests__/identify.test.ts
+++ b/packages/plugins/plugin-taplytics/src/methods/__tests__/identify.test.ts
@@ -1,0 +1,55 @@
+import type { IdentifyEventType } from '@segment/analytics-react-native/src';
+import identify from '../identify';
+import * as Taplytics from 'taplytics-react-native';
+
+jest.mock('taplytics-react-native', () => ({
+  setUserAttributes: jest.fn(),
+}));
+
+describe('#identify', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sends the identify event with only userId', () => {
+    const event = {
+      type: 'identify',
+      userId: 'testId',
+      traits: {
+        description: 'description',
+      },
+    } as IdentifyEventType;
+
+    identify(event);
+
+    expect(Taplytics.setUserAttributes).toHaveBeenCalledTimes(1);
+    expect(Taplytics.setUserAttributes).toHaveBeenCalledWith({
+      user_id: 'testId',
+    });
+  });
+
+  it('sends the identify event with ID and other user attributes', () => {
+    const event = {
+      type: 'identify',
+      userId: 'testId',
+      traits: {
+        age: 25,
+        gender: 'female',
+        description: 'description',
+        name: 'Test Name',
+        email: 'test@test.com',
+      },
+    } as IdentifyEventType;
+
+    identify(event);
+
+    expect(Taplytics.setUserAttributes).toHaveBeenCalledTimes(1);
+    expect(Taplytics.setUserAttributes).toHaveBeenCalledWith({
+      user_id: 'testId',
+      age: 25,
+      gender: 'female',
+      name: 'Test Name',
+      email: 'test@test.com',
+    });
+  });
+});

--- a/packages/plugins/plugin-taplytics/src/methods/__tests__/reset.test.ts
+++ b/packages/plugins/plugin-taplytics/src/methods/__tests__/reset.test.ts
@@ -1,0 +1,18 @@
+import reset from '../reset';
+import * as Taplytics from 'taplytics-react-native';
+
+jest.mock('taplytics-react-native', () => ({
+  resetAppUser: jest.fn(),
+}));
+
+describe('#reset', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('forwards reset event', () => {
+    reset();
+
+    expect(Taplytics.resetAppUser).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/plugins/plugin-taplytics/src/methods/__tests__/screen.test.ts
+++ b/packages/plugins/plugin-taplytics/src/methods/__tests__/screen.test.ts
@@ -1,0 +1,36 @@
+import type { ScreenEventType } from '@segment/analytics-react-native/src';
+import screen from '../screen';
+import * as Taplytics from 'taplytics-react-native';
+
+jest.mock('taplytics-react-native', () => ({
+  logEvent: jest.fn(),
+}));
+
+describe('#screen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('logs a screen event', () => {
+    const event = {
+      type: 'screen',
+      name: 'Test Screen',
+      properties: {
+        description: 'description',
+        test: 'test',
+      },
+    } as ScreenEventType;
+
+    screen(event);
+
+    expect(Taplytics.logEvent).toHaveBeenCalledTimes(1);
+    expect(Taplytics.logEvent).toHaveBeenCalledWith(
+      'SCREEN event: Test Screen',
+      0,
+      {
+        description: 'description',
+        test: 'test',
+      }
+    );
+  });
+});

--- a/packages/plugins/plugin-taplytics/src/methods/__tests__/track.test.ts
+++ b/packages/plugins/plugin-taplytics/src/methods/__tests__/track.test.ts
@@ -1,0 +1,36 @@
+import type { TrackEventType } from '@segment/analytics-react-native/src';
+import track from '../track';
+import * as Taplytics from 'taplytics-react-native';
+
+jest.mock('taplytics-react-native', () => ({
+  logEvent: jest.fn(),
+}));
+
+describe('#track', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('logs a track event', () => {
+    const event = {
+      type: 'track',
+      event: 'Track Event',
+      properties: {
+        description: 'description',
+        test: 'test',
+      },
+    } as TrackEventType;
+
+    track(event);
+
+    expect(Taplytics.logEvent).toHaveBeenCalledTimes(1);
+    expect(Taplytics.logEvent).toHaveBeenCalledWith(
+      'TRACK event: Track Event',
+      0,
+      {
+        description: 'description',
+        test: 'test',
+      }
+    );
+  });
+});

--- a/packages/plugins/plugin-taplytics/src/methods/group.ts
+++ b/packages/plugins/plugin-taplytics/src/methods/group.ts
@@ -1,0 +1,9 @@
+import type { GroupEventType } from '@segment/analytics-react-native';
+import * as Taplytics from 'taplytics-react-native';
+
+export default (event: GroupEventType) => {
+  const eventName = `${event.type.toUpperCase()} event: ${event.groupId}`;
+
+  Taplytics.logEvent(eventName, 0, event.traits);
+  return event;
+};

--- a/packages/plugins/plugin-taplytics/src/methods/identify.ts
+++ b/packages/plugins/plugin-taplytics/src/methods/identify.ts
@@ -1,0 +1,17 @@
+import type { IdentifyEventType } from '@segment/analytics-react-native';
+import * as Taplytics from 'taplytics-react-native';
+
+export default (event: IdentifyEventType) => {
+  const userAttributes = {
+    user_id: event.userId,
+    email: event.traits?.email,
+    name: event.traits?.name,
+    age: event.traits?.age,
+    gender: event.traits?.gender,
+  };
+
+  const cleanedUserAttributes = JSON.parse(JSON.stringify(userAttributes));
+
+  Taplytics.setUserAttributes(cleanedUserAttributes);
+  return event;
+};

--- a/packages/plugins/plugin-taplytics/src/methods/reset.ts
+++ b/packages/plugins/plugin-taplytics/src/methods/reset.ts
@@ -1,0 +1,5 @@
+import * as Taplytics from 'taplytics-react-native';
+
+export default () => {
+  Taplytics.resetAppUser();
+};

--- a/packages/plugins/plugin-taplytics/src/methods/screen.ts
+++ b/packages/plugins/plugin-taplytics/src/methods/screen.ts
@@ -1,0 +1,9 @@
+import type { ScreenEventType } from '@segment/analytics-react-native';
+import * as Taplytics from 'taplytics-react-native';
+
+export default (event: ScreenEventType) => {
+  const eventName = `${event.type.toUpperCase()} event: ${event.name}`;
+
+  Taplytics.logEvent(eventName, 0, event.properties);
+  return event;
+};

--- a/packages/plugins/plugin-taplytics/src/methods/track.ts
+++ b/packages/plugins/plugin-taplytics/src/methods/track.ts
@@ -1,0 +1,9 @@
+import type { TrackEventType } from '@segment/analytics-react-native';
+import * as Taplytics from 'taplytics-react-native';
+
+export default (event: TrackEventType) => {
+  const eventName = `${event.type.toUpperCase()} event: ${event.event}`;
+
+  Taplytics.logEvent(eventName, 0, event.properties);
+  return event;
+};

--- a/packages/plugins/plugin-taplytics/tsconfig.json
+++ b/packages/plugins/plugin-taplytics/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "lib/typescript",
+    "baseUrl": ".",
+    "paths": {
+      "@segment/analytics-react-native": ["<rootDir>/../../core/src/index"]
+    }
+  },
+  "references": [{ "path": "../../core" }]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6747,6 +6747,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.clonedeep@*:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -9393,6 +9398,13 @@ table@^6.0.9:
     slice-ansi "^4.0.0"
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
+
+taplytics-react-native@^3.0.0-rc.6:
+  version "3.0.0-rc.6"
+  resolved "https://registry.yarnpkg.com/taplytics-react-native/-/taplytics-react-native-3.0.0-rc.6.tgz#de8b1a2e77f2e841545a4a12e80603dfe4ca7e38"
+  integrity sha512-PtB7JrmpY2CdXv8q+lAMNYqaOms05fqbRbc1TCZsIWQmMTyg0GFCJoj50odip9J18jG0YS6Zh7jB0Wd7r3SxoA==
+  dependencies:
+    lodash.clonedeep "*"
 
 temp-dir@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- add Taplytics Plugin to forward `track`, `screen`, `identify`, `group` events to Taplytics as a destination
- use plugin's implementation of `reset`