### PR TITLE
fix(async-storage-persistor): Correctly import AsyncStorage 

### DIFF
--- a/packages/sovran/src/persistor/async-storage-persistor.ts
+++ b/packages/sovran/src/persistor/async-storage-persistor.ts
@@ -7,7 +7,7 @@ let AsyncStorage: {
 
 try {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  AsyncStorage = require('@react-native-async-storage/async-storage');
+  AsyncStorage = require('@react-native-async-storage/async-storage').default;
 } catch (error) {
   AsyncStorage = null;
 }


### PR DESCRIPTION
We recently discovered that our Application Install events are rising exponentially. Turns out the store context was not correctly persisted, due to the wrong import on the CommonJS module of AsyncStorage.


Also, I think it'd be great to also mention in docs that users need to use store persistor so that some context events are not repeated on every App start. It's easy to miss in docs and Segment does not provide a default implementation out of the box already set up.