### PR TITLE
Fix/package path

### DIFF
--- a/packages/core/constants-generator.js
+++ b/packages/core/constants-generator.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const packageJson = require('./package.json');
+
+const body = `
+export const libraryInfo = {
+  name: '${packageJson.name}',
+  version: '${packageJson.version}',
+}
+`;
+
+fs.writeFile('./src/info.ts', body, function (err) {
+  if (err) {
+    return console.log(err);
+  }
+
+  console.log('Configuration file has generated');
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,7 @@
   "description": "The hassle-free way to add Segment analytics to your React-Native app.",
   "main": "lib/commonjs/index",
   "scripts": {
+    "prebuild": "node constants-generator.js",
     "build": "bob build",
     "test": "jest",
     "typescript": "tsc --noEmit",

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,5 +1,5 @@
 import { NativeModules } from 'react-native';
-import packageJson from '../package.json';
+import { libraryInfo } from './info';
 
 import type {
   Context,
@@ -54,8 +54,8 @@ export const getContext = async (
     },
     device,
     library: {
-      name: packageJson.name,
-      version: packageJson.version,
+      name: libraryInfo.name,
+      version: libraryInfo.version,
     },
     locale,
     network: {

--- a/packages/core/src/info.ts
+++ b/packages/core/src/info.ts
@@ -1,5 +1,4 @@
-
 export const libraryInfo = {
   name: '@segment/analytics-react-native',
   version: '2.3.2',
-}
+};

--- a/packages/core/src/info.ts
+++ b/packages/core/src/info.ts
@@ -1,0 +1,5 @@
+
+export const libraryInfo = {
+  name: '@segment/analytics-react-native',
+  version: '2.3.2',
+}


### PR DESCRIPTION
Based on https://github.com/segmentio/analytics-react-native/issues/572


This solution implements the creation of a `info.ts` file so as not to use `package.json` at runtime since it is outside of `src` folder, making it unreachable for invocations.

Why:

- Don't use the whole package just the necessary variables.
- Copying the entire file is not such a good solution.
- `process.env.npm_package_version` is not a solution because this is not Node runtime.

Downsides:

- Each version change in the `package.json` generates a new change to commit in the new file.


It's not the most elegant solution, but it works! :p, I would like to know your thoughts on this.

Thank you!