### PR TITLE
feat: Create Client Proxy Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ You must pass at least the `writeKey`. Additional configuration options are list
 | `defaultSettings`          | undefined | Settings that will be used if the request to get the settings from Segment fails                                                               |
 | `autoAddSegmentDestination`| true      | Set to false to skip adding the SegmentDestination plugin                                                                                      |
 | `storePersistor`           | undefined | A custom persistor for the store that `analytics-react-native` leverages. Must match `Persistor` interface exported from [sovran-react-native](https://github.com/segmentio/sovran-react-native).|
+| `proxy`                    | undefined | Proxy config object consisting of `scheme`(e.g. "https"), `host`(e.g. "mysite.com"), `port`(e.g. 80), and `path`(e.g. "/events")  to post events to instead of `segment.io`. |
+
 
 \* The default value of `debug` will be false in production.
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ You must pass at least the `writeKey`. Additional configuration options are list
 | `defaultSettings`          | undefined | Settings that will be used if the request to get the settings from Segment fails                                                               |
 | `autoAddSegmentDestination`| true      | Set to false to skip adding the SegmentDestination plugin                                                                                      |
 | `storePersistor`           | undefined | A custom persistor for the store that `analytics-react-native` leverages. Must match `Persistor` interface exported from [sovran-react-native](https://github.com/segmentio/sovran-react-native).|
-| `proxy`                    | undefined | Proxy config object consisting of `scheme`(e.g. "https"), `host`(e.g. "mysite.com"), `port`(e.g. 80), and `path`(e.g. "/events")  to post events to instead of `segment.io`. |
+| `proxy`                    | undefined | `proxy` is a batch url to post to instead of 'https://api.segment.io/v1/b'.                                                                    |
 
 
 \* The default value of `debug` will be false in production.

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -9,7 +9,8 @@ export const sendEvents = async ({
   config: Config;
   events: SegmentEvent[];
 }) => {
-  await fetch(batchApi, {
+  const requestUrl = config.proxy || batchApi;
+  await fetch(requestUrl, {
     method: 'POST',
     body: JSON.stringify({
       batch: events,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -126,6 +126,7 @@ export type Config = {
   autoAddSegmentDestination?: boolean;
   collectDeviceId?: boolean;
   storePersistor?: Persistor;
+  proxy?: string;
 };
 
 export type ClientMethods = {


### PR DESCRIPTION
# Summary
The gist of this PR is that it allows for a `proxy` client option to be specified in the `createClient` function call. Previously in Analytics React Native 1.0, a `proxy` client option was available in the `setup` function call.

# Use Case
Gopuff's Customer Data Platform team wants to be able to empower other internal engineerings teams with the ability to inspect events and assert them for integrations tests in realtime. To do this we were hoping to be able to specify a `proxy` that the events would be posted to first before we post them to Segment. `analytics-node` and `analytics-next` already have the ability to specify proxies, so we were hoping we could make it possible for `analytics-react-native`.

# Documentation
Updated README.md's section on **Client Options**. Hopefully that was sufficient. Please let me know if additional documentation is required.

# Unit Tests
Updated `api.test.ts` to include a test case that asserts that the `proxy` client option overrides the Segment batch url.

# References
- Feature request: https://github.com/segmentio/analytics-react-native/issues/520

 