### PR TITLE
Removed the AdMob link from the setup instructions

### DIFF
--- a/packages/plugins/plugin-advertising-id/README.md
+++ b/packages/plugins/plugin-advertising-id/README.md
@@ -12,7 +12,6 @@ yarn add @segment/analytics-react-native-plugin-advertising-id
 
 This plugin requires a `compileSdkVersion` of at least 19. 
 
-See [Google Play Services documentation](https://developers.google.com/admob/android/quick-start) for `advertisingId` setup
 ## Usage
 
 Follow the instructions for adding plugins on the main Analytics client:


### PR DESCRIPTION
Addresses this issue: https://github.com/segmentio/analytics-react-native/issues/687

It seems like the issue was closed saying the AdMob setup is not necessary but the piece of documentation from the setup steps was not removed