### PR TITLE
fix: timeline safe processing events for destinations

### DIFF
--- a/packages/core/src/__tests__/timeline.test.ts
+++ b/packages/core/src/__tests__/timeline.test.ts
@@ -1,0 +1,128 @@
+import { SegmentClient } from '../analytics';
+import { Plugin } from '../plugin';
+import { Timeline } from '../timeline';
+import { EventType, PluginType, SegmentEvent, TrackEventType } from '../types';
+import { getMockLogger } from './__helpers__/mockLogger';
+import { MockSegmentStore } from './__helpers__/mockSegmentStore';
+
+jest
+  .spyOn(Date.prototype, 'toISOString')
+  .mockReturnValue('2010-01-01T00:00:00.000Z');
+
+describe('timeline', () => {
+  const initialUserInfo = {
+    traits: {
+      name: 'Stacy',
+      age: 30,
+    },
+    userId: 'current-user-id',
+    anonymousId: 'very-anonymous',
+  };
+
+  const store = new MockSegmentStore({
+    userInfo: initialUserInfo,
+    settings: {
+      '1': true,
+      '2': true,
+    },
+  });
+
+  const clientArgs = {
+    config: {
+      writeKey: 'mock-write-key',
+    },
+    logger: getMockLogger(),
+    store: store,
+  };
+
+  const client = new SegmentClient(clientArgs);
+
+  class MockPlugin extends Plugin {
+    constructor(
+      private readonly executeFunc: (
+        event: SegmentEvent
+      ) => SegmentEvent | undefined,
+      type: PluginType
+    ) {
+      super();
+      this.type = type;
+      this.analytics = client;
+    }
+
+    execute(event: SegmentEvent) {
+      return this.executeFunc(event);
+    }
+  }
+
+  it('processes each destination independently', () => {
+    const timeline = new Timeline();
+
+    const goodPlugin = jest.fn().mockImplementation((e) => e);
+    const badPlugin = jest.fn().mockImplementation(() => undefined);
+    timeline.add(new MockPlugin(badPlugin, PluginType.destination));
+    timeline.add(new MockPlugin(goodPlugin, PluginType.destination));
+
+    const expectedEvent: TrackEventType = {
+      type: EventType.TrackEvent,
+      event: 'test',
+      properties: {
+        test: 'sample',
+      },
+    };
+
+    const result = timeline.process(expectedEvent);
+
+    expect(result).toEqual(expectedEvent);
+    expect(goodPlugin).toHaveBeenCalled();
+    expect(badPlugin).toHaveBeenCalled();
+  });
+
+  it('handles errors from plugins execution', () => {
+    const timeline = new Timeline();
+
+    const goodPlugin = jest.fn().mockImplementation((e) => e);
+    const badPlugin = jest.fn().mockImplementation(() => {
+      throw 'ERROR';
+    });
+    timeline.add(new MockPlugin(badPlugin, PluginType.before));
+    timeline.add(new MockPlugin(goodPlugin, PluginType.before));
+
+    const expectedEvent: TrackEventType = {
+      type: EventType.TrackEvent,
+      event: 'test',
+      properties: {
+        test: 'sample',
+      },
+    };
+
+    const result = timeline.process(expectedEvent);
+
+    expect(result).toEqual(expectedEvent);
+    expect(goodPlugin).toHaveBeenCalled();
+    expect(badPlugin).toHaveBeenCalled();
+  });
+
+  it('shortcircuits plugin execution if a plugin return undefined', () => {
+    const timeline = new Timeline();
+
+    const goodPlugin = jest.fn().mockImplementation((e) => e);
+    const badPlugin = jest.fn().mockImplementation(() => undefined);
+    timeline.add(new MockPlugin(badPlugin, PluginType.before));
+    timeline.add(new MockPlugin(goodPlugin, PluginType.before));
+    timeline.add(new MockPlugin(goodPlugin, PluginType.destination));
+
+    const expectedEvent: TrackEventType = {
+      type: EventType.TrackEvent,
+      event: 'test',
+      properties: {
+        test: 'sample',
+      },
+    };
+
+    const result = timeline.process(expectedEvent);
+
+    expect(result).toEqual(undefined);
+    expect(goodPlugin).not.toHaveBeenCalled();
+    expect(badPlugin).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -155,7 +155,7 @@ export class DestinationPlugin extends EventPlugin {
 
   execute(event: SegmentEvent): SegmentEvent | undefined {
     if (!this.isEnabled(event)) {
-      return undefined;
+      return;
     }
 
     // Apply before and enrichment plugins

--- a/packages/core/src/timeline.ts
+++ b/packages/core/src/timeline.ts
@@ -1,5 +1,5 @@
 import { PluginType, SegmentEvent, UpdateType } from './types';
-import type { Plugin } from './plugin';
+import type { DestinationPlugin, Plugin } from './plugin';
 import { getAllPlugins } from './util';
 
 /*
@@ -97,7 +97,19 @@ export class Timeline {
     if (plugins) {
       plugins.forEach((plugin) => {
         if (result) {
-          result = plugin.execute(result);
+          try {
+            const pluginResult = plugin.execute(result);
+            // Each destination is independent from each other, so we don't roll over changes caused internally in each one of their processing
+            if (type !== PluginType.destination) {
+              result = pluginResult;
+            }
+          } catch (error) {
+            console.warn(
+              `Destination ${
+                (plugin as DestinationPlugin).key
+              } failed to execute: ${JSON.stringify(error)}`
+            );
+          }
         }
       });
     }

--- a/packages/plugins/plugin-braze/src/BrazePlugin.tsx
+++ b/packages/plugins/plugin-braze/src/BrazePlugin.tsx
@@ -10,7 +10,7 @@ import flush from './methods/flush';
 
 export class BrazePlugin extends DestinationPlugin {
   type = PluginType.destination;
-  key = 'Braze';
+  key = 'Appboy';
 
   identify(event: IdentifyEventType) {
     const currentUserInfo = this.analytics?.userInfo.get();


### PR DESCRIPTION
-  Timeline won't shortcircuit destinations if one fails or returns undefined (each DestinationPlugin should be independent)
- Fixed Braze plugin key ('Appboy')
