### PR TITLE
Add Android Advertising ID plugin to plugin table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ Refer to the following table for Plugins you can use to meet your tracking needs
 | [IDFA](https://github.com/segmentio/analytics-react-native/tree/master/packages/plugins/plugin-idfa)     | `@segment/analytics-react-native-plugin-idfa` |
 | [Mixpanel](https://github.com/segmentio/analytics-react-native/tree/master/packages/plugins/plugin-mixpanel)    | `@segment/analytics-react-native-plugin-mixpanel` |
 | [Taplytics](https://github.com/taplytics/segment-react-native-plugin-taplytics)     | `@taplytics/segment-react-native-plugin-taplytics` |
-
+| [Android Advertising ID](https://github.com/segmentio/analytics-react-native/tree/master/packages/plugins/plugin-advertising-id) | `@segment/analytics-react-native-plugin-advertising-id` |
   
   
 


### PR DESCRIPTION
There is zero documentation about this plugin, even searching google is missing any reference to this plugin. I only found it through an issue ticket and then searching source code for plugins. This is such a critical piece that prevents partners like Branch from working correctly without this ID. Too many hours spent on trying to find out why segment events don't show in branch.io. All basically due to all documentation missing related to getting this advertising ID.

This is still missing from any page at segment.com so someone will need to go tip off future explorers of clear documentation at Segment.