### PR TITLE
Add information about `Application Installed` in 2.x migration

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -3,6 +3,14 @@
 Analytics-React-Native 2.0 currently supports [these destinations](https://github.com/segmentio/analytics-react-native/tree/master/packages/plugins) with Segment actively adding more to the list. 
 If you’re using  `analytics-react-native 1.5.1`  or older, follow these steps to migrate to the `analytics-react-native 2.0`. You can continue to use your React Native source write key for the migration to view historical events.
 
+---
+
+🚨 **Important Note**: Analytics React Native 2.0 implements a new storage framework, [@segment/sovran-react-native](https://github.com/segmentio/sovran-react-native), **which makes it impossible to determine if your app has been previously installed**. 
+
+**Migrating to Analytics React Native 2.0 results in new `Application Installed` events for your existing users**. To filter these events out you can either create an Enrichment Plugin to drop events or filter them using your Segment workspace.
+
+---
+
 1. Update existing package
 
 ```sh


### PR DESCRIPTION
`Application Installed` will re-fire after an upgrade from 1.x to 2.x, and this seems to be expected.

This information, along with some strategies for filtering out the extra events, is present in [your documentation at segment.com](https://segment.com/docs/connections/sources/catalog/libraries/mobile/react-native/migration/), but it's missing here. Its absence made it extremely difficult and scary to figure out why our `Application Installed` events were firing so frequently.

I added what was in segment.com's migration documentation. Alternatively, this file could mostly go away – you could link to the migration documentation on segment.com from here instead 🤷 