### PR TITLE
chore: bump firebase to new version

### DIFF
--- a/packages/plugins/plugin-firebase/package.json
+++ b/packages/plugins/plugin-firebase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics-react-native-plugin-firebase",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "The hassle-free way to add Segment analytics to your React-Native app.",
   "main": "lib/commonjs/index",
   "scripts": {


### PR DESCRIPTION
- bumps firebase to `0.3.5` to fix missing `lib` directory in npm package. 