### PR TITLE
feat: adds option to provide a custom logger object to consume library logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ You must pass at least the `writeKey`. Additional configuration options are list
 | `writeKey` **(REQUIRED)**  | ''        | Your Segment API key.                                                                                                                          |
 | `collectDeviceId`          | false    | Set to true to automatically collect the device Id.from the DRM API on Android devices.                                           |
 | `debug`                    | true\*    | When set to false, it will not generate any logs.                                                                                              |
+| `logger`                   | undefined | Custom logger instance to expose internal Segment client logging.                                                                            |
 | `flushAt`                  | 20        | How many events to accumulate before sending events to the backend.                                                                            |
 | `flushInterval`            | 30        | In seconds, how often to send events to the backend.                                                                                           |
 | `maxBatchSize`             | 1000      | How many events to send to the API at once                                                                                                     |

--- a/packages/core/src/__tests__/client.test.ts
+++ b/packages/core/src/__tests__/client.test.ts
@@ -1,0 +1,25 @@
+import type { SegmentClient } from '../analytics';
+import { createClient } from '../client';
+import { getMockLogger } from './__helpers__/mockLogger';
+
+describe('#createClient', () => {
+  const config = {
+    writeKey: 'SEGMENT_KEY',
+    logger: getMockLogger(),
+  };
+
+  let client: SegmentClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    client.cleanup();
+  });
+
+  it('creates the client with the provided logger', async () => {
+    client = createClient(config);
+    expect(client.logger).toBe(config.logger);
+  });
+});

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -13,7 +13,6 @@ import {
   createScreenEvent,
   createTrackEvent,
 } from './events';
-import type { Logger } from './logger';
 import type { DestinationPlugin, PlatformPlugin, Plugin } from './plugin';
 import { InjectContext } from './plugins/InjectContext';
 import { InjectUserInfo } from './plugins/InjectUserInfo';
@@ -33,6 +32,7 @@ import {
   GroupTraits,
   IntegrationSettings,
   JsonMap,
+  LoggerType,
   PluginType,
   SegmentAPIIntegrations,
   SegmentEvent,
@@ -59,7 +59,7 @@ export class SegmentClient {
   private appStateSubscription: any;
 
   // logger
-  public logger: Logger;
+  public logger: LoggerType;
 
   // internal time to know when to flush, ticks every second
   private flushInterval: ReturnType<typeof setTimeout> | null = null;
@@ -147,7 +147,7 @@ export class SegmentClient {
     store,
   }: {
     config: Config;
-    logger: Logger;
+    logger: LoggerType;
     store: any;
   }) {
     this.logger = logger;

--- a/packages/core/src/client.tsx
+++ b/packages/core/src/client.tsx
@@ -7,7 +7,7 @@ import { SegmentClient } from './analytics';
 import { SovranStorage } from './storage';
 
 export const createClient = (config: Config) => {
-  const logger = createLogger();
+  const logger = config?.logger || createLogger();
   if (typeof config?.debug === 'boolean') {
     if (config.debug) {
       logger.enable();

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,4 +1,6 @@
-export class Logger {
+import type { DeactivableLoggerType } from './types';
+
+export class Logger implements DeactivableLoggerType {
   isDisabled: boolean;
 
   constructor(isDisabled: boolean = process.env.NODE_ENV === 'production') {

--- a/packages/core/src/plugins/SegmentDestination.ts
+++ b/packages/core/src/plugins/SegmentDestination.ts
@@ -38,7 +38,7 @@ export class SegmentDestination extends DestinationPlugin {
           });
           sentEvents = sentEvents.concat(batch);
         } catch (e) {
-          console.warn(e);
+          this.analytics?.logger.warn(e);
           numFailedEvents += batch.length;
         } finally {
           this.queuePlugin.dequeue(sentEvents);
@@ -48,12 +48,12 @@ export class SegmentDestination extends DestinationPlugin {
 
     if (sentEvents.length) {
       if (this.analytics?.getConfig().debug) {
-        console.info(`Sent ${sentEvents.length} events`);
+        this.analytics?.logger.info(`Sent ${sentEvents.length} events`);
       }
     }
 
     if (numFailedEvents) {
-      console.error(`Failed to send ${numFailedEvents} events.`);
+      this.analytics?.logger.error(`Failed to send ${numFailedEvents} events.`);
     }
 
     return Promise.resolve();

--- a/packages/core/src/timeline.ts
+++ b/packages/core/src/timeline.ts
@@ -116,7 +116,7 @@ export class Timeline {
               result = await pluginResult;
             }
           } catch (error) {
-            console.warn(
+            plugin.analytics?.logger.warn(
               `Destination ${
                 (plugin as DestinationPlugin).key
               } failed to execute: ${JSON.stringify(error)}`

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -114,9 +114,21 @@ export type GroupTraits = JsonMap & {
   plan?: string;
 };
 
+export interface LoggerType {
+  info(message?: any, ...optionalParams: any[]): void;
+  warn(message?: any, ...optionalParams: any[]): void;
+  error(message?: any, ...optionalParams: any[]): void;
+}
+
+export interface DeactivableLoggerType extends LoggerType {
+  enable(): void;
+  disable(): void;
+}
+
 export type Config = {
   writeKey: string;
   debug?: boolean;
+  logger?: DeactivableLoggerType;
   flushAt?: number;
   flushInterval?: number;
   trackAppLifecycleEvents?: boolean;

--- a/packages/plugins/plugin-idfa/src/IdfaPlugin.tsx
+++ b/packages/plugins/plugin-idfa/src/IdfaPlugin.tsx
@@ -32,7 +32,7 @@ export class IdfaPlugin extends Plugin {
         this.analytics?.context.set({ device: { ...idfa } });
       })
       .catch((err: any) => {
-        console.warn(err);
+        this.analytics?.logger.warn(err);
       });
   }
 }


### PR DESCRIPTION
In response to issue #605 , this PR allows users to configure a custom logger via `createClient(config: Config)` as in:
```
const client = createClient({
   writeKey: 'SEGMENT_KEY',
   logger: customLogger
});
```
The custom logger just has to implement a simple interface `DeactivableLoggerType`.
This allows full flexibility to escalate logs, process them etc. And would effectively solve #605.