### PR TITLE
fix: add unknown option to current state

### DIFF
--- a/packages/core/src/flushPolicies/background-flush-policy.ts
+++ b/packages/core/src/flushPolicies/background-flush-policy.ts
@@ -18,7 +18,7 @@ export class BackgroundFlushPolicy extends FlushPolicyBase {
       'change',
       (nextAppState) => {
         if (
-          this.appState === 'active' &&
+          (this.appState === 'active' || 'unknown') &&
           ['inactive', 'background'].includes(nextAppState)
         ) {
           // When the app goes into the background we will trigger a flush

--- a/packages/core/src/flushPolicies/background-flush-policy.ts
+++ b/packages/core/src/flushPolicies/background-flush-policy.ts
@@ -18,7 +18,7 @@ export class BackgroundFlushPolicy extends FlushPolicyBase {
       'change',
       (nextAppState) => {
         if (
-          (this.appState === 'active' || 'unknown') &&
+          (this.appState === 'active' || this.appState === 'unknown') &&
           ['inactive', 'background'].includes(nextAppState)
         ) {
           // When the app goes into the background we will trigger a flush


### PR DESCRIPTION
- Added a check for `currentState` to allow for the `unknown` value occasionally generated by RN per this [GH issue](https://github.com/facebook/react-native/issues/37793) in iOS. This will prevent the backgroundFlushPolicy from failing on initial launch. 
