### PR TITLE
Add support for hasUnmappedDestinations

### DIFF
--- a/packages/core/src/__tests__/__helpers__/mockSegmentStore.ts
+++ b/packages/core/src/__tests__/__helpers__/mockSegmentStore.ts
@@ -12,6 +12,7 @@ import type {
   DestinationFilters,
   IntegrationSettings,
   RoutingRule,
+  SegmentAPIConsentSettings,
   SegmentAPIIntegrations,
   UserInfoState,
 } from '../../types';
@@ -22,6 +23,7 @@ export type StoreData = {
   isReady: boolean;
   context?: DeepPartial<Context>;
   settings: SegmentAPIIntegrations;
+  consentSettings?: SegmentAPIConsentSettings;
   filters: DestinationFilters;
   userInfo: UserInfoState;
   deepLinkData: DeepLinkData;
@@ -33,6 +35,7 @@ const INITIAL_VALUES: StoreData = {
   settings: {
     [SEGMENT_DESTINATION_KEY]: {},
   },
+  consentSettings: undefined,
   filters: {},
   userInfo: {
     anonymousId: 'anonymousId',
@@ -71,6 +74,9 @@ export class MockSegmentStore implements Storage {
   private callbacks = {
     context: createCallbackManager<DeepPartial<Context> | undefined>(),
     settings: createCallbackManager<SegmentAPIIntegrations>(),
+    consentSettings: createCallbackManager<
+      SegmentAPIConsentSettings | undefined
+    >(),
     filters: createCallbackManager<DestinationFilters>(),
     userInfo: createCallbackManager<UserInfoState>(),
     deepLinkData: createCallbackManager<DeepLinkData>(),
@@ -120,6 +126,19 @@ export class MockSegmentStore implements Storage {
       this.data.settings[key] = value;
       this.callbacks.settings.run(this.data.settings);
       return Promise.resolve(this.data.settings);
+    },
+  };
+
+  readonly consentSettings: Watchable<SegmentAPIConsentSettings | undefined> &
+    Settable<SegmentAPIConsentSettings | undefined> = {
+    get: createMockStoreGetter(() => this.data.consentSettings),
+    onChange: (callback: (value?: SegmentAPIConsentSettings) => void) =>
+      this.callbacks.consentSettings.register(callback),
+    set: (value) => {
+      this.data.consentSettings =
+        value instanceof Function ? value(this.data.consentSettings) : value;
+      this.callbacks.consentSettings.run(this.data.consentSettings);
+      return this.data.consentSettings;
     },
   };
 

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -59,6 +59,7 @@ import {
   SegmentError,
   translateHTTPError,
 } from './errors';
+import type { SegmentAPIConsentSettings } from '.';
 
 type OnPluginAddedCallback = (plugin: Plugin) => void;
 
@@ -115,6 +116,11 @@ export class SegmentClient {
    * Access or subscribe to integration settings
    */
   readonly settings: Watchable<SegmentAPIIntegrations | undefined>;
+
+  /**
+   * Access or subscribe to integration settings
+   */
+  readonly consentSettings: Watchable<SegmentAPIConsentSettings | undefined>;
 
   /**
    * Access or subscribe to destination filter settings
@@ -196,6 +202,11 @@ export class SegmentClient {
     this.settings = {
       get: this.store.settings.get,
       onChange: this.store.settings.onChange,
+    };
+
+    this.consentSettings = {
+      get: this.store.consentSettings.get,
+      onChange: this.store.consentSettings.onChange,
     };
 
     this.filters = {
@@ -305,12 +316,14 @@ export class SegmentClient {
       const resJson: SegmentAPISettings =
         (await res.json()) as SegmentAPISettings;
       const integrations = resJson.integrations;
+      const consentSettings = resJson.consentSettings;
       const filters = this.generateFiltersMap(
         resJson.middlewareSettings?.routingRules ?? []
       );
       this.logger.info(`Received settings from Segment succesfully.`);
       await Promise.all([
         this.store.settings.set(integrations),
+        this.store.consentSettings.set(consentSettings),
         this.store.filters.set(filters),
       ]);
     } catch (e) {

--- a/packages/core/src/plugins/ConsentPlugin.ts
+++ b/packages/core/src/plugins/ConsentPlugin.ts
@@ -80,12 +80,14 @@ export class ConsentPlugin extends Plugin {
     if (this.isDestinationPlugin(plugin)) {
       plugin.add(
         new ConsentFilterPlugin((event) => {
+          const allCategories =
+            this.analytics?.consentSettings.get()?.allCategories || [];
           const settings = this.analytics?.settings.get() || {};
           const preferences = event.context?.consent?.categoryPreferences || {};
 
           if (plugin.key === SEGMENT_DESTINATION_KEY) {
-            const noneConsented = Object.values(preferences).every(
-              (consented) => !consented
+            const noneConsented = allCategories.every(
+              (category) => !preferences[category]
             );
 
             return (

--- a/packages/core/src/plugins/ConsentPlugin.ts
+++ b/packages/core/src/plugins/ConsentPlugin.ts
@@ -84,14 +84,14 @@ export class ConsentPlugin extends Plugin {
           const preferences = event.context?.consent?.categoryPreferences || {};
 
           if (plugin.key === SEGMENT_DESTINATION_KEY) {
+            const noneConsented = Object.values(preferences).every(
+              (consented) => !consented
+            );
+
             return (
               this.isConsentUpdateEvent(event) ||
-              !(
-                Object.values(preferences).every((consented) => !consented) &&
-                Object.entries(settings)
-                  .filter(([k]) => k !== SEGMENT_DESTINATION_KEY)
-                  .every(([_, v]) => this.containsConsentSettings(v))
-              )
+              !this.isConsentFeatureSetup() ||
+              !(noneConsented && !this.hasUnmappedDestinations())
             );
           }
 
@@ -126,6 +126,16 @@ export class ConsentPlugin extends Plugin {
 
   private isConsentUpdateEvent(event: SegmentEvent): boolean {
     return (event as TrackEventType).event === CONSENT_PREF_UPDATE_EVENT;
+  }
+
+  private hasUnmappedDestinations(): boolean {
+    return (
+      this.analytics?.consentSettings.get()?.hasUnmappedDestinations === true
+    );
+  }
+
+  private isConsentFeatureSetup(): boolean {
+    return typeof this.analytics?.consentSettings.get() === 'object';
   }
 }
 

--- a/packages/core/src/plugins/__tests__/consent/destinationMultipleCategories.test.ts
+++ b/packages/core/src/plugins/__tests__/consent/destinationMultipleCategories.test.ts
@@ -13,6 +13,7 @@ describe('Destinations multiple categories', () => {
     createTestClient(
       {
         settings: destinationsMultipleCategories.integrations,
+        consentSettings: destinationsMultipleCategories.consentSettings,
       },
       { autoAddSegmentDestination: true }
     );

--- a/packages/core/src/plugins/__tests__/consent/mockSettings/ConsentNotEnabledAtSegment.json
+++ b/packages/core/src/plugins/__tests__/consent/mockSettings/ConsentNotEnabledAtSegment.json
@@ -68,4 +68,3 @@
   "legacyVideoPluginsEnabled": false,
   "remotePlugins": []
 }
-

--- a/packages/core/src/plugins/__tests__/consent/mockSettings/DestinationsMultipleCategories.json
+++ b/packages/core/src/plugins/__tests__/consent/mockSettings/DestinationsMultipleCategories.json
@@ -64,10 +64,10 @@
   "legacyVideoPluginsEnabled": false,
   "remotePlugins": [],
   "consentSettings": {
+    "hasUnmappedDestinations": false,
     "allCategories": [
       "C0001",
       "C0002"
     ]
   }
 }
-

--- a/packages/core/src/plugins/__tests__/consent/mockSettings/NoUnmappedDestinations.json
+++ b/packages/core/src/plugins/__tests__/consent/mockSettings/NoUnmappedDestinations.json
@@ -93,6 +93,7 @@
   "legacyVideoPluginsEnabled": false,
   "remotePlugins": [],
   "consentSettings": {
+    "hasUnmappedDestinations": false,
     "allCategories": [
       "C0001",
       "C0002",
@@ -102,4 +103,3 @@
     ]
   }
 }
-

--- a/packages/core/src/plugins/__tests__/consent/mockSettings/UnmappedDestinations.json
+++ b/packages/core/src/plugins/__tests__/consent/mockSettings/UnmappedDestinations.json
@@ -89,6 +89,7 @@
   "legacyVideoPluginsEnabled": false,
   "remotePlugins": [],
   "consentSettings": {
+    "hasUnmappedDestinations": true,
     "allCategories": [
       "C0001",
       "C0002",
@@ -98,4 +99,3 @@
     ]
   }
 }
-

--- a/packages/core/src/plugins/__tests__/consent/noUnmapped.test.ts
+++ b/packages/core/src/plugins/__tests__/consent/noUnmapped.test.ts
@@ -8,6 +8,7 @@ describe('No unmapped destinations', () => {
   const createClient = () =>
     createTestClient({
       settings: noUnmappedDestinations.integrations,
+      consentSettings: noUnmappedDestinations.consentSettings,
     });
 
   test('no to all', async () => {

--- a/packages/core/src/plugins/__tests__/consent/unmapped.test.ts
+++ b/packages/core/src/plugins/__tests__/consent/unmapped.test.ts
@@ -13,6 +13,7 @@ describe('Unmapped destinations', () => {
     createTestClient(
       {
         settings: unmappedDestinations.integrations,
+        consentSettings: unmappedDestinations.consentSettings,
       },
       { autoAddSegmentDestination: true }
     );

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -1,4 +1,5 @@
 import type { Unsubscribe, Persistor } from '@segment/sovran-react-native';
+import type { SegmentAPIConsentSettings } from '..';
 import type {
   Context,
   DeepPartial,
@@ -70,6 +71,9 @@ export interface Storage {
   readonly settings: Watchable<SegmentAPIIntegrations | undefined> &
     Settable<SegmentAPIIntegrations> &
     Dictionary<string, IntegrationSettings, SegmentAPIIntegrations>;
+
+  readonly consentSettings: Watchable<SegmentAPIConsentSettings | undefined> &
+    Settable<SegmentAPIConsentSettings | undefined>;
 
   readonly filters: Watchable<DestinationFilters | undefined> &
     Settable<DestinationFilters> &

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -290,6 +290,11 @@ export type SegmentAPIIntegrations = {
   [key: string]: IntegrationSettings;
 };
 
+export type SegmentAPIConsentSettings = {
+  allCategories: string[];
+  hasUnmappedDestinations: boolean;
+};
+
 export type RoutingRule = Rule;
 
 export interface MetricsOptions {
@@ -309,6 +314,7 @@ export type SegmentAPISettings = {
     routingRules: RoutingRule[];
   };
   metrics?: MetricsOptions;
+  consentSettings?: SegmentAPIConsentSettings;
 };
 
 export type DestinationMetadata = {


### PR DESCRIPTION
Implements the spec as explained [here](https://docs.google.com/document/d/13jxE3nwyn6pbUokOreJUFsfZtK7gjYq0JlPFLSUj21Y/edit)

Parity established with https://github.com/segment-integrations/analytics-swift-consent/commit/6563d95f6f1783bba4bd225d51fc849a48c7c3a5