### PR TITLE
Set minSdkVersion to 19 per documentation for plugin-advertising-id

### DIFF
--- a/packages/plugins/plugin-advertising-id/android/build.gradle
+++ b/packages/plugins/plugin-advertising-id/android/build.gradle
@@ -28,7 +28,7 @@ def getExtOrIntegerDefault(name) {
 android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   defaultConfig {
-    minSdkVersion 31
+    minSdkVersion 19
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"


### PR DESCRIPTION
The current minSdkVersion set at 31 is breaking builds for anyone supporting older devices.
https://developers.google.com/android/guides/setup

To test your app when using Google Play services, you must use one of the following:

A compatible Android device that runs Android 4.4 (API level 19) or higher and has the Google Play Store app installed.
The Android emulator with an AVD that runs the Google APIs platform based on Android 4.4 (API level 19) or higher.