### PR TITLE
fix: add null/undefined check to attribution data

### DIFF
--- a/packages/plugins/plugin-braze/src/methods/__tests__/track.test.ts
+++ b/packages/plugins/plugin-braze/src/methods/__tests__/track.test.ts
@@ -82,6 +82,70 @@ describe('#track', () => {
     });
   });
 
+  it('tracks an Application Installed event when a value is null', () => {
+    const payload = {
+      type: 'track',
+      event: 'Install Attributed',
+      properties: {
+        campaign: {
+          source: 'source',
+          name: 'name',
+          ad_group: null,
+          ad_creative: 'ad_creative',
+        },
+      },
+    };
+
+    track(payload as TrackEventType);
+
+    expect(setAttributionData).toHaveBeenCalledWith(
+      'source',
+      'name',
+      '',
+      'ad_creative'
+    );
+    expect(logCustomEvent).toHaveBeenCalledWith('Install Attributed', {
+      campaign: {
+        source: 'source',
+        name: 'name',
+        ad_group: null,
+        ad_creative: 'ad_creative',
+      },
+    });
+  });
+
+  it('tracks an Application Installed event when a value is undefined/missing', () => {
+    const payload = {
+      type: 'track',
+      event: 'Install Attributed',
+      properties: {
+        campaign: {
+          source: 'source',
+          name: 'name',
+          //missing value
+          // ad_group: null,
+          ad_creative: 'ad_creative',
+        },
+      },
+    };
+
+    track(payload as TrackEventType);
+
+    expect(setAttributionData).toHaveBeenCalledWith(
+      'source',
+      'name',
+      '',
+      'ad_creative'
+    );
+    expect(logCustomEvent).toHaveBeenCalledWith('Install Attributed', {
+      campaign: {
+        source: 'source',
+        name: 'name',
+        ad_creative: 'ad_creative',
+      },
+    });
+  });
+
   it('logs an order completed event', () => {
     const payload = {
       type: 'track',

--- a/packages/plugins/plugin-braze/src/methods/track.ts
+++ b/packages/plugins/plugin-braze/src/methods/track.ts
@@ -5,6 +5,11 @@ export default (payload: TrackEventType) => {
   if (payload.event === 'Install Attributed') {
     if (payload.properties?.campaign) {
       const attributionData: any = payload.properties.campaign;
+      for (const [attribution, data] of Object.entries(attributionData)) {
+        if (data === undefined || data === null) {
+          attributionData[attribution] = '';
+        }
+      }
       const network = attributionData.source;
       const campaign = attributionData.name;
       const adGroup = attributionData.ad_group;

--- a/packages/plugins/plugin-braze/src/methods/track.ts
+++ b/packages/plugins/plugin-braze/src/methods/track.ts
@@ -1,19 +1,22 @@
 import ReactAppboy from 'react-native-appboy-sdk';
 import type { TrackEventType, JsonMap } from '@segment/analytics-react-native';
 
+const attributionProperties = {
+  network: '',
+  campaign: '',
+  adGroup: '',
+  creative: '',
+};
+
 export default (payload: TrackEventType) => {
   if (payload.event === 'Install Attributed') {
     if (payload.properties?.campaign) {
       const attributionData: any = payload.properties.campaign;
-      for (const [attribution, data] of Object.entries(attributionData)) {
-        if (data === undefined || data === null) {
-          attributionData[attribution] = '';
-        }
-      }
-      const network = attributionData.source;
-      const campaign = attributionData.name;
-      const adGroup = attributionData.ad_group;
-      const creative = attributionData.ad_creative;
+      const network = attributionData.source ?? attributionProperties.network;
+      const campaign = attributionData.name ?? attributionProperties.campaign;
+      const adGroup = attributionData.ad_group ?? attributionProperties.adGroup;
+      const creative =
+        attributionData.ad_creative ?? attributionProperties.creative;
       ReactAppboy.setAttributionData(network, campaign, adGroup, creative);
     }
   }


### PR DESCRIPTION
- adds safety check for attribution values in `Install Attributed` events in Braze Plugin