### PR TITLE
fix: appsflyer attribution error due to install conversion data failure

### DIFF
--- a/packages/plugins/plugin-appsflyer/src/AppsflyerPlugin.tsx
+++ b/packages/plugins/plugin-appsflyer/src/AppsflyerPlugin.tsx
@@ -85,7 +85,7 @@ export class AppsflyerPlugin extends DestinationPlugin {
         },
       };
 
-      if (JSON.parse(is_first_launch) === true) {
+      if (is_first_launch && JSON.parse(is_first_launch) === true) {
         if (af_status === 'Non-organic') {
           this.analytics?.track('Install Attributed', properties);
         } else {


### PR DESCRIPTION
This PR prevents the `onInstallConversionData` handler from throwing an error when the SDK is not able to get the conversion data. In this case, `res?.data?.is_first_launch` would be undefined and `JSON.parse` would fail.

Sample payload in `onInstallConversionData` that would cause this error:

```
{
  status: 'failure',
  type: 'onInstallConversionFailure',
  data: 'Launch status code: 404'
}
```