### PR TITLE
fix: switching UUID library, new depedencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The hassle-free way to add Segment analytics to your React-Native app.
 
 ## Installation
 
-Install `@segment/analytics-react-native`,  [`@segment/sovran-react-native`](https://github.com/segmentio/sovran-react-native) and [`react-native-async-storage/async-storage`](https://github.com/react-native-async-storage/async-storage): 
+Install `@segment/analytics-react-native`,  [`@segment/sovran-react-native`](https://github.com/segmentio/sovran-react-native), [`react-native-get-random-values`](https://github.com/LinusU/react-native-get-random-values) and [`react-native-async-storage/async-storage`](https://github.com/react-native-async-storage/async-storage): 
 
 ```sh
 yarn add @segment/analytics-react-native @segment/sovran-react-native @react-native-async-storage/async-storage 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -220,6 +220,8 @@ PODS:
   - React-jsinspector (0.69.7)
   - React-logger (0.69.7):
     - glog
+  - react-native-get-random-values (1.8.0):
+    - React-Core
   - react-native-safe-area-context (3.4.1):
     - React-Core
   - react-native-tracking-transparency (0.1.1):
@@ -298,12 +300,12 @@ PODS:
     - React
   - RNGestureHandler (2.6.0):
     - React-Core
-  - segment-analytics-react-native (2.13.0):
+  - segment-analytics-react-native (2.13.1):
     - React-Core
     - sovran-react-native
   - segment-analytics-react-native-plugin-idfa (0.6.0):
     - React-Core
-  - sovran-react-native (0.4.5):
+  - sovran-react-native (1.0.0):
     - React-Core
   - Yoga (1.14.0)
 
@@ -328,6 +330,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
+  - react-native-get-random-values (from `../node_modules/react-native-get-random-values`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - react-native-tracking-transparency (from `../node_modules/react-native-tracking-transparency`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
@@ -394,6 +397,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
+  react-native-get-random-values:
+    :path: "../node_modules/react-native-get-random-values"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
   react-native-tracking-transparency:
@@ -460,6 +465,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: a73bec0218ba959fc92f811b581ad6c2270c6b6f
   React-jsinspector: 8134ee22182b8dd98dc0973db6266c398103ce6c
   React-logger: 1e7ac909607ee65fd5c4d8bea8c6e644f66b8843
+  react-native-get-random-values: a6ea6a8a65dc93e96e24a11105b1a9c8cfe1d72a
   react-native-safe-area-context: 9e40fb181dac02619414ba1294d6c2a807056ab9
   react-native-tracking-transparency: b2029ff756f1128b1f2c7c7c7f3003bc3c950f9f
   React-perflogger: 8e832d4e21fdfa613033c76d58d7e617341e804b
@@ -478,9 +484,9 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 0c357f3156fcb16c8589ede67cc036330b6698ca
   RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
   RNGestureHandler: 920eb17f5b1e15dae6e5ed1904045f8f90e0b11e
-  segment-analytics-react-native: bd1f13ea95bad2313a9c7130da032af0e9a6da60
+  segment-analytics-react-native: f962dff3a084655a29f9403b8c139c75a3362524
   segment-analytics-react-native-plugin-idfa: 6b0231a40b5aebc869eba83d51ea509023345ef7
-  sovran-react-native: 046c21798af2c4c34acdf963329cd331df069649
+  sovran-react-native: 1ac9ae5d8c95f945e0c7aa0a2f443133ede68f02
   Yoga: 0b84a956f7393ef1f37f3bb213c516184e4a689d
 
 PODFILE CHECKSUM: 148f23dc44ebce74497f5fef0651f1fea1f8a361

--- a/example/package.json
+++ b/example/package.json
@@ -28,6 +28,7 @@
     "react-native": "0.69.7",
     "react-native-bootsplash": "^3.2.4",
     "react-native-gesture-handler": "^2.2.0",
+    "react-native-get-random-values": "^1.8.0",
     "react-native-safe-area-context": "^3.3.0",
     "react-native-tracking-transparency": "^0.1.1"
   },

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3738,6 +3738,11 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+fast-base64-decode@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz#b434a0dd7d92b12b43f26819300d2dafb83ee418"
+  integrity sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -6723,6 +6728,13 @@ react-native-gesture-handler@^2.2.0:
     invariant "^2.2.4"
     lodash "^4.17.21"
     prop-types "^15.7.2"
+
+react-native-get-random-values@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/react-native-get-random-values/-/react-native-get-random-values-1.8.0.tgz#1cb4bd4bd3966a356e59697b8f372999fe97cb16"
+  integrity sha512-H/zghhun0T+UIJLmig3+ZuBCvF66rdbiWUfRSNS6kv5oDSpa1ZiVyvRWtuPesQpT8dXj+Bv7WJRQOUP+5TB1sA==
+  dependencies:
+    fast-base64-decode "^1.0.0"
 
 react-native-gradle-plugin@^0.0.7:
   version "0.0.7"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,8 @@
     "@segment/sovran-react-native": "^0.4.5",
     "deepmerge": "^4.2.2",
     "js-base64": "^3.7.2",
-    "react-native-uuid": "^2.0.1"
+    "react-native-get-random-values": "^1.8.0",
+    "uuid": "^9.0.0"
   },
   "peerDependencies": {
     "react": "*",

--- a/packages/core/src/__mocks__/uuid.ts
+++ b/packages/core/src/__mocks__/uuid.ts
@@ -1,1 +1,3 @@
 export const getUUID = () => 'mocked-uuid';
+
+export const v4 = () => 'mocked-uuid';

--- a/packages/core/src/__tests__/client.test.ts
+++ b/packages/core/src/__tests__/client.test.ts
@@ -2,6 +2,8 @@ import type { SegmentClient } from '../analytics';
 import { createClient } from '../client';
 import { getMockLogger } from './__helpers__/mockLogger';
 
+jest.mock('uuid');
+
 describe('#createClient', () => {
   const config = {
     writeKey: 'SEGMENT_KEY',

--- a/packages/core/src/__tests__/internal/checkInstalledVersion.test.ts
+++ b/packages/core/src/__tests__/internal/checkInstalledVersion.test.ts
@@ -5,6 +5,8 @@ import { MockSegmentStore } from '../__helpers__/mockSegmentStore';
 import { Context, EventType } from '../../types';
 import deepmerge from 'deepmerge';
 
+jest.mock('uuid');
+
 jest
   .spyOn(Date.prototype, 'toISOString')
   .mockReturnValue('2010-01-01T00:00:00.000Z');

--- a/packages/core/src/__tests__/internal/handleAppStateChange.test.ts
+++ b/packages/core/src/__tests__/internal/handleAppStateChange.test.ts
@@ -5,7 +5,7 @@ import { EventType, SegmentEvent } from '../../types';
 import type { MockSegmentStore } from '../__helpers__/mockSegmentStore';
 import { createTestClient } from '../__helpers__/setupSegmentClient';
 
-jest.mock('../../uuid');
+jest.mock('uuid');
 jest.mock('../../context');
 jest.mock('react-native');
 

--- a/packages/core/src/__tests__/internal/trackDeepLinks.test.ts
+++ b/packages/core/src/__tests__/internal/trackDeepLinks.test.ts
@@ -7,6 +7,8 @@ import {
   MockSegmentStore,
 } from '../__helpers__/mockSegmentStore';
 
+jest.mock('uuid');
+
 jest
   .spyOn(Date.prototype, 'toISOString')
   .mockReturnValue('2000-01-01T00:00:00.000Z');

--- a/packages/core/src/__tests__/methods/alias.test.ts
+++ b/packages/core/src/__tests__/methods/alias.test.ts
@@ -1,7 +1,7 @@
 import { EventType, SegmentEvent } from '../../types';
 import { createTestClient } from '../__helpers__/setupSegmentClient';
 
-jest.mock('../../uuid');
+jest.mock('uuid');
 
 jest
   .spyOn(Date.prototype, 'toISOString')

--- a/packages/core/src/__tests__/methods/flush.test.ts
+++ b/packages/core/src/__tests__/methods/flush.test.ts
@@ -6,7 +6,7 @@ import type { DestinationPlugin } from '../../plugin';
 import { MockSegmentStore } from '../__helpers__/mockSegmentStore';
 
 jest.mock('react-native');
-jest.mock('../../uuid');
+jest.mock('uuid');
 
 describe('methods #flush', () => {
   const store = new MockSegmentStore();

--- a/packages/core/src/__tests__/methods/group.test.ts
+++ b/packages/core/src/__tests__/methods/group.test.ts
@@ -2,7 +2,7 @@ import { SegmentClient } from '../../analytics';
 import { getMockLogger } from '../__helpers__/mockLogger';
 import { MockSegmentStore } from '../__helpers__/mockSegmentStore';
 
-jest.mock('../../uuid');
+jest.mock('uuid');
 
 jest
   .spyOn(Date.prototype, 'toISOString')

--- a/packages/core/src/__tests__/methods/screen.test.ts
+++ b/packages/core/src/__tests__/methods/screen.test.ts
@@ -2,7 +2,7 @@ import { SegmentClient } from '../../analytics';
 import { getMockLogger } from '../__helpers__/mockLogger';
 import { MockSegmentStore } from '../__helpers__/mockSegmentStore';
 
-jest.mock('../../uuid');
+jest.mock('uuid');
 
 jest
   .spyOn(Date.prototype, 'toISOString')

--- a/packages/core/src/__tests__/methods/track.test.ts
+++ b/packages/core/src/__tests__/methods/track.test.ts
@@ -4,7 +4,7 @@ import { EventType } from '../../types';
 import { getMockLogger } from '../__helpers__/mockLogger';
 import { MockSegmentStore } from '../__helpers__/mockSegmentStore';
 
-jest.mock('../../uuid');
+jest.mock('uuid');
 
 jest
   .spyOn(Date.prototype, 'toISOString')

--- a/packages/core/src/__tests__/timeline.test.ts
+++ b/packages/core/src/__tests__/timeline.test.ts
@@ -5,6 +5,8 @@ import { EventType, PluginType, SegmentEvent, TrackEventType } from '../types';
 import { getMockLogger } from './__helpers__/mockLogger';
 import { MockSegmentStore } from './__helpers__/mockSegmentStore';
 
+jest.mock('uuid');
+
 jest
   .spyOn(Date.prototype, 'toISOString')
   .mockReturnValue('2010-01-01T00:00:00.000Z');

--- a/packages/core/src/info.ts
+++ b/packages/core/src/info.ts
@@ -1,4 +1,4 @@
 export const libraryInfo = {
   name: '@segment/analytics-react-native',
-  version: '2.13.0',
+  version: '2.13.1',
 };

--- a/packages/core/src/plugins/__tests__/SegmentDestination.test.ts
+++ b/packages/core/src/plugins/__tests__/SegmentDestination.test.ts
@@ -19,6 +19,8 @@ import {
   SEGMENT_DESTINATION_KEY,
 } from '../SegmentDestination';
 
+jest.mock('uuid');
+
 describe('SegmentDestination', () => {
   const store = new MockSegmentStore();
   const clientArgs = {

--- a/packages/core/src/storage/__tests__/sovranStorage.test.ts
+++ b/packages/core/src/storage/__tests__/sovranStorage.test.ts
@@ -3,6 +3,8 @@ import deepmerge from 'deepmerge';
 import { createCallbackManager as mockCreateCallbackManager } from '../../__tests__/__helpers__/utils';
 import { SovranStorage } from '../sovranStorage';
 
+jest.mock('uuid');
+
 jest.mock('@segment/sovran-react-native', () => ({
   registerBridgeStore: jest.fn(),
   createStore: <T extends {}>(initialState: T) => {

--- a/packages/core/src/uuid.ts
+++ b/packages/core/src/uuid.ts
@@ -1,6 +1,7 @@
-import uuid from 'react-native-uuid';
+import 'react-native-get-random-values';
+import { v4 as uuidv4 } from 'uuid';
 
 export const getUUID = (): string => {
-  let UUID = uuid.v4().toString();
+  let UUID = uuidv4().toString();
   return UUID;
 };

--- a/packages/plugins/plugin-firebase/src/methods/___tests__/track.test.ts
+++ b/packages/plugins/plugin-firebase/src/methods/___tests__/track.test.ts
@@ -1,6 +1,8 @@
 import { EventType, TrackEventType } from '@segment/analytics-react-native';
 import track from '../track';
 
+jest.mock('uuid');
+
 const mockLogEvent = jest.fn();
 
 jest.mock('@react-native-firebase/analytics', () => () => ({

--- a/packages/plugins/plugin-mixpanel/src/methods/__tests__/alias.test.ts
+++ b/packages/plugins/plugin-mixpanel/src/methods/__tests__/alias.test.ts
@@ -6,6 +6,7 @@ import { SegmentClient } from '../../../../../core/src/analytics';
 import { MockSegmentStore } from '../../../../../core/src/__tests__/__helpers__/mockSegmentStore';
 import { getMockLogger } from '../../../../../core/src/__tests__/__helpers__/mockLogger';
 
+jest.mock('uuid');
 jest.mock('mixpanel-react-native');
 
 describe('#alias', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2458,6 +2458,16 @@
   resolved "https://registry.yarnpkg.com/@react-native/polyfills/-/polyfills-2.0.0.tgz#4c40b74655c83982c8cf47530ee7dc13d957b6aa"
   integrity sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==
 
+"@segment/sovran-react-native@^0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@segment/sovran-react-native/-/sovran-react-native-0.4.5.tgz#2ae057790623cfbd84eb15e4a3bb9835d108f815"
+  integrity sha512-/dvud4hkszRNgTHdb7p822U+NXTuPxifqQzhcrfdjmFoXMafnzOUAi1KxeGV6Qdb73VAIxcnr/8hkTqdjZ3YLw==
+  dependencies:
+    "@react-native-async-storage/async-storage" "^1.15.15"
+    ansi-regex "5.0.1"
+    deepmerge "^4.2.2"
+    shell-quote "1.7.3"
+
 "@segment/tsub@^0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@segment/tsub/-/tsub-0.2.0.tgz#456345ad04bca81f6c3fefacac722fd9eb4923ce"
@@ -6119,6 +6129,11 @@ extract-zip@^1.6.6:
     debug "^2.6.9"
     mkdirp "^0.5.4"
     yauzl "^2.10.0"
+
+fast-base64-decode@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz#b434a0dd7d92b12b43f26819300d2dafb83ee418"
+  integrity sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -10609,10 +10624,12 @@ react-native-fbsdk-next@^10.1.0:
     "@expo/config-plugins" "^4.1.5"
     xml2js "^0.4.23"
 
-react-native-uuid@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/react-native-uuid/-/react-native-uuid-2.0.1.tgz#ed4e2dfb1683eddb66967eb5dca140dfe1abddb9"
-  integrity sha512-cptnoIbL53GTCrWlb/+jrDC6tvb7ypIyzbXNJcpR3Vab0mkeaaVd5qnB3f0whXYzS+SMoSQLcUUB0gEWqkPC0g==
+react-native-get-random-values@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/react-native-get-random-values/-/react-native-get-random-values-1.8.0.tgz#1cb4bd4bd3966a356e59697b8f372999fe97cb16"
+  integrity sha512-H/zghhun0T+UIJLmig3+ZuBCvF66rdbiWUfRSNS6kv5oDSpa1ZiVyvRWtuPesQpT8dXj+Bv7WJRQOUP+5TB1sA==
+  dependencies:
+    fast-base64-decode "^1.0.0"
 
 react-native@^0.67.2:
   version "0.67.4"
@@ -12432,6 +12449,11 @@ uuid@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
+
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
- Previous UUID library had instances of repeated IDs

**Important**
Requires installing new native dependency [react-native-get-random-values](https://github.com/LinusU/react-native-get-random-values) on application
