### PR TITLE
feat: add property to disable segment client

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -50,27 +50,27 @@ const segmentClient = createClient({
 
 const LoggerPlugin = new Logger();
 
-segmentClient.add({ plugin: LoggerPlugin });
+segmentClient?.add({ plugin: LoggerPlugin });
 
 // To see an example Consent Manager uncomment the following
 // const ConsentManagerPlugin = new ConsentManager();
-// segmentClient.add({ plugin: ConsentManagerPlugin });
+// segmentClient?.add({ plugin: ConsentManagerPlugin });
 
 // To test the Firebase plugin make sure to add your own API_KEY in example/ios/GoogleService-Info.plist
-// segmentClient.add({ plugin: new FirebasePlugin() });
+// segmentClient?.add({ plugin: new FirebasePlugin() });
 
 // To test the Facebook App Events plugin make sure to add your Facebook App Id to Info.plist
 // segmentClient.add({ plugin: new FacebookAppEventsPlugin() });
 // const idfaPlugin = new IdfaPlugin();
-// segmentClient.add({ plugin: idfaPlugin });
+// segmentClient?.add({ plugin: idfaPlugin });
 
-segmentClient.add({ plugin: new AmplitudeSessionPlugin() });
+segmentClient?.add({ plugin: new AmplitudeSessionPlugin() });
 
-// segmentClient.add({ plugin: new BrazePlugin() });
+// segmentClient?.add({ plugin: new BrazePlugin() });
 
-// segmentClient.add({ plugin: new ClevertapPlugin() });
+// segmentClient?.add({ plugin: new ClevertapPlugin() });
 
-// segmentClient.add({
+// segmentClient?.add({
 //   plugin: new AdvertisingIdPlugin(),
 // });
 
@@ -133,7 +133,7 @@ const App = () => {
           const newRouteName = getActiveRouteName(state);
 
           if (routeName !== newRouteName) {
-            void segmentClient.screen(newRouteName);
+            void segmentClient?.screen(newRouteName);
 
             setRouteName(newRouteName);
           }

--- a/packages/core/src/__tests__/client.test.ts
+++ b/packages/core/src/__tests__/client.test.ts
@@ -10,7 +10,7 @@ describe('#createClient', () => {
     logger: getMockLogger(),
   };
 
-  let client: SegmentClient | null;
+  let client: SegmentClient | undefined;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -27,6 +27,6 @@ describe('#createClient', () => {
 
   it('returns undefined client if enabled is set as false', () => {
     client = createClient({ enabled: false, ...config });
-    expect(client).toBeNull();
+    expect(client).toBeUndefined();
   });
 });

--- a/packages/core/src/__tests__/client.test.ts
+++ b/packages/core/src/__tests__/client.test.ts
@@ -10,18 +10,23 @@ describe('#createClient', () => {
     logger: getMockLogger(),
   };
 
-  let client: SegmentClient;
+  let client: SegmentClient | null;
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   afterEach(() => {
-    client.cleanup();
+    client?.cleanup();
   });
 
   it('creates the client with the provided logger', () => {
     client = createClient(config);
-    expect(client.logger).toBe(config.logger);
+    expect(client?.logger).toBe(config.logger);
+  });
+
+  it('returns undefined client if enabled is set as false', () => {
+    client = createClient({ enabled: false, ...config });
+    expect(client).toBeNull();
   });
 });

--- a/packages/core/src/client.tsx
+++ b/packages/core/src/client.tsx
@@ -7,7 +7,13 @@ import { SegmentClient } from './analytics';
 import { SovranStorage } from './storage';
 
 export const createClient = (config: Config) => {
-  const logger = config?.logger || createLogger();
+  const logger = config?.logger ?? createLogger();
+
+  if (typeof config?.enabled === 'boolean' && config.enabled === false) {
+    // do nothing if client is defined as disabled
+    return null;
+  }
+
   if (typeof config?.debug === 'boolean') {
     if (config.debug) {
       logger.enable();
@@ -57,7 +63,7 @@ export const useAnalytics = (): ClientMethods => {
   return React.useMemo(() => {
     if (!client) {
       console.error(
-        'Segment client not configured!',
+        'Segment client not configured or is disabled by defining client.enabled as false!',
         'To use the useAnalytics() hook, pass an initialized Segment client into the AnalyticsProvider'
       );
     }

--- a/packages/core/src/client.tsx
+++ b/packages/core/src/client.tsx
@@ -11,7 +11,7 @@ export const createClient = (config: Config) => {
 
   if (typeof config?.enabled === 'boolean' && config.enabled === false) {
     // do nothing if client is defined as disabled
-    return null;
+    return undefined;
   }
 
   if (typeof config?.debug === 'boolean') {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -132,6 +132,7 @@ export interface DeactivableLoggerType extends LoggerType {
 export type Config = {
   writeKey: string;
   debug?: boolean;
+  enabled?: boolean;
   logger?: DeactivableLoggerType;
   // Legacy, for compat only
   flushAt?: number;


### PR DESCRIPTION
### Summary

This PR adds a new property to disable the segment client as if the client was never set. That can be useful in the scenario when no segment related calls should be made while running in the debug mode.

This change modifies the return type of the `createClient` function which can be an undefined object now. I believe the impact should be something users can fix quickly but this feature could help people avoid sending not needed debug scenarios to segment.