### PR TITLE
fix: map correct facebook events

### DIFF
--- a/packages/plugins/plugin-facebook-app-events/src/methods/parameterMapping.ts
+++ b/packages/plugins/plugin-facebook-app-events/src/methods/parameterMapping.ts
@@ -7,6 +7,7 @@ export const mapEventNames = {
   'Order Completed': 'fb_mobile_purchase',
   'Product Added': 'fb_mobile_add_to_cart',
   'Product Added to Wishlist': 'fb_mobile_add_to_wishlist',
+  'Checkout Started': 'fb_mobile_initiated_checkout',
 } as any;
 
 export const mapEventProps: { [key: string]: string } = {

--- a/packages/plugins/plugin-facebook-app-events/src/methods/track.ts
+++ b/packages/plugins/plugin-facebook-app-events/src/methods/track.ts
@@ -46,7 +46,10 @@ export default (event: TrackEventType) => {
   let safeProps = sanitizeEvent(safeEvent);
   const currency = (safeProps.fb_currency as string | undefined) ?? 'USD';
 
-  if (safeProps._valueToSum !== undefined) {
+  if (
+    safeProps._valueToSum !== undefined &&
+    safeName === 'fb_mobile_purchase'
+  ) {
     let purchasePrice = safeProps._valueToSum as number;
 
     AppEventsLogger.logPurchase(purchasePrice, currency, safeProps);


### PR DESCRIPTION
This PR:

- map the missing Checkout Started [spec’d events](https://segment.com/docs/connections/spec/) to the matching Facebook Event following the [docs](https://segment.com/docs/connections/destinations/catalog/facebook-app-events/#facebook-events).
- correctly trigger a facebook purchase event just in case the event is a `fb_mobile_purchase`. Previously the event was triggered also for events having the props `_valueToSum`, e.g. `Product Added`