### PR TITLE
Fix plugin yarn add command for plugin: react-native-plugin-advertising-id

### DIFF
--- a/packages/plugins/plugin-advertising-id/README.md
+++ b/packages/plugins/plugin-advertising-id/README.md
@@ -7,7 +7,7 @@
 Add the package
 
 ```sh
-yarn add react-native-analytics-react-native-plugin-advertising-id
+yarn add @segment/analytics-react-native-plugin-advertising-id
 ```
 
 This plugin requires a `compileSdkVersion` of at least 31. 


### PR DESCRIPTION
The command will now work for those copying it.