### PR TITLE
fix: avoids calling Firebase::setUserId with undefined value

### DIFF
--- a/packages/plugins/plugin-firebase/src/methods/___tests__/identify.test.ts
+++ b/packages/plugins/plugin-firebase/src/methods/___tests__/identify.test.ts
@@ -49,4 +49,22 @@ describe('#identify', () => {
     expect(mockSetUserId).toHaveBeenCalledWith('123');
     expect(mockSetUserProperties).toHaveBeenCalledWith({ name: 'Mary' });
   });
+
+  it('forwards the identify event without ID', async () => {
+    const event = {
+      type: 'identify',
+      anonymousId: 'anon',
+      messageId: 'message-id',
+      timestamp: '00000',
+      traits: {
+        name: 'Mary',
+      },
+    } as IdentifyEventType;
+
+    await identify(event);
+
+    expect(mockSetUserId).not.toHaveBeenCalled();
+    expect(mockSetUserProperties).toHaveBeenCalledTimes(1);
+    expect(mockSetUserProperties).toHaveBeenCalledWith({ name: 'Mary' });
+  });
 });

--- a/packages/plugins/plugin-firebase/src/methods/identify.ts
+++ b/packages/plugins/plugin-firebase/src/methods/identify.ts
@@ -2,7 +2,9 @@ import type { IdentifyEventType } from '@segment/analytics-react-native';
 import firebaseAnalytics from '@react-native-firebase/analytics';
 
 export default async (event: IdentifyEventType) => {
-  await firebaseAnalytics().setUserId(event.userId!);
+  if (event.userId !== undefined) {
+    await firebaseAnalytics().setUserId(event.userId!);
+  }
   if (event.traits) {
     await firebaseAnalytics().setUserProperties(event.traits as any);
   }


### PR DESCRIPTION
This fixes a bug where calling `identify` on the client without specifying a `userId` could result in the Firebase Plugin throwing out type errors.