### PR TITLE
fix: revert traits behavior

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -8,6 +8,9 @@ If you’re using  `analytics-react-native 1.5.1`  or older, follow these steps 
 ```sh
 yarn upgrade @segment/analytics-react-native
 ```
+
+If you are using any device mode destinations from V1 you will have to remove them and add their [equivalent plugin package for V2](#plugins).
+
 2. Add/Update pods
 ```sh
 npx pod-install
@@ -133,3 +136,43 @@ const Home = ({ navigation }: { navigation: any }) => {
  ...
 };
 ```
+
+### Plugins
+
+**The plugins for V2 have changed from V1**. 
+
+The plugins have been re-released with different names. These are the equivalent packages for V2. Not all packages in V1 have yet been released for V2 but Segment is actively adding more packages to the list. 
+
+Also review [the main package list](README.md#supported-plugins) for new V2 plugins.
+
+| Plugin | V1 Package      | V2 Package     |
+| ----------- | ----------- | ----------- |
+| [Adjust](https://github.com/segmentio/analytics-react-native/tree/master/packages/plugins/plugin-adjust)      | `@segment/analytics-react-native-adjust`|  `@segment/analytics-react-native-plugin-adjust` |
+| [Amplitude Sessions](https://github.com/segmentio/analytics-react-native/tree/master/packages/plugins/plugin-amplitudeSession)      | `@segment/analytics-react-native-amplitude`| `@segment/analytics-react-native-plugin-amplitude-session`|
+| [AppsFlyer](https://github.com/segmentio/analytics-react-native/tree/master/packages/plugins/plugin-appsflyer)    | `@segment/analytics-react-native-appsflyer` | `@segment/analytics-react-native-plugin-appsflyer`|
+| [Facebook App Events](https://github.com/segmentio/analytics-react-native/tree/master/packages/plugins/plugin-facebook-app-events)    | `@segment/analytics-react-native-facebook-app-events-ios` | `@segment/analytics-react-native-plugin-facebook-app-events` |
+| [Firebase](https://github.com/segmentio/analytics-react-native/tree/master/packages/plugins/plugin-firebase)      | `@segment/analytics-react-native-firebase` | `@segment/analytics-react-native-plugin-firebase`|
+| [Mixpanel](https://github.com/segmentio/analytics-react-native/tree/master/packages/plugins/plugin-mixpanel)    | `@segment/analytics-react-native-mixpanel` | `@segment/analytics-react-native-plugin-mixpanel` |
+| [Taplytics](https://github.com/taplytics/segment-react-native-plugin-taplytics)     | `@segment/analytics-react-native-taplytics-ios` | `@taplytics/segment-react-native-plugin-taplytics` |
+
+### Context Traits
+
+Previous versions of this library used to persist `traits` accross events after an `identify` was sent inside `context.traits` we're not supporting this out of the box in V2 and the rest of our mobile libraries due concerns of data privacy for some device destinations. Some device mode destinations might not accept events if they contain identifiable data.
+
+If you need to keep this behavior, we have an example plugin [`InjectTraits`](example/src/plugins/InjectTraits.ts) that you can use for it. This plugin injects the current user traits into `context.traits` of every event.
+
+To use it, copy the [file](example/src/plugins/InjectTraits.ts) into your codebase and add it into your client:
+
+```ts
+import { createClient } from '@segment/analytics-react-native';
+
+import { InjectTraits } from './InjectTraits';
+
+const segmentClient = createClient({
+  writeKey: 'SEGMENT_KEY'
+});
+
+segmentClient.add({ plugin: new InjectTraits() });
+```
+
+Please note that as this is an example we don't offer full support for it nor release it as an npm package.

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -157,7 +157,7 @@ Also review [the main package list](README.md#supported-plugins) for new V2 plug
 
 ### Context Traits
 
-Previous versions of this library used to persist `traits` accross events after an `identify` was sent inside `context.traits` we're not supporting this out of the box in V2 and the rest of our mobile libraries due concerns of data privacy for some device destinations. Some device mode destinations might not accept events if they contain identifiable data.
+Previous versions of this library used to persist `traits` in `context.traits` across all event types after an `identify` event was sent. We no longer not support this out of the box in V2 as well as the rest of our mobile libraries due to concerns of data privacy for some device mode destinations. Some device mode destinations might not accept events if they contain identifiable data as it is against their Terms of Service.
 
 If you need to keep this behavior, we have an example plugin [`InjectTraits`](example/src/plugins/InjectTraits.ts) that you can use for it. This plugin injects the current user traits into `context.traits` of every event.
 
@@ -175,4 +175,4 @@ const segmentClient = createClient({
 segmentClient.add({ plugin: new InjectTraits() });
 ```
 
-Please note that as this is an example we don't offer full support for it nor release it as an npm package.
+Please note that as this is an example we don't offer full support for it and will not release it as an NPM package.

--- a/example/src/plugins/InjectTraits.ts
+++ b/example/src/plugins/InjectTraits.ts
@@ -1,0 +1,25 @@
+import {
+  PluginType,
+  SegmentEvent,
+  PlatformPlugin,
+} from '@segment/analytics-react-native';
+
+/**
+ * Plugin that injects the user traits to every event
+ */
+export class InjectTraits extends PlatformPlugin {
+  type = PluginType.before;
+
+  execute(event: SegmentEvent) {
+    return {
+      ...event,
+      context: {
+        ...event.context,
+        traits: {
+          ...event.context,
+          ...this.analytics!.userInfo.get().traits,
+        },
+      },
+    };
+  }
+}

--- a/packages/core/src/__tests__/methods/identify.test.ts
+++ b/packages/core/src/__tests__/methods/identify.test.ts
@@ -103,7 +103,7 @@ describe('methods #identify', () => {
     });
   });
 
-  it('persists identity traits accross events', () => {
+  it('does not persist identity traits accross events', () => {
     const client = new SegmentClient(clientArgs);
     jest.spyOn(client, 'process');
     // @ts-ignore accessing the internal timeline to check the processed events
@@ -139,10 +139,6 @@ describe('methods #identify', () => {
       messageId: 'mocked-uuid',
       properties: {},
       timestamp: '2010-01-01T00:00:00.000Z',
-      traits: {
-        age: 30,
-        name: 'Mary',
-      },
       type: 'track',
       userId: 'new-user-id',
     });

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -82,8 +82,6 @@ const isAliasEvent = (event: SegmentEvent): event is AliasEventType =>
   event.type === EventType.AliasEvent;
 const isIdentifyEvent = (event: SegmentEvent): event is AliasEventType =>
   event.type === EventType.IdentifyEvent;
-const isGroupEvent = (event: SegmentEvent): event is GroupEventType =>
-  event.type === EventType.GroupEvent;
 
 export const applyRawEventData = (
   event: SegmentEvent,
@@ -99,9 +97,5 @@ export const applyRawEventData = (
       isAliasEvent(event) || isIdentifyEvent(event)
         ? event.userId
         : userInfo.userId,
-    traits:
-      isIdentifyEvent(event) || isGroupEvent(event)
-        ? event.traits
-        : userInfo.traits,
   };
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -26,7 +26,6 @@ interface BaseEventType {
   messageId?: string;
   userId?: string;
   timestamp?: string;
-  traits?: UserTraits | GroupTraits;
 
   context?: PartialContext;
   integrations?: SegmentAPIIntegrations;


### PR DESCRIPTION
- Reverted the traits behavior to not persist after an `identify` event
- Added example plugin `InjectTraits` and documentation for how to preserve this behavior
- Added migration guide for Plugins from V1 to V2
