### PR TITLE
docs: add Taplytics under Example Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,7 @@ Refer to the following table for example Plugins you can use and alter to meet y
 | Facebook App Events    | `@segment/analytics-react-native-plugin-facebook-app-events` |
 | Firebase      | `@segment/analytics-react-native-plugin-consent-firebase`|
 | IDFA     | `@segment/analytics-react-native-plugin-idfa` |
+| [Taplytics](https://github.com/taplytics/segment-react-native-plugin-taplytics)     | `@taplytics/segment-react-native-plugin-taplytics` |
 
   
   


### PR DESCRIPTION
- add the Taplytics Destination plugin as an example to the README