### PR TITLE
fix: prevent locking before setting new user data

### DIFF
--- a/packages/core/src/__tests__/methods/identify.test.ts
+++ b/packages/core/src/__tests__/methods/identify.test.ts
@@ -58,8 +58,6 @@ describe('methods #identify', () => {
   });
 
   it('does not update userId when userId is undefined', async () => {
-    jest.spyOn(client, 'process');
-
     await client.identify(undefined, { name: 'Mary' });
 
     const expectedEvent = {
@@ -107,6 +105,26 @@ describe('methods #identify', () => {
       properties: {},
       timestamp: '2010-01-01T00:00:00.000Z',
       type: EventType.TrackEvent,
+      userId: 'new-user-id',
+    });
+  });
+
+  it('is concurrency safe', async () => {
+    // We trigger an identify and do not await it, we do a track immediately and await.
+    // The track call should have the correct values injected into it.
+    client.identify('new-user-id');
+    await client.track('something');
+
+    const expectedTrackEvent: Partial<SegmentEvent> = {
+      event: 'something',
+      userId: 'new-user-id',
+      type: EventType.TrackEvent,
+    };
+
+    expectEvent(expectedTrackEvent);
+
+    expect(client.userInfo.get()).toEqual({
+      ...initialUserInfo,
       userId: 'new-user-id',
     });
   });

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -507,8 +507,9 @@ export class SegmentClient {
   }
 
   async alias(newUserId: string) {
-    const { anonymousId, userId: previousUserId } =
-      await this.store.userInfo.get(true);
+    // We don't use a concurrency safe version of get here as we don't want to lock the values yet,
+    // we will update the values correctly when InjectUserInfo processes the change
+    const { anonymousId, userId: previousUserId } = this.store.userInfo.get();
 
     const event = createAliasEvent({
       anonymousId,

--- a/packages/core/src/plugins/__tests__/InjectUserInfo.test.ts
+++ b/packages/core/src/plugins/__tests__/InjectUserInfo.test.ts
@@ -1,0 +1,109 @@
+import { createIdentifyEvent, createTrackEvent } from '../../events';
+import { type SegmentEvent, EventType, UserTraits } from '../../types';
+import { createTestClient } from '../../__tests__/__helpers__/setupSegmentClient';
+import { InjectUserInfo } from '../InjectUserInfo';
+
+describe('InjectContext', () => {
+  const currentUserId = 'current-user-id';
+  const anonymousId = 'very-anonymous';
+
+  const initialUserInfo = {
+    traits: {
+      name: 'Stacy',
+      age: 30,
+    },
+    userId: currentUserId,
+    anonymousId: anonymousId,
+  };
+  const { store, client } = createTestClient({
+    userInfo: initialUserInfo,
+  });
+
+  beforeEach(() => {
+    store.reset();
+    jest.clearAllMocks();
+  });
+
+  it('adds userId and anonymousId to events', async () => {
+    const expectedEvent: Partial<SegmentEvent> = {
+      event: 'something',
+      userId: currentUserId,
+      anonymousId: anonymousId,
+      type: EventType.TrackEvent,
+    };
+
+    const plugin = new InjectUserInfo();
+    plugin.configure(client);
+    const event = await plugin.execute(
+      createTrackEvent({
+        event: 'something',
+      })
+    );
+
+    expect(event).toMatchObject(expectedEvent);
+  });
+
+  it('updates userId and traits on identify', async () => {
+    const newUserId = 'new-user-id';
+    const newTraits: UserTraits = {
+      age: 30,
+    };
+
+    const expectedEvent: Partial<SegmentEvent> = {
+      userId: newUserId,
+      anonymousId: anonymousId,
+      traits: newTraits,
+      type: EventType.IdentifyEvent,
+    };
+
+    const plugin = new InjectUserInfo();
+    plugin.configure(client);
+    const event = await plugin.execute(
+      createIdentifyEvent({
+        userId: newUserId,
+        userTraits: newTraits,
+      })
+    );
+
+    expect(event).toMatchObject(expectedEvent);
+    expect(client.userInfo.get()).toEqual({
+      ...initialUserInfo,
+      userId: 'new-user-id',
+    });
+  });
+
+  it('is concurrency safe', async () => {
+    const newUserId = 'new-user-id';
+    const newTraits: UserTraits = {
+      age: 30,
+    };
+
+    const expectedEvent: Partial<SegmentEvent> = {
+      userId: newUserId,
+      anonymousId: anonymousId,
+      type: EventType.TrackEvent,
+    };
+
+    const plugin = new InjectUserInfo();
+    plugin.configure(client);
+
+    plugin.execute(
+      createIdentifyEvent({
+        userId: newUserId,
+        userTraits: newTraits,
+      })
+    );
+
+    const event = await plugin.execute(
+      createTrackEvent({
+        event: 'something',
+      })
+    );
+
+    expect(event).toMatchObject(expectedEvent);
+    expect(client.userInfo.get()).toEqual({
+      ...initialUserInfo,
+      userId: 'new-user-id',
+    });
+  });
+});


### PR DESCRIPTION
This fixes an issue where `identify` followed by a `track` call without awaiting would still end up with `userId` not being set correctly.

The order is important inside `InjectUserInfo`, previously it was locking when accessing the current user data before getting to set, which caused `track` to finish before `identify`. 
It isn't required to do a `get` before `set` as the setter will get access to its most current state when run.

Added tests to prevent regressions.