### PR TITLE
fix: event name should contain 40 alphanumeric characters or underscores

### DIFF
--- a/packages/plugins/plugin-firebase/src/methods/track.ts
+++ b/packages/plugins/plugin-firebase/src/methods/track.ts
@@ -16,7 +16,11 @@ export default async (event: TrackEventType) => {
     event as unknown as Record<string, unknown>
   );
   const convertedName = safeEvent.event as string;
-  const safeEventName = sanitizeName(convertedName);
+  let safeEventName = sanitizeName(convertedName);
   const safeProps = safeEvent.properties as { [key: string]: unknown };
+  // Clip the event name if it exceeds 40 characters
+  if (safeEventName.length > 40) {
+    safeEventName = safeEventName.substring(0, 40);
+  }
   await firebaseAnalytics().logEvent(safeEventName, safeProps);
 };


### PR DESCRIPTION
- In previous plugin of firebase segment used to remove the characters if it exceeds 40 characters.
This PR fixed this issue to maintain the backward compatibility. 

This fixes
https://ekeekaran-ventures.sentry.io/share/issue/8b521c3429fd49f39c5459b84046030a/