### PR TITLE
Update peer dependency to version 18 of Firebase

### DIFF
--- a/packages/plugins/plugin-firebase/package.json
+++ b/packages/plugins/plugin-firebase/package.json
@@ -46,12 +46,12 @@
   "homepage": "https://github.com/segmentio/analytics-react-native/tree/master/packages/plugins/plugin-firebase#readme",
   "peerDependencies": {
     "@segment/analytics-react-native": "*",
-    "@react-native-firebase/app": "^17.3.2",
-    "@react-native-firebase/analytics": "^17.3.2"
+    "@react-native-firebase/app": "^18.4.0",
+    "@react-native-firebase/analytics": "^18.4.0"
   },
   "devDependencies": {
-    "@react-native-firebase/app": "^17.3.2",
-    "@react-native-firebase/analytics": "^17.3.2",
+    "@react-native-firebase/app": "^18.4.0",
+    "@react-native-firebase/analytics": "^18.4.0",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/commit-analyzer": "^9.0.2",
     "@semantic-release/git": "^10.0.1",


### PR DESCRIPTION
I needed this change in my project otherwise it creates a dependency issue (since I'm using rn-firebase 18.4.0). I've been using this for about two weeks now without any issues, ie all segment events are being sent as expected