### PR TITLE
feat: createClient "storePersistor" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,17 +98,18 @@ You must pass at least the `writeKey`. Additional configuration options are list
   
 ### Client Options
 
-| Name                       | Default   | Description                                                                                                                          |
-| -------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `writeKey` **(REQUIRED)**  | ''        | Your Segment API key.                                                                                                                |
-| `debug`                    | true\*    | When set to false, it will not generate any logs.                                                                                    |
-| `flushAt`                  | 20        | How many events to accumulate before sending events to the backend.                                                                  |
-| `flushInterval`            | 30        | In seconds, how often to send events to the backend.                                                                                 |
-| `maxBatchSize`             | 1000      | How many events to send to the API at once                                                                                           |
+| Name                       | Default   | Description                                                                                                                                    |
+| -------------------------- | --------- | -----------------------------------------------------------------------------------------------------------------------------------------------|
+| `writeKey` **(REQUIRED)**  | ''        | Your Segment API key.                                                                                                                          |
+| `debug`                    | true\*    | When set to false, it will not generate any logs.                                                                                              |
+| `flushAt`                  | 20        | How many events to accumulate before sending events to the backend.                                                                            |
+| `flushInterval`            | 30        | In seconds, how often to send events to the backend.                                                                                           |
+| `maxBatchSize`             | 1000      | How many events to send to the API at once                                                                                                     |
 | `trackAppLifecycleEvents`  | false     | Enable automatic tracking for [app lifecycle events](https://segment.com/docs/connections/spec/mobile/#lifecycle-events): application installed, opened, updated, backgrounded) |
 | `trackDeepLinks`           | false     | Enable automatic tracking for when the user opens the app via a deep link (Note: Requires additional setup on iOS, [see instructions](#ios-deep-link-tracking-setup))                                                            |
-| `defaultSettings`          | undefined | Settings that will be used if the request to get the settings from Segment fails                                                     |
-| `autoAddSegmentDestination`| true      | Set to false to skip adding the SegmentDestination plugin                                                                            |
+| `defaultSettings`          | undefined | Settings that will be used if the request to get the settings from Segment fails                                                               |
+| `autoAddSegmentDestination`| true      | Set to false to skip adding the SegmentDestination plugin                                                                                      |
+| `storePersistor`           | undefined | A custom persistor for the store that `analytics-react-native` leverages. Must match `Persistor` interface exported from [sovran-react-native](https://github.com/segmentio/sovran-react-native).|
 
 \* The default value of `debug` will be false in production.
 

--- a/packages/core/src/client.tsx
+++ b/packages/core/src/client.tsx
@@ -17,7 +17,10 @@ export const createClient = (config: Config) => {
   }
   const clientConfig = { ...defaultConfig, ...config };
 
-  const segmentStore = new SovranStorage(config.writeKey);
+  const segmentStore = new SovranStorage({
+    storeId: config.writeKey,
+    storePersistor: config.storePersistor,
+  });
 
   const client = new SegmentClient({
     config: clientConfig,

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -1,4 +1,4 @@
-import type { Unsubscribe } from '@segment/sovran-react-native';
+import type { Unsubscribe, Persistor } from '@segment/sovran-react-native';
 import type { SegmentEvent } from '..';
 import type {
   Context,
@@ -69,3 +69,8 @@ export interface DeepLinkData {
   referring_application: string;
   url: string;
 }
+
+export type StorageConfig = {
+  storeId: string;
+  storePersistor?: Persistor;
+};

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,3 +1,5 @@
+import type { Persistor } from '@segment/sovran-react-native';
+
 export type JsonValue =
   | boolean
   | number
@@ -123,6 +125,7 @@ export type Config = {
   defaultSettings?: SegmentAPISettings;
   autoAddSegmentDestination?: boolean;
   collectDeviceId?: boolean;
+  storePersistor?: Persistor;
 };
 
 export type ClientMethods = {


### PR DESCRIPTION
# Summary
The gist of this PR is that it allows for a `storePersistor` client option to be specified in the `createClient` function call. Currently `@segment/sovran-react-native`, the store that backs `@segment/analytics-react-native`, uses `AsyncStorage` as the default persistor. However with this changeset, the new client option allows for Segment clients to leverage a storage mechanism other than `AsyncStorage`.

# Use Case
Gopuff's app uses MMKV for key/value storage. And the Consumer Platform Team required that MMKV be the storage mechanism for `@segment/analytics-react-native`'s stores. Hopefully this enhancement will be beneficial to other Segment client as well.

# Documentation
Updated README.md's section on **Client Options**. Hopefully that was sufficient. Please let me know if additional documentation is required.

# Unit Tests
Updated `sovranStorage.test.ts` to also perform assertions on a `SovranStorage` instance that's using a `CustomPersistor`(i.e. in-memory) instead of the default `AsyncStoragePersistor`.

**NOTE:** I did not add additional assertions for the `events` and `userInfo` stores that the `SovranStorage` class creates. Please let me know if you would like assertions added for those.

# References
- Feature request: https://github.com/segmentio/analytics-react-native/issues/542

 