### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: '8'
+          java-version: '11.0.14.1'
           cache: 'gradle'
         
       - name: Gradle cache


### PR DESCRIPTION
bump java version to work with new RN architecture