### PR TITLE
Fix `_metadata` population

### DIFF
--- a/packages/core/src/plugins/DestinationMetadataEnrichment.ts
+++ b/packages/core/src/plugins/DestinationMetadataEnrichment.ts
@@ -42,7 +42,7 @@ export class DestinationMetadataEnrichment extends UtilityPlugin {
 
     // All active integrations, not in `bundled` are put in `unbundled`
     // All unbundledIntegrations not in `bundled` are put in `unbundled`
-    for (const integration in segmentInfo) {
+    for (const integration in pluginSettings) {
       if (integration !== this.destinationKey && !bundled.has(integration)) {
         unbundled.add(integration);
       }

--- a/packages/core/src/plugins/__tests__/SegmentDestination.test.ts
+++ b/packages/core/src/plugins/__tests__/SegmentDestination.test.ts
@@ -142,7 +142,7 @@ describe('SegmentDestination', () => {
       store: new MockSegmentStore({
         settings: {
           [SEGMENT_DESTINATION_KEY]: {
-            unbundledIntegrations: ['Amplitude', 'firebase'],
+            unbundledIntegrations: ['Amplitude'],
           },
           Mixpanel: {}, // Mixpanel is active but not bundled
         },
@@ -166,7 +166,7 @@ describe('SegmentDestination', () => {
       ...event,
       _metadata: {
         bundled: [],
-        unbundled: ['Amplitude', 'Mixpanel'],
+        unbundled: ['Mixpanel', 'Amplitude'],
         bundledIds: [],
       },
     });

--- a/packages/core/src/plugins/__tests__/SegmentDestination.test.ts
+++ b/packages/core/src/plugins/__tests__/SegmentDestination.test.ts
@@ -135,16 +135,16 @@ describe('SegmentDestination', () => {
     });
   });
 
-  it('marks maybeBundled integrations to unbundled if they are not bundled', async () => {
+  it('marks active integrations as unbundled if plugin is not bundled', async () => {
     const plugin = new SegmentDestination();
     const analytics = new SegmentClient({
       ...clientArgs,
       store: new MockSegmentStore({
         settings: {
           [SEGMENT_DESTINATION_KEY]: {
-            unbundledIntegrations: ['Amplitude'],
-            maybeBundledConfigIds: { Mixpanel: ['123'] },
+            unbundledIntegrations: ['Amplitude', 'firebase'],
           },
+          Mixpanel: {}, // Mixpanel is active but not bundled
         },
       }),
     });


### PR DESCRIPTION
Our previous implementation was lacking a little, causing issues with sending data to destinations on cloud-mode.

These changes should now incorporate the list of active destinations and mark them as `unbundled` if no device-mode equivalent is present.