### PR TITLE
Fix can not read property of undefined when identity trait value is undefined. 

### DIFF
--- a/packages/plugins/plugin-firebase/src/FirebasePlugin.tsx
+++ b/packages/plugins/plugin-firebase/src/FirebasePlugin.tsx
@@ -35,7 +35,7 @@ export class FirebasePlugin extends DestinationPlugin {
             return acc;
           }
           if (trait !== undefined) {
-            acc[trait] = eventTraits[trait]!.toString();
+            acc[trait] = typeof eventTraits[trait] === undefined ? "" : eventTraits[trait]!.toString();
           }
           return acc;
         },


### PR DESCRIPTION
This PR fixes the issue
https://ekeekaran-ventures.sentry.io/share/issue/c97dcae32cde4f3f832e90cd363fdd23/

in older plugin we were able to send undefined values as trait but now if I will call 

```js
identify(userId, {
   enabled: undefined
})
```

error was getting thrown in this case. Fixed this passing empty string if value is undefined. 
