### PR TITLE
fix: put user traits on the context rather than userInfo

### DIFF
--- a/packages/core/src/__tests__/__helpers__/mockSegmentStore.ts
+++ b/packages/core/src/__tests__/__helpers__/mockSegmentStore.ts
@@ -29,7 +29,6 @@ const INITIAL_VALUES: Data = {
   userInfo: {
     anonymousId: 'anonymousId',
     userId: undefined,
-    traits: undefined,
   },
   deepLinkData: {
     referring_application: '',

--- a/packages/core/src/__tests__/analytics.test.ts
+++ b/packages/core/src/__tests__/analytics.test.ts
@@ -128,7 +128,6 @@ describe('SegmentClient', () => {
       expect(setUserInfo).toHaveBeenCalledWith({
         anonymousId: 'anonymousId',
         userId: undefined,
-        traits: undefined,
       });
     });
 
@@ -141,7 +140,6 @@ describe('SegmentClient', () => {
       expect(setUserInfo).toHaveBeenCalledWith({
         anonymousId: 'mocked-uuid',
         userId: undefined,
-        traits: undefined,
       });
     });
   });

--- a/packages/core/src/__tests__/methods/alias.test.ts
+++ b/packages/core/src/__tests__/methods/alias.test.ts
@@ -48,7 +48,6 @@ describe('methods #alias', () => {
     expect(client.userInfo.get()).toEqual({
       anonymousId: 'anonymousId',
       userId: 'new-user-id',
-      traits: undefined,
     });
   });
 
@@ -78,7 +77,6 @@ describe('methods #alias', () => {
     expect(client.userInfo.get()).toEqual({
       anonymousId: 'anonymousId',
       userId: 'new-user-id',
-      traits: undefined,
     });
   });
 });

--- a/packages/core/src/__tests__/methods/flush.test.ts
+++ b/packages/core/src/__tests__/methods/flush.test.ts
@@ -75,9 +75,6 @@ describe('methods #flush', () => {
       store: new MockSegmentStore({
         userInfo: {
           anonymousId: '123-456',
-          traits: {
-            name: 'Mary',
-          },
         },
         events: events,
       }),

--- a/packages/core/src/__tests__/methods/identify.test.ts
+++ b/packages/core/src/__tests__/methods/identify.test.ts
@@ -59,6 +59,11 @@ describe('methods #identify', () => {
       ...initialUserInfo,
       userId: 'new-user-id',
     });
+    expect(client.context.get()?.traits).toEqual({
+      ...initialContext.traits,
+      name: 'Mary',
+      age: 30,
+    });
   });
 
   it('does not update user traits when there are no new ones provided', () => {
@@ -83,6 +88,11 @@ describe('methods #identify', () => {
       ...initialUserInfo,
       userId: 'new-user-id',
     });
+    expect(client.context.get()?.traits).toEqual({
+      ...initialContext.traits,
+      name: 'Stacy',
+      age: 30,
+    });
   });
 
   it('does not update userId when userId is undefined', () => {
@@ -103,7 +113,9 @@ describe('methods #identify', () => {
       ...initialUserInfo,
     });
     expect(client.context.get()?.traits).toEqual({
-      ...expectedEvent.traits,
+      ...initialContext.traits,
+      name: 'Mary',
+      age: 30,
     });
   });
 
@@ -131,7 +143,11 @@ describe('methods #identify', () => {
       ...initialUserInfo,
       userId: 'new-user-id',
     });
-    expect(client.context.get()?.traits).toEqual(expectedEvent.traits);
+    expect(client.context.get()?.traits).toEqual({
+      ...initialContext.traits,
+      name: 'Mary',
+      age: 30,
+    });
 
     client.track('track event');
 

--- a/packages/core/src/__tests__/methods/identify.test.ts
+++ b/packages/core/src/__tests__/methods/identify.test.ts
@@ -9,16 +9,19 @@ jest
   .mockReturnValue('2010-01-01T00:00:00.000Z');
 
 describe('methods #identify', () => {
-  const initialUserInfo = {
+  const initialContext = {
     traits: {
       name: 'Stacy',
       age: 30,
     },
+  };
+  const initialUserInfo = {
     userId: 'current-user-id',
     anonymousId: 'very-anonymous',
   };
   const store = new MockSegmentStore({
     userInfo: initialUserInfo,
+    context: initialContext,
   });
 
   const clientArgs = {
@@ -55,7 +58,6 @@ describe('methods #identify', () => {
     expect(client.userInfo.get()).toEqual({
       ...initialUserInfo,
       userId: 'new-user-id',
-      traits: expectedEvent.traits,
     });
   });
 
@@ -66,9 +68,12 @@ describe('methods #identify', () => {
     client.identify('new-user-id');
 
     const expectedEvent = {
-      traits: initialUserInfo.traits,
       userId: 'new-user-id',
       type: 'identify',
+      traits: {
+        name: 'Stacy',
+        age: 30,
+      },
     };
 
     expect(client.process).toHaveBeenCalledTimes(1);
@@ -96,10 +101,9 @@ describe('methods #identify', () => {
     expect(client.process).toHaveBeenCalledWith(expectedEvent);
     expect(client.userInfo.get()).toEqual({
       ...initialUserInfo,
-      traits: {
-        age: 30,
-        name: 'Mary',
-      },
+    });
+    expect(client.context.get()?.traits).toEqual({
+      ...expectedEvent.traits,
     });
   });
 
@@ -126,8 +130,8 @@ describe('methods #identify', () => {
     expect(client.userInfo.get()).toEqual({
       ...initialUserInfo,
       userId: 'new-user-id',
-      traits: expectedEvent.traits,
     });
+    expect(client.context.get()?.traits).toEqual(expectedEvent.traits);
 
     client.track('track event');
 
@@ -139,10 +143,6 @@ describe('methods #identify', () => {
       messageId: 'mocked-uuid',
       properties: {},
       timestamp: '2010-01-01T00:00:00.000Z',
-      traits: {
-        age: 30,
-        name: 'Mary',
-      },
       type: 'track',
       userId: 'new-user-id',
     });

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -504,7 +504,8 @@ export class SegmentClient {
 
   identify(userId?: string, userTraits?: UserTraits) {
     const userInfo = this.store.userInfo.get();
-    const { traits: currentUserTraits } = userInfo;
+    const context = this.store.context.get();
+    const currentUserTraits = context?.traits || {};
 
     const mergedTraits = {
       ...currentUserTraits,
@@ -519,6 +520,10 @@ export class SegmentClient {
     this.store.userInfo.set({
       ...userInfo,
       userId: userId ?? userInfo.userId,
+    });
+
+    this.store.context.set({
+      ...context,
       traits: mergedTraits,
     });
 
@@ -678,7 +683,6 @@ export class SegmentClient {
     this.store.userInfo.set({
       anonymousId,
       userId: undefined,
-      traits: undefined,
     });
 
     getPluginsWithReset(this.timeline).forEach((plugin) => plugin.reset());

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -82,8 +82,6 @@ const isAliasEvent = (event: SegmentEvent): event is AliasEventType =>
   event.type === EventType.AliasEvent;
 const isIdentifyEvent = (event: SegmentEvent): event is AliasEventType =>
   event.type === EventType.IdentifyEvent;
-const isGroupEvent = (event: SegmentEvent): event is GroupEventType =>
-  event.type === EventType.GroupEvent;
 
 export const applyRawEventData = (
   event: SegmentEvent,
@@ -99,9 +97,5 @@ export const applyRawEventData = (
       isAliasEvent(event) || isIdentifyEvent(event)
         ? event.userId
         : userInfo.userId,
-    traits:
-      isIdentifyEvent(event) || isGroupEvent(event)
-        ? event.traits
-        : userInfo.traits,
   };
 };

--- a/packages/core/src/storage/sovranStorage.ts
+++ b/packages/core/src/storage/sovranStorage.ts
@@ -37,7 +37,6 @@ const INITIAL_VALUES: Data = {
   userInfo: {
     anonymousId: getUUID(),
     userId: undefined,
-    traits: undefined,
   },
 };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -26,7 +26,6 @@ interface BaseEventType {
   messageId?: string;
   userId?: string;
   timestamp?: string;
-  traits?: UserTraits | GroupTraits;
 
   context?: PartialContext;
   integrations?: SegmentAPIIntegrations;
@@ -53,7 +52,7 @@ export interface IdentifyEventType extends BaseEventType {
 export interface GroupEventType extends BaseEventType {
   type: EventType.GroupEvent;
   groupId: string;
-  traits?: GroupTraits;
+  traits: GroupTraits;
 }
 
 export interface AliasEventType extends BaseEventType {
@@ -298,5 +297,4 @@ export enum EventType {
 export type UserInfoState = {
   anonymousId: string;
   userId?: string;
-  traits?: UserTraits | GroupTraits;
 };

--- a/packages/plugins/plugin-braze/src/BrazePlugin.tsx
+++ b/packages/plugins/plugin-braze/src/BrazePlugin.tsx
@@ -14,13 +14,14 @@ export class BrazePlugin extends DestinationPlugin {
 
   identify(event: IdentifyEventType) {
     const currentUserInfo = this.analytics?.userInfo.get();
+    const traits = this.analytics?.context.get()?.traits;
 
     //check to see if anything has changed.
     //if it hasn't changed don't send event
     if (
       currentUserInfo?.userId === event.userId &&
       currentUserInfo?.anonymousId === event.anonymousId &&
-      currentUserInfo?.traits === event.traits
+      traits === event.traits
     ) {
       let integrations = event.integrations;
 


### PR DESCRIPTION
fix: put user traits on the context rather than userInfo
test: add context traits to identify tests

In version 1.x of Analytics React Native user traits were contained in the context and not the root of the event as pointed out in [this issue](https://github.com/segmentio/analytics-react-native/issues/586). This change moves the user traits into the context object so 2.x can be compatible with 1.x.

Not sure if the traits now need to be in both the context and root level to stay compatible with previous versions of 2.x and 1.x. If something like this is not going to be adapted it should definitely be noted in the migration guide that traits are no longer present in the same location and how to deal with that.