### PR TITLE
fix: resolve potential build issues with RN 0.72

### DIFF
--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -50,10 +50,6 @@ android {
     sourceCompatibility JavaVersion.VERSION_11
     targetCompatibility JavaVersion.VERSION_11
   }
-  
-  kotlinOptions {
-    jvmTarget=11
-  }
 }
 
 repositories {

--- a/packages/plugins/plugin-advertising-id/android/build.gradle
+++ b/packages/plugins/plugin-advertising-id/android/build.gradle
@@ -48,10 +48,6 @@ android {
     sourceCompatibility JavaVersion.VERSION_11
     targetCompatibility JavaVersion.VERSION_11
   }
-
-  kotlinOptions {
-    jvmTarget=11
-  }
 }
 
 repositories {


### PR DESCRIPTION
Starting with RN 0.72 the JVM target will be enforced across all packages. Unfortunately in my case instead of enforcing JVM 11, I am going to have to enforce JVM 17 because that's the java version I have locally installed. 

The RN team introduced a fix which updates the `sourceCompatibility` and `targetCompatibility` in all projects to make that compatible. `kotlinOptions.jvmTarget` is by default set by the JVM version that is installed on the machine - in my case 17. At the moment, the RN fix is not updating the `kotlinOptions.jvmTarget` - I hope that will still make it as part of the 0.72.0 stable relaese. Generally the JVM target of java and kotlin needs to match. If the RN team does not decide to update their fix, then I would need to patch this library manually to fix build errors on RN 0.72.

I believe dropping the suggested lines will have no impact on this project but will ensure other people with my same use-case are not running into any issues.