### PR TITLE
fix: map to correct firebase event name/attributes

### DIFF
--- a/packages/plugins/plugin-firebase/src/methods/___tests__/track.test.ts
+++ b/packages/plugins/plugin-firebase/src/methods/___tests__/track.test.ts
@@ -78,6 +78,6 @@ describe('#track', () => {
     await track(event);
 
     expect(mockLogEvent).toHaveBeenCalledTimes(1);
-    expect(mockLogEvent).toHaveBeenCalledWith('purchase_refund', {});
+    expect(mockLogEvent).toHaveBeenCalledWith('refund', {});
   });
 });

--- a/packages/plugins/plugin-firebase/src/methods/parameterMapping.ts
+++ b/packages/plugins/plugin-firebase/src/methods/parameterMapping.ts
@@ -1,0 +1,36 @@
+const mapEventNames = {
+  'Product Clicked': 'select_content',
+  'Product Viewed': 'view_item',
+  'Product Added': 'add_to_cart',
+  'Product Removed': 'remove_from_cart',
+  'Checkout Started': 'begin_checkout',
+  'Promotion Viewed': 'view_promotion',
+  'Payment Info Entered': 'add_payment_info',
+  'Order Completed': 'purchase',
+  'Order Refunded': 'refund',
+  'Product List Viewed': 'view_item_list',
+  'Product Added to Wishlist': 'add_to_wishlist',
+  'Product Shared': 'share',
+  'Cart Shared': 'share',
+  'Products Searched': 'search',
+} as any;
+
+export const mapEventProps: { [key: string]: string } = {
+  price: 'price',
+  total: 'value',
+  products: 'items',
+  name: 'item_name',
+  product_id: 'item_id',
+  productId: 'item_id',
+  category: 'item_category',
+  query: 'search_term',
+} as any;
+
+export const transformMap: { [key: string]: (value: any) => any } = {
+  event: (value: string) => {
+    if (value in mapEventNames) {
+      return mapEventNames[value];
+    }
+    return value;
+  },
+};

--- a/packages/plugins/plugin-firebase/src/methods/parameterMapping.ts
+++ b/packages/plugins/plugin-firebase/src/methods/parameterMapping.ts
@@ -1,4 +1,4 @@
-const mapEventNames = {
+const mapEventNames: { [key: string]: string } = {
   'Product Clicked': 'select_content',
   'Product Viewed': 'view_item',
   'Product Added': 'add_to_cart',
@@ -13,7 +13,7 @@ const mapEventNames = {
   'Product Shared': 'share',
   'Cart Shared': 'share',
   'Products Searched': 'search',
-} as any;
+};
 
 export const mapEventProps: { [key: string]: string } = {
   price: 'price',
@@ -24,7 +24,7 @@ export const mapEventProps: { [key: string]: string } = {
   productId: 'item_id',
   category: 'item_category',
   query: 'search_term',
-} as any;
+};
 
 export const transformMap: { [key: string]: (value: any) => any } = {
   event: (value: string) => {

--- a/packages/plugins/plugin-firebase/src/methods/track.ts
+++ b/packages/plugins/plugin-firebase/src/methods/track.ts
@@ -1,25 +1,17 @@
 import firebaseAnalytics from '@react-native-firebase/analytics';
-import type { TrackEventType } from '@segment/analytics-react-native';
+import { generateMapTransform, TrackEventType } from '@segment/analytics-react-native';
+import { mapEventProps, transformMap } from './parameterMapping';
 
-const mapEventNames = {
-  'Product Clicked': 'select_content',
-  'Product Viewed': 'view_item',
-  'Product Added': 'add_to_cart',
-  'Product Removed': 'remove_from_cart',
-  'Checkout Started': 'begin_checkout',
-  'Promotion Viewed': 'present_offer',
-  'Payment Info Entered': 'add_payment_info',
-  'Order Completed': 'ecommerce_purchase',
-  'Order Refunded': 'purchase_refund',
-  'Product List Viewed': 'view_item_list',
-  'Product Added to Wishlist': 'add_to_wishlist',
-  'Product Shared': 'share',
-  'Cart Shared': 'share',
-  'Products Searched': 'search',
-} as any;
+const mappedPropNames = generateMapTransform(mapEventProps, transformMap);
+
+const sanitizeName = (name: string) => {
+  return name.replace(/[^a-zA-Z0-9]/g, '_');
+};
 
 export default async (event: TrackEventType) => {
-  const safeEventName =
-    mapEventNames[event.event] || event.event.replace(/[^a-zA-Z0-9]/g, '_');
-  await firebaseAnalytics().logEvent(safeEventName, event.properties);
+  const safeEvent = mappedPropNames(event as Record<string, any>);
+  let convertedName = safeEvent.event as string;
+  const safeEventName = sanitizeName(convertedName);
+  const safeProps = safeEvent.properties as {[key: string]: any};
+  await firebaseAnalytics().logEvent(safeEventName, safeProps);
 };

--- a/packages/plugins/plugin-firebase/src/methods/track.ts
+++ b/packages/plugins/plugin-firebase/src/methods/track.ts
@@ -1,5 +1,8 @@
 import firebaseAnalytics from '@react-native-firebase/analytics';
-import { generateMapTransform, TrackEventType } from '@segment/analytics-react-native';
+import {
+  generateMapTransform,
+  TrackEventType,
+} from '@segment/analytics-react-native';
 import { mapEventProps, transformMap } from './parameterMapping';
 
 const mappedPropNames = generateMapTransform(mapEventProps, transformMap);
@@ -12,6 +15,6 @@ export default async (event: TrackEventType) => {
   const safeEvent = mappedPropNames(event as Record<string, any>);
   let convertedName = safeEvent.event as string;
   const safeEventName = sanitizeName(convertedName);
-  const safeProps = safeEvent.properties as {[key: string]: any};
+  const safeProps = safeEvent.properties as { [key: string]: any };
   await firebaseAnalytics().logEvent(safeEventName, safeProps);
 };


### PR DESCRIPTION
This PR:
Correctly map the following event names (the name previously used are now [deprecated](https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event#public-static-final-string-ecommerce_purchase)):
- `Order Complete` maps to `purchase` instead of `ecommerce_purchase`
- `Promotion Viewed` maps to `view_promotion` instead of `present_offer`
-  `Order Refunded` maps to `refund` instead of `purchase_refund`

We also added a map for the events props inspired by the facebook event plugin, as some events were not fired if the attributes provided didn't have the correct names.