### PR TITLE
fix(plugin-facebook): Fix Dedup issues in Facebook Plugin

### DIFF
--- a/packages/plugins/plugin-facebook-app-events/package.json
+++ b/packages/plugins/plugin-facebook-app-events/package.json
@@ -45,7 +45,7 @@
   "homepage": "https://github.com/segmentio/analytics-react-native/tree/master/packages/plugins/plugin-facebook-app-events#readme",
   "peerDependencies": {
     "@segment/analytics-react-native": "^2.18.0",
-    "react-native-fbsdk-next": "^11"
+    "react-native-fbsdk-next": "^12"
   },
   "devDependencies": {
     "@segment/analytics-react-native": "^2.18.0",
@@ -53,7 +53,7 @@
     "@segment/sovran-react-native": "^1.1.0",
     "jest": "^29.7.0",
     "react-native-builder-bob": "^0.23.1",
-    "react-native-fbsdk-next": "^11",
+    "react-native-fbsdk-next": "^12",
     "rimraf": "^5.0.5",
     "typescript": "^5.2.2"
   },

--- a/packages/plugins/plugin-facebook-app-events/src/FacebookAppEventsPlugin.ts
+++ b/packages/plugins/plugin-facebook-app-events/src/FacebookAppEventsPlugin.ts
@@ -73,12 +73,16 @@ const sanitizeEvent = (
     params._logTime = event._logTime;
   }
 
+  // Map messageId to event_id to support FB deduplication
+  // https://developers.facebook.com/docs/marketing-api/conversions-api/deduplicate-pixel-and-server-events#event-deduplication-options
+  const messageId = unknownToString(event.messageId);
+  if (messageId !== null && messageId !== undefined && messageId !== '') {
+    params.event_id = messageId;
+  }
+
   return {
     ...params,
     fb_num_items: productCount,
-    // Map messageId to event_id to support FB deduplication
-    // https://developers.facebook.com/docs/marketing-api/conversions-api/deduplicate-pixel-and-server-events#event-deduplication-options
-    event_id: unknownToString(event.messageId)!,
     _appVersion: (event.context as Context).app.version,
   };
 };

--- a/packages/plugins/plugin-facebook-app-events/src/FacebookAppEventsPlugin.ts
+++ b/packages/plugins/plugin-facebook-app-events/src/FacebookAppEventsPlugin.ts
@@ -12,6 +12,7 @@ import {
   SegmentClient,
   SegmentError,
   TrackEventType,
+  unknownToString,
   UpdateType,
 } from '@segment/analytics-react-native';
 import { AppEventsLogger, Settings } from 'react-native-fbsdk-next';
@@ -75,6 +76,9 @@ const sanitizeEvent = (
   return {
     ...params,
     fb_num_items: productCount,
+    // Map messageId to event_id to support FB deduplication
+    // https://developers.facebook.com/docs/marketing-api/conversions-api/deduplicate-pixel-and-server-events#event-deduplication-options
+    event_id: unknownToString(event.messageId)!,
     _appVersion: (event.context as Context).app.version,
   };
 };

--- a/packages/plugins/plugin-facebook-app-events/src/__tests__/FacebookAppEventsPlugin.test.ts
+++ b/packages/plugins/plugin-facebook-app-events/src/__tests__/FacebookAppEventsPlugin.test.ts
@@ -247,5 +247,38 @@ describe('FacebookAppEventsPlugin', () => {
 
       expect(AppEventsLogger.logEvent).toHaveBeenCalledWith('ACTION', expected);
     });
+
+    it('logTime is converted to number', () => {
+      const time = new Date(1704267463 * 1000).toISOString();
+
+      const payload = {
+        messageId: '12345',
+        type: 'track',
+        event: 'ACTION',
+        context: {
+          app: {
+            build: '1',
+            name: 'Analytics',
+            namespace: 'org.reactjs.native.AnalyticsReactNativeExample',
+            version: '1.0',
+          },
+        },
+        properties: {
+          foo: 'bar',
+        },
+        timestamp: time,
+      };
+
+      const expected = {
+        _appVersion: '1.0',
+        _logTime: Math.floor(Date.parse(time) / 1000), // Unix timestamp
+        event_id: '12345',
+        fb_num_items: 0,
+      };
+
+      plugin.track(payload as TrackEventType);
+
+      expect(AppEventsLogger.logEvent).toHaveBeenCalledWith('ACTION', expected);
+    });
   });
 });

--- a/packages/plugins/plugin-facebook-app-events/src/__tests__/FacebookAppEventsPlugin.test.ts
+++ b/packages/plugins/plugin-facebook-app-events/src/__tests__/FacebookAppEventsPlugin.test.ts
@@ -1,5 +1,6 @@
 import {
   SegmentClient,
+  SegmentEvent,
   TrackEventType,
   UpdateType,
 } from '@segment/analytics-react-native';
@@ -118,6 +119,7 @@ describe('FacebookAppEventsPlugin', () => {
 
     it('logs a custom event', () => {
       const payload = {
+        messageId: '12345',
         type: 'track',
         event: 'ACTION',
         context: {
@@ -132,12 +134,13 @@ describe('FacebookAppEventsPlugin', () => {
           foo: 'bar',
         },
         timestamp: '2021-11-08T21:42:32.242Z',
-      };
+      } as SegmentEvent;
 
       const expected = {
         _appVersion: '1.0',
         _logTime: 1636407752,
         fb_num_items: 0,
+        event_id: '12345',
       };
 
       plugin.track(payload as TrackEventType);
@@ -147,6 +150,7 @@ describe('FacebookAppEventsPlugin', () => {
 
     it('logs an order completed event', () => {
       const payload = {
+        messageId: '12345',
         type: 'track',
         event: 'Order Completed',
         context: {
@@ -167,6 +171,7 @@ describe('FacebookAppEventsPlugin', () => {
       const expected = {
         _appVersion: '1.0',
         _logTime: 1636407752,
+        event_id: '12345',
         fb_num_items: 0,
         _valueToSum: 10,
       };
@@ -181,6 +186,7 @@ describe('FacebookAppEventsPlugin', () => {
 
     it('maps event names', () => {
       const payload = {
+        messageId: '12345',
         type: 'track',
         event: 'original_event',
         context: {
@@ -200,6 +206,7 @@ describe('FacebookAppEventsPlugin', () => {
       const expected = {
         _appVersion: '1.0',
         _logTime: 1636407752,
+        event_id: '12345',
         fb_num_items: 0,
       };
 
@@ -213,6 +220,7 @@ describe('FacebookAppEventsPlugin', () => {
 
     it('skips logTime when timestamp is not a date', () => {
       const payload = {
+        messageId: '12345',
         type: 'track',
         event: 'ACTION',
         context: {
@@ -231,6 +239,7 @@ describe('FacebookAppEventsPlugin', () => {
 
       const expected = {
         _appVersion: '1.0',
+        event_id: '12345',
         fb_num_items: 0,
       };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3532,12 +3532,12 @@ __metadata:
     "@segment/sovran-react-native": "npm:^1.1.0"
     jest: "npm:^29.7.0"
     react-native-builder-bob: "npm:^0.23.1"
-    react-native-fbsdk-next: "npm:^11"
+    react-native-fbsdk-next: "npm:^12"
     rimraf: "npm:^5.0.5"
     typescript: "npm:^5.2.2"
   peerDependencies:
     "@segment/analytics-react-native": ^2.18.0
-    react-native-fbsdk-next: ^11
+    react-native-fbsdk-next: ^12
   languageName: unknown
   linkType: soft
 
@@ -13123,18 +13123,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-fbsdk-next@npm:^11":
-  version: 11.3.0
-  resolution: "react-native-fbsdk-next@npm:11.3.0"
-  dependencies:
-    xml2js: "npm:^0.4.23"
+"react-native-fbsdk-next@npm:^12":
+  version: 12.1.4
+  resolution: "react-native-fbsdk-next@npm:12.1.4"
   peerDependencies:
     expo: ">=47.0.0"
     react-native: ">=0.63.3"
   peerDependenciesMeta:
     expo:
       optional: true
-  checksum: 10c0/8122cfac39c93886255dc6335e4d3d3361c8a64636773767e4daf700acb319f673c910b12b55230f3b46d320437157bc3e8f6753588125e31a3f789bd622f378
+  checksum: 10c0/b9722c0936bc6373af330b7429be45c8b6d87600a8a863f367a581928133d4009b7802411440b8e64c36a42506c42f0f70dd3bf917c565b78d3af4f425cb442a
   languageName: node
   linkType: hard
 
@@ -13712,13 +13710,6 @@ __metadata:
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: 10c0/7e3c8b2e88a1841c9671094bbaeebd94448111dd90a81a1f606f3f67708a6ec57763b3b47f06da09fc6054193e0e6709e77325415dc8422b04497a8070fa02d4
-  languageName: node
-  linkType: hard
-
-"sax@npm:>=0.6.0":
-  version: 1.3.0
-  resolution: "sax@npm:1.3.0"
-  checksum: 10c0/599dbe0ba9d8bd55e92d920239b21d101823a6cedff71e542589303fa0fa8f3ece6cf608baca0c51be846a2e88365fac94a9101a9c341d94b98e30c4deea5bea
   languageName: node
   linkType: hard
 
@@ -15552,23 +15543,6 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10c0/aec4ef4eb65821a7dde7b44790f8699cfafb7978c9b080f6d7a98a7f8fc0ce674c027073a78574c94786ba7112cc90fa2cc94fc224ceba4d4b1030cff9662494
-  languageName: node
-  linkType: hard
-
-"xml2js@npm:^0.4.23":
-  version: 0.4.23
-  resolution: "xml2js@npm:0.4.23"
-  dependencies:
-    sax: "npm:>=0.6.0"
-    xmlbuilder: "npm:~11.0.0"
-  checksum: 10c0/a3f41c9afc46d5bd0bea4070e5108777b605fd5ce2ebb978a68fd4c75513978ad5939f8135664ffea6f1adb342f391b1ba1584ed7955123b036e9ab8a1d26566
-  languageName: node
-  linkType: hard
-
-"xmlbuilder@npm:~11.0.0":
-  version: 11.0.1
-  resolution: "xmlbuilder@npm:11.0.1"
-  checksum: 10c0/74b979f89a0a129926bc786b913459bdbcefa809afaa551c5ab83f89b1915bdaea14c11c759284bb9b931e3b53004dbc2181e21d3ca9553eeb0b2a7b4e40c35b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Adds `event_id` from `messageId` to the FB events to support deduplication
- Adds a `_logTime` unit test to verify the E notation error (no-repro)
- Bumps `FBSDK-Next` to latest
