### PR TITLE
Niall/braze debounce update

### DIFF
--- a/packages/plugins/plugin-braze/src/BrazePlugin.tsx
+++ b/packages/plugins/plugin-braze/src/BrazePlugin.tsx
@@ -83,56 +83,36 @@ export class BrazePlugin extends DestinationPlugin {
     return undefined;
   };
 
-  private isObject(object: any):boolean {
-    return object != null && typeof object === 'object';
-  }
-
-  private deepEqual(object1: any, object2: any): boolean {
-    const keys1 = Object.keys(object1);
-    const keys2 = Object.keys(object2);
-  
-    if (keys1.length !== keys2.length) {
-      return false;
-    }
-  
-    for (let key of keys1) {
-      const val1 = object1[key];
-      const val2 = object2[key];
-      const areObjects = this.isObject(val1) && this.isObject(val2);
-      if (
-        areObjects && !this.deepEqual(val1, val2) ||
-        !areObjects && val1 !== val2
-      ) {
-        return false;
+  private compareObjects(person1: any, person2: any): boolean {
+    for (let key in person2) {
+      if (person2.hasOwnProperty(key)) {
+        if (typeof person2[key] === 'object' && !Array.isArray(person2[key])) {
+          if (!this.compareObjects(person1[key], person2[key])) {
+            return false;
+          }
+        } else if (Array.isArray(person2[key])) {
+          for (let i = 0; i < person2[key].length; i++) {
+            if (!this.compareObjects(person1[key][i], person2[key][i])) {
+              return false;
+            }
+          }
+        } else if (person1[key] !== person2[key]) {
+          return false;
+        }
       }
     }
-  
     return true;
   }
 
   identify(event: IdentifyEventType) {
     //check to see if anything has changed.
     //if it hasn't changed don't send event
-    let isPresent = true; // This will return true if all key-value pairs in event.traits are present in this.lastSeenTraits?.traits, otherwise false
-
-    for (let [key, value] of Object.entries(event.traits)) {
-      if (isObject(value)) {
-        if (!this.deepEqual(this.lastSeenTraits?.traits[key], value)) {
-          isPresent = false;
-          break;
-        }
-      } else {
-        if (this.lastSeenTraits?.traits[key] !== value) {
-          isPresent = false;
-          break;
-        }
-      }
-    }
+    let identical = this.compareObjects(this.lastSeenTraits?.traits, event.traits);
 
     if (
       this.lastSeenTraits?.userId === event.userId &&
       this.lastSeenTraits?.anonymousId === event.anonymousId &&
-      isPresent
+      identical
     ) {
       return;
     } else {

--- a/packages/plugins/plugin-braze/src/BrazePlugin.tsx
+++ b/packages/plugins/plugin-braze/src/BrazePlugin.tsx
@@ -83,20 +83,20 @@ export class BrazePlugin extends DestinationPlugin {
     return undefined;
   };
 
-  private compareObjects(person1: any, person2: any): boolean {
-    for (let key in person2) {
-      if (person2.hasOwnProperty(key)) {
-        if (typeof person2[key] === 'object' && !Array.isArray(person2[key])) {
-          if (!this.compareObjects(person1[key], person2[key])) {
+  private compareObjects(oldTraits: any, newTraits: any): boolean {
+    for (let key in newTraits) {
+      if (newTraits.hasOwnProperty(key)) {
+        if (typeof newTraits[key] === 'object' && !Array.isArray(newTraits[key])) {
+          if (!this.compareObjects(oldTraits[key], newTraits[key])) {
             return false;
           }
-        } else if (Array.isArray(person2[key])) {
-          for (let i = 0; i < person2[key].length; i++) {
-            if (!this.compareObjects(person1[key][i], person2[key][i])) {
+        } else if (Array.isArray(newTraits[key])) {
+          for (let i = 0; i < newTraits[key].length; i++) {
+            if (!this.compareObjects(oldTraits[key][i], newTraits[key][i])) {
               return false;
             }
           }
-        } else if (person1[key] !== person2[key]) {
+        } else if (oldTraits[key] !== newTraits[key]) {
           return false;
         }
       }
@@ -107,7 +107,7 @@ export class BrazePlugin extends DestinationPlugin {
   identify(event: IdentifyEventType) {
     //check to see if anything has changed.
     //if it hasn't changed don't send event
-    let identical = this.compareObjects(this.lastSeenTraits?.traits, event.traits);
+    let identical =  typeof this.lastSeenTraits?.traits === 'undefined' ? false : this.compareObjects(this.lastSeenTraits?.traits, event.traits);
 
     if (
       this.lastSeenTraits?.userId === event.userId &&

--- a/packages/plugins/plugin-braze/src/BrazePlugin.tsx
+++ b/packages/plugins/plugin-braze/src/BrazePlugin.tsx
@@ -85,7 +85,7 @@ export class BrazePlugin extends DestinationPlugin {
 
   identify(event: IdentifyEventType) {
     //check to see if anything has changed.
-    //if it hasn't changed don't send event
+    //if it hasn't changed don't send event to braze
     if (
       this.lastSeenTraits?.userId === event.userId &&
       this.lastSeenTraits?.anonymousId === event.anonymousId &&


### PR DESCRIPTION
Our current logic for comparing the last seen traits and the current traits does not actually compare values. Our current logic to compare the traits is just checking the referential equality:

`      
this.lastSeenTraits?.traits === event.traits
`

Referential equality can be determined with equality operators such as strict equality (===) or coercive equality (==) and also by using [Object.is](http://object.is/)() functions, but determining deep equality is tricky as the objects can be nested.

Customer issue: https://github.com/segmentio/analytics-react-native/issues/907