### PR TITLE
fix: appsflyer attribution

### DIFF
--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -26,7 +26,6 @@ import {
   JsonMap,
   PluginType,
   SegmentAPIIntegrations,
-  SegmentAPISettings,
   SegmentEvent,
   UpdateType,
   UserInfoState,
@@ -360,13 +359,15 @@ export class SegmentClient {
   }: {
     plugin: P;
     settings?: P extends DestinationPlugin ? IntegrationSettings : never;
-
   }) {
     // plugins can either be added immediately or
     // can be cached and added later during the next state update
     // this is to avoid adding plugins before network requests made as part of setup have resolved
     if (settings !== undefined && plugin.type === PluginType.destination) {
-      this.store.settings.add((plugin as unknown as DestinationPlugin).key, settings);
+      this.store.settings.add(
+        (plugin as unknown as DestinationPlugin).key,
+        settings
+      );
     }
 
     if (!this.store.isReady.get()) {

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -22,6 +22,7 @@ import {
   Context,
   DeepPartial,
   GroupTraits,
+  IntegrationSettings,
   JsonMap,
   PluginType,
   SegmentAPIIntegrations,
@@ -351,20 +352,21 @@ export class SegmentClient {
 
   /**
    * Adds a new plugin to the currently loaded set.
-   * @param {{ plugin: Plugin, settings?: SegmentAPISettings }} Plugin to be added. Settings are optional if you want to force a configuration instead of the Segment Cloud received one
+   * @param {{ plugin: Plugin, settings?: IntegrationSettings }} Plugin to be added. Settings are optional if you want to force a configuration instead of the Segment Cloud received one
    */
-  add({
+  add<P extends Plugin>({
     plugin,
     settings,
   }: {
-    plugin: Plugin;
-    settings?: Plugin extends DestinationPlugin ? SegmentAPISettings : never;
+    plugin: P;
+    settings?: P extends DestinationPlugin ? IntegrationSettings : never;
+
   }) {
     // plugins can either be added immediately or
     // can be cached and added later during the next state update
     // this is to avoid adding plugins before network requests made as part of setup have resolved
     if (settings !== undefined && plugin.type === PluginType.destination) {
-      this.store.settings.add((plugin as DestinationPlugin).key, settings);
+      this.store.settings.add((plugin as unknown as DestinationPlugin).key, settings);
     }
 
     if (!this.store.isReady.get()) {

--- a/packages/plugins/plugin-appsflyer/src/AppsflyerPlugin.tsx
+++ b/packages/plugins/plugin-appsflyer/src/AppsflyerPlugin.tsx
@@ -85,7 +85,7 @@ export class AppsflyerPlugin extends DestinationPlugin {
         },
       };
 
-      if (is_first_launch === 'true') {
+      if (is_first_launch && JSON.parse(is_first_launch) === true) {
         if (af_status === 'Non-organic') {
           this.analytics?.track('Install Attributed', properties);
         } else {

--- a/packages/plugins/plugin-appsflyer/src/AppsflyerPlugin.tsx
+++ b/packages/plugins/plugin-appsflyer/src/AppsflyerPlugin.tsx
@@ -85,7 +85,7 @@ export class AppsflyerPlugin extends DestinationPlugin {
         },
       };
 
-      if (is_first_launch && JSON.parse(is_first_launch) === true) {
+      if (JSON.parse(is_first_launch) === true) {
         if (af_status === 'Non-organic') {
           this.analytics?.track('Install Attributed', properties);
         } else {


### PR DESCRIPTION
Fixes AppsFlyer plugin not reporting install events due to the condition being always false:

Types in `appsflyer-react-native` package are wrongly reporting `is_first_launch: "true" | "false";`
But at runtime, these are actual boolean values.

https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/blob/master/index.d.ts#L12

Also added extra safety JSON.parse based on the examples in https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/blob/master/Docs/DeepLink.md#-1-deferred-deep-linking-get-conversion-data

Also, fixed types for `analytics.add(plugin)`

