### PR TITLE
Remove isString typo

### DIFF
--- a/packages/plugins/plugin-appsflyer/src/methods/track.ts
+++ b/packages/plugins/plugin-appsflyer/src/methods/track.ts
@@ -1,5 +1,5 @@
 import appsFlyer from 'react-native-appsflyer';
-import { isString, TrackEventType } from '@segment/analytics-react-native';
+import { TrackEventType } from '@segment/analytics-react-native';
 
 type Properties = { [key: string]: unknown };
 
@@ -54,7 +54,7 @@ const extractCurrency = (
   defaultCurrency: string
 ): string => {
   const value = properties[key];
-  if (isString(value)) {
+  if (typeof value === 'string')) {
     return value;
   }
   return defaultCurrency;


### PR DESCRIPTION
We received millions of event errors from sentry (our quota was exceeded because of it 🙃 ), What I've found that @segment/analytics-react-native doesn't have any method called **isString**
![image](https://github.com/segmentio/analytics-react-native/assets/83827983/cdae7e4a-5dfc-4e88-9d25-25b29de06f28)
![image](https://github.com/segmentio/analytics-react-native/assets/83827983/3782fa02-cc82-4d7c-90f1-f66a77bae66f)
