### PR TITLE
feat: add uuid and device info provider config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The hassle-free way to add Segment analytics to your React-Native app.
 ## Table of Contents
 
 - [@segment/analytics-react-native](#segmentanalytics-react-native)
-    - [🎉 Flagship 🎉](#-flagship-)
+  - [🎉 Flagship 🎉](#-flagship-)
   - [Table of Contents](#table-of-contents)
   - [Installation](#installation)
     - [Expo](#expo)
@@ -48,6 +48,10 @@ The hassle-free way to add Segment analytics to your React-Native app.
     - [Creating your own flush policies](#creating-your-own-flush-policies)
   - [Handling errors](#handling-errors)
     - [Reporting errors from plugins](#reporting-errors-from-plugins)
+  - [Advanced Options](#advanced-options)
+    - [storagePersistor](#storagepersistor)
+    - [uuidProvider](#uuidprovider)
+    - [deviceInfoProvider](#deviceinfoprovider)
   - [Contributing](#contributing)
   - [Code of Conduct](#code-of-conduct)
   - [License](#license)
@@ -114,24 +118,26 @@ You must pass at least the `writeKey`. Additional configuration options are list
 
 ### Client Options
 
-| Name                        | Default   | Description                                                                                                                                                                                                                                          |
-| --------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `writeKey` **(REQUIRED)**   | ''        | Your Segment API key.                                                                                                                                                                                                                                |
-| `collectDeviceId`           | false     | Set to true to automatically collect the device Id.from the DRM API on Android devices.                                                                                                                                                              |
-| `debug`                     | true\*    | When set to false, it will not generate any logs.                                                                                                                                                                                                    |
-| `logger`                    | undefined | Custom logger instance to expose internal Segment client logging.                                                                                                                                                                                    |
-| `flushAt`                   | 20        | How many events to accumulate before sending events to the backend.                                                                                                                                                                                  |
-| `flushInterval`             | 30        | In seconds, how often to send events to the backend.                                                                                                                                                                                                 |
-| `flushPolicies`             | undefined | Add more granular control for when to flush, see [Adding or removing policies](#adding-or-removing-policies). **Mutually exclusive with flushAt/flushInterval**                                                                                      |
-| `maxBatchSize`              | 1000      | How many events to send to the API at once                                                                                                                                                                                                           |
-| `trackAppLifecycleEvents`   | false     | Enable automatic tracking for [app lifecycle events](https://segment.com/docs/connections/spec/mobile/#lifecycle-events): application installed, opened, updated, backgrounded)                                                                      |
-| `trackDeepLinks`            | false     | Enable automatic tracking for when the user opens the app via a deep link (Note: Requires additional setup on iOS, [see instructions](#ios-deep-link-tracking-setup))                                                                                |
-| `defaultSettings`           | undefined | Settings that will be used if the request to get the settings from Segment fails. Type: [SegmentAPISettings](https://github.com/segmentio/analytics-react-native/blob/c0a5895c0c57375f18dd20e492b7d984393b7bc4/packages/core/src/types.ts#L293-L299) |
-| `autoAddSegmentDestination` | true      | Set to false to skip adding the SegmentDestination plugin                                                                                                                                                                                            |
-| `storePersistor`            | undefined | A custom persistor for the store that `analytics-react-native` leverages. Must match [`Persistor`](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/state/persistor/persistor.ts#L1-L18) interface.                 |
-| `proxy`                     | undefined | `proxy` is a batch url to post to instead of 'https://api.segment.io/v1/b'.                                                                                                                                                                          |
-| `errorHandler`              | undefined | Create custom actions when errors happen, see [Handling errors](#handling-errors)                                                                                                                                                                    |
-| `cdnProxy`                  | undefined | Sets an alternative CDN host for settings retrieval                                                                                                                                                                                                  |
+| Name                        | Default                                                                                                                                                                                                         | Description                                                                                                                                                                                                                                          |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `writeKey` **(REQUIRED)**   | ''                                                                                                                                                                                                              | Your Segment API key.                                                                                                                                                                                                                                |
+| `collectDeviceId`           | false                                                                                                                                                                                                           | Set to true to automatically collect the device Id.from the DRM API on Android devices.                                                                                                                                                              |
+| `debug`                     | true\*                                                                                                                                                                                                          | When set to false, it will not generate any logs.                                                                                                                                                                                                    |
+| `logger`                    | undefined                                                                                                                                                                                                       | Custom logger instance to expose internal Segment client logging.                                                                                                                                                                                    |
+| `flushAt`                   | 20                                                                                                                                                                                                              | How many events to accumulate before sending events to the backend.                                                                                                                                                                                  |
+| `flushInterval`             | 30                                                                                                                                                                                                              | In seconds, how often to send events to the backend.                                                                                                                                                                                                 |
+| `flushPolicies`             | undefined                                                                                                                                                                                                       | Add more granular control for when to flush, see [Adding or removing policies](#adding-or-removing-policies). **Mutually exclusive with flushAt/flushInterval**                                                                                      |
+| `maxBatchSize`              | 1000                                                                                                                                                                                                            | How many events to send to the API at once                                                                                                                                                                                                           |
+| `trackAppLifecycleEvents`   | false                                                                                                                                                                                                           | Enable automatic tracking for [app lifecycle events](https://segment.com/docs/connections/spec/mobile/#lifecycle-events): application installed, opened, updated, backgrounded)                                                                      |
+| `trackDeepLinks`            | false                                                                                                                                                                                                           | Enable automatic tracking for when the user opens the app via a deep link (Note: Requires additional setup on iOS, [see instructions](#ios-deep-link-tracking-setup))                                                                                |
+| `defaultSettings`           | undefined                                                                                                                                                                                                       | Settings that will be used if the request to get the settings from Segment fails. Type: [SegmentAPISettings](https://github.com/segmentio/analytics-react-native/blob/c0a5895c0c57375f18dd20e492b7d984393b7bc4/packages/core/src/types.ts#L293-L299) |
+| `autoAddSegmentDestination` | true                                                                                                                                                                                                            | Set to false to skip adding the SegmentDestination plugin                                                                                                                                                                                            |
+| `storePersistor`            | undefined                                                                                                                                                                                                       | A custom persistor for the store that `analytics-react-native` leverages. Must match [`Persistor`](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/state/persistor/persistor.ts#L1-L18) interface.                 |
+| `proxy`                     | undefined                                                                                                                                                                                                       | `proxy` is a batch url to post to instead of 'https://api.segment.io/v1/b'.                                                                                                                                                                          |
+| `errorHandler`              | undefined                                                                                                                                                                                                       | Create custom actions when errors happen, see [Handling errors](#handling-errors)                                                                                                                                                                    |
+| `cdnProxy`                  | undefined                                                                                                                                                                                                       | Sets an alternative CDN host for settings retrieval                                                                                                                                                                                                  |
+| `uuidProvider`              | Native generator using [`react-native-get-random-values`](https://github.com/LinusU/react-native-get-random-values)[`react-native-get-random-values`](https://github.com/LinusU/react-native-get-random-values) | Unique ID generator used for messageIDs and anonymousIDs. See the []()                                                                                                                                                                               |
+| `deviceInfoProvider`        | Native implementation for iOS & Android.                                                                                                                                                                        | Sets a provider for device context information. Useful for extending to new platforms. See []() for more details                                                                                                                                     |
 
 \* The default value of `debug` will be false in production.
 
@@ -734,6 +740,69 @@ try {
   analytics.logger.warn(e);
 }
 ```
+
+## Advanced Options
+
+These options let you supply your own replacements of some internals of the library. This can be helpful to simplify your app dependencies or extend this lib to other platforms: Expo, Web, Windows, etc.
+
+### storagePersistor
+
+```ts
+export interface Persistor {
+  /**
+   * Retrieves an item from Storage
+   * @param key storeId
+   * @returns State object or undefined if no state is in the storage
+   */
+  get: <T>(key: string) => Promise<T | undefined>;
+  /**
+   * Saves a state object to Storage
+   */
+  set: <T>(key: string, state: T) => Promise<void>;
+}
+```
+
+By default the lib uses [`@react-native-async-storage/async-storage`](https://github.com/react-native-async-storage/async-storage) if installed for persistence of events and data when offline, but you can override this option by supplying your own object complying to a `Persistor` interface.
+
+### uuidProvider
+
+```ts
+export type UUIDProvider = () => string;
+```
+
+Supplies a simple UUID generator. By default it will try to use `react-native-get-random-values` unless one specific provider is passed. If the dependency is not installed it will rely on JS random generators and log a warning
+
+### deviceInfoProvider
+
+```ts
+export type NativeContextInfo = {
+  appName: string;
+  appVersion: string;
+  buildNumber: string;
+  bundleId: string;
+  locale: string;
+  networkType: string;
+  osName: string;
+  osVersion: string;
+  screenHeight: number;
+  screenWidth: number;
+  screenDensity?: number; // android only
+  timezone: string;
+  manufacturer: string;
+  model: string;
+  deviceName: string;
+  deviceId?: string;
+  deviceType: string;
+  adTrackingEnabled?: boolean; // ios only
+  advertisingId?: string; // ios only
+};
+
+export type DeviceInfoProvider = (
+  config: GetContextConfig
+) => Promise<NativeContextInfo>;
+```
+
+A function that returns the device context information. By default we will use our own native module if there's one available for the platform (Android & iOS).
 
 ## Contributing
 

--- a/examples/AnalyticsReactNativeExample/App.tsx
+++ b/examples/AnalyticsReactNativeExample/App.tsx
@@ -31,6 +31,8 @@ import {Logger} from './plugins/Logger';
 // import { ClevertapPlugin } from '@segment/analytics-react-native-plugin-clevertap';
 // import { BrazePlugin } from '@segment/analytics-react-native-plugin-braze';
 
+let startingUUID = 0;
+
 const segmentClient = createClient({
   writeKey: '<WRITE_KEY>',
   trackAppLifecycleEvents: true,
@@ -43,6 +45,32 @@ const segmentClient = createClient({
     // new TimerFlushPolicy(1000),
     // new StartupFlushPolicy(),
   ],
+  deviceInfoProvider: async config => {
+    return {
+      appName: 'Test Example',
+      appVersion: '0.1',
+      buildNumber: '1',
+      bundleId: 'com.segment.testing.custom.device.info',
+      locale: 'en_US',
+      networkType: 'wifi',
+      osName: 'iOS',
+      osVersion: '20.0',
+      screenHeight: 800,
+      screenWidth: 600,
+      screenDensity: 2.625,
+      timezone: 'Europe/London',
+      manufacturer: 'Apple',
+      model: 'x86_64',
+      deviceName: 'iPhone',
+      deviceId: '123-456-789',
+      deviceType: 'phone',
+    };
+  },
+  // uuidProvider: () => {
+  //   let next = startingUUID.toString();
+  //   startingUUID++;
+  //   return next;
+  // },
 });
 
 const LoggerPlugin = new Logger();

--- a/examples/AnalyticsReactNativeExample/ios/Podfile.lock
+++ b/examples/AnalyticsReactNativeExample/ios/Podfile.lock
@@ -375,8 +375,6 @@ PODS:
   - React-jsinspector (0.72.9)
   - React-logger (0.72.9):
     - glog
-  - react-native-get-random-values (1.10.0):
-    - React-Core
   - react-native-safe-area-context (4.7.4):
     - React-Core
   - React-NativeModulesApple (0.72.9):
@@ -553,7 +551,6 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
-  - react-native-get-random-values (from `../node_modules/react-native-get-random-values`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
@@ -639,8 +636,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
-  react-native-get-random-values:
-    :path: "../node_modules/react-native-get-random-values"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
   React-NativeModulesApple:
@@ -724,7 +719,6 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 5a169b1dd1abad06bed40ab7e1aca883c657d865
   React-jsinspector: 54205b269da20c51417e0fc02c4cde9f29a4bf1a
   React-logger: f42d2f2bc4cbb5d19d7c0ce84b8741b1e54e88c8
-  react-native-get-random-values: 384787fd76976f5aec9465aff6fa9e9129af1e74
   react-native-safe-area-context: 2cd91d532de12acdb0a9cbc8d43ac72a8e4c897c
   React-NativeModulesApple: 9f72feb8a04020b32417f768a7e1e40eec91fef4
   React-perflogger: cb433f318c6667060fc1f62e26eb58d6eb30a627

--- a/examples/AnalyticsReactNativeExample/package.json
+++ b/examples/AnalyticsReactNativeExample/package.json
@@ -22,7 +22,6 @@
     "react": "18.2.0",
     "react-native": "0.72.9",
     "react-native-gesture-handler": "^2.13.4",
-    "react-native-get-random-values": "^1.9.0",
     "react-native-safe-area-context": "^4.7.4",
     "react-native-screens": "^3.27.0"
   },

--- a/examples/AnalyticsReactNativeExample/yarn.lock
+++ b/examples/AnalyticsReactNativeExample/yarn.lock
@@ -2043,7 +2043,6 @@ __metadata:
     react: "npm:18.2.0"
     react-native: "npm:0.72.9"
     react-native-gesture-handler: "npm:^2.13.4"
-    react-native-get-random-values: "npm:^1.9.0"
     react-native-safe-area-context: "npm:^4.7.4"
     react-native-screens: "npm:^3.27.0"
     react-test-renderer: "npm:18.2.0"
@@ -3637,13 +3636,6 @@ __metadata:
   version: 3.1.1
   resolution: "exponential-backoff@npm:3.1.1"
   checksum: 10c0/160456d2d647e6019640bd07111634d8c353038d9fa40176afb7cd49b0548bdae83b56d05e907c2cce2300b81cae35d800ef92fefb9d0208e190fa3b7d6bb579
-  languageName: node
-  linkType: hard
-
-"fast-base64-decode@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "fast-base64-decode@npm:1.0.0"
-  checksum: 10c0/6d8feab513222a463d1cb58d24e04d2e04b0791ac6559861f99543daaa590e2636d040d611b40a50799bfb5c5304265d05e3658b5adf6b841a50ef6bf833d821
   languageName: node
   linkType: hard
 
@@ -6470,17 +6462,6 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10c0/d567c26756aefc85fb6056efc6be4cdf0c1e7fd45a9d92f4bf0dc0fd94d3e099207398978bac8bdf3fa731f1020d41a7576566b552c525dc71bf7bc270bad25f
-  languageName: node
-  linkType: hard
-
-"react-native-get-random-values@npm:^1.9.0":
-  version: 1.10.0
-  resolution: "react-native-get-random-values@npm:1.10.0"
-  dependencies:
-    fast-base64-decode: "npm:^1.0.0"
-  peerDependencies:
-    react-native: ">=0.56"
-  checksum: 10c0/ec601ffefae3b08314182765168e11d2dae412962a2e3d7b6b7fe5a15ed867ee75eaf68057ddcea1088cbcaa484e22298a7adb51adc6b2facd8744b575007bb5
   languageName: node
   linkType: hard
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,8 +48,7 @@
   "dependencies": {
     "@segment/tsub": "^2",
     "deepmerge": "^4.3.1",
-    "js-base64": "^3.7.5",
-    "uuid": "^9.0.1"
+    "js-base64": "^3.7.5"
   },
   "devDependencies": {
     "@types/uuid": "^9.0.7",
@@ -60,7 +59,8 @@
     "@react-native-async-storage/async-storage": "1.x",
     "react": "*",
     "react-native": "*",
-    "react-native-get-random-values": "1.x"
+    "react-native-get-random-values": "1.x",
+    "uuid": "9.x"
   },
   "peerDependenciesMeta": {
     "@react-native-async-storage/async-storage": {

--- a/packages/core/src/__tests__/api.test.ts
+++ b/packages/core/src/__tests__/api.test.ts
@@ -1,25 +1,8 @@
-import {
-  Context,
-  EventType,
-  SegmentAPIIntegrations,
-  TrackEventType,
-  UserTraits,
-} from '../types';
 import { uploadEvents } from '../api';
-import * as context from '../context';
+import { EventType, TrackEventType } from '../types';
 
 describe('#sendEvents', () => {
   beforeEach(() => {
-    jest
-      .spyOn(context, 'getContext')
-      .mockImplementationOnce(
-        async (userTraits?: UserTraits): Promise<Context> => {
-          return {
-            traits: userTraits ?? {},
-          } as Context;
-        }
-      );
-
     jest
       .spyOn(Date.prototype, 'toISOString')
       .mockReturnValue('2001-01-01T00:00:00.000Z');
@@ -40,20 +23,8 @@ describe('#sendEvents', () => {
       messageId: '1d1744bf-5beb-41ac-ad7a-943eac33babc',
     };
 
-    // Context and Integration exist on SegmentEvents but are transmitted separately to avoid duplication
-    const additionalEventProperties: {
-      context: Context;
-      integrations: SegmentAPIIntegrations;
-    } = {
-      context: await context.getContext({ name: 'Hello' }),
-      integrations: {
-        Firebase: false,
-      },
-    };
-
     const event = {
       ...serializedEventProperties,
-      ...additionalEventProperties,
     };
 
     await uploadEvents({

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -5,13 +5,24 @@ import {
   AppStateStatus,
   NativeEventSubscription,
 } from 'react-native';
+import type {
+  DeviceInfoProvider,
+  SegmentAPIConsentSettings,
+  UUIDProvider,
+} from '.';
 import {
+  defaultFlushAt,
+  defaultFlushInterval,
   settingsCDN,
   workspaceDestinationFilterKey,
-  defaultFlushInterval,
-  defaultFlushAt,
 } from './constants';
-import { getContext } from './context';
+import { defaultContext, getContext } from './context';
+import {
+  ErrorType,
+  SegmentError,
+  checkResponseForErrors,
+  translateHTTPError,
+} from './errors';
 import {
   createAliasEvent,
   createGroupEvent,
@@ -19,47 +30,43 @@ import {
   createScreenEvent,
   createTrackEvent,
 } from './events';
+import type { FlushPolicy } from './flushPolicies';
 import {
   CountFlushPolicy,
   Observable,
   TimerFlushPolicy,
 } from './flushPolicies';
 import { FlushPolicyExecuter } from './flushPolicies/flush-policy-executer';
+import { AnalyticsReactNativeModule } from './native-module';
 import type { DestinationPlugin, PlatformPlugin, Plugin } from './plugin';
 import { SegmentDestination } from './plugins/SegmentDestination';
 import {
-  createGetter,
   DeepLinkData,
   Settable,
   Storage,
   Watchable,
+  createGetter,
 } from './storage';
 import { Timeline } from './timeline';
-import { DestinationFilters, EventType, SegmentAPISettings } from './types';
 import {
   Config,
   Context,
   DeepPartial,
+  DestinationFilters,
+  EventType,
   GroupTraits,
   IntegrationSettings,
   JsonMap,
   LoggerType,
   PluginType,
   SegmentAPIIntegrations,
+  SegmentAPISettings,
   SegmentEvent,
   UserInfoState,
   UserTraits,
 } from './types';
 import { allSettled, getPluginsWithFlush, getPluginsWithReset } from './util';
 import { getUUID } from './uuid';
-import type { FlushPolicy } from './flushPolicies';
-import {
-  checkResponseForErrors,
-  ErrorType,
-  SegmentError,
-  translateHTTPError,
-} from './errors';
-import type { SegmentAPIConsentSettings } from '.';
 
 type OnPluginAddedCallback = (plugin: Plugin) => void;
 
@@ -132,6 +139,8 @@ export class SegmentClient {
 
   readonly deepLinkData: Watchable<DeepLinkData>;
 
+  readonly deviceInfoProvider: DeviceInfoProvider;
+  readonly uuidProvider: UUIDProvider;
   // private telemetry?: Telemetry;
 
   /**
@@ -166,15 +175,25 @@ export class SegmentClient {
     config,
     logger,
     store,
+    uuidProvider,
   }: {
     config: Config;
     logger: LoggerType;
     store: Storage;
+    uuidProvider?: UUIDProvider;
   }) {
     this.logger = logger;
     this.config = config;
     this.store = store;
     this.timeline = new Timeline();
+
+    this.deviceInfoProvider =
+      this.config.deviceInfoProvider ??
+      AnalyticsReactNativeModule?.getContextInfo ??
+      (() => Promise.resolve({ ...defaultContext }));
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    this.uuidProvider = uuidProvider ?? require('./uuid').getUUID;
 
     // Initialize the watchables
     this.context = {
@@ -599,7 +618,11 @@ export class SegmentClient {
    * Application Opened - the previously detected version is same as the current version
    */
   private async checkInstalledVersion() {
-    const context = await getContext(undefined, this.config);
+    const context = await getContext({
+      collectDeviceId: this.config?.collectDeviceId ?? false,
+      deviceInfoProvider: this.deviceInfoProvider,
+      uuidProvider: this.uuidProvider,
+    });
 
     const previousContext = this.store.context.get();
 
@@ -692,7 +715,8 @@ export class SegmentClient {
   async reset(resetAnonymousId = true) {
     try {
       const { anonymousId: currentId } = await this.store.userInfo.get(true);
-      const anonymousId = resetAnonymousId === true ? getUUID() : currentId;
+      const anonymousId =
+        resetAnonymousId === true ? this.uuidProvider() : currentId;
 
       await this.store.userInfo.set({
         anonymousId,
@@ -807,7 +831,7 @@ export class SegmentClient {
   private applyRawEventData = (event: SegmentEvent): SegmentEvent => {
     return {
       ...event,
-      messageId: getUUID(),
+      messageId: this.uuidProvider(),
       timestamp: new Date().toISOString(),
       integrations: event.integrations ?? {},
     } as SegmentEvent;

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -66,7 +66,6 @@ import {
   UserTraits,
 } from './types';
 import { allSettled, getPluginsWithFlush, getPluginsWithReset } from './util';
-import { getUUID } from './uuid';
 
 type OnPluginAddedCallback = (plugin: Plugin) => void;
 

--- a/packages/core/src/client.tsx
+++ b/packages/core/src/client.tsx
@@ -16,17 +16,21 @@ export const createClient = (config: Config) => {
     }
   }
   const clientConfig = { ...defaultConfig, ...config };
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const uuidProvider = config.uuidProvider ?? require('./uuid').getUUID;
 
   const segmentStore = new SovranStorage({
     storeId: config.writeKey,
     storePersistor: config.storePersistor,
     storePersistorSaveDelay: config.storePersistorSaveDelay,
+    uuidProvider: uuidProvider,
   });
 
   const client = new SegmentClient({
     config: clientConfig,
     logger,
     store: segmentStore,
+    uuidProvider: uuidProvider,
   });
 
   // We don't await the client to be initialized to let the user start attaching plugins and queueing events

--- a/packages/core/src/native-module.ts
+++ b/packages/core/src/native-module.ts
@@ -1,4 +1,4 @@
-import { NativeContextInfo } from './types';
+import { DeviceInfoProvider } from './types';
 import {
   NativeEventEmitter,
   NativeModule,
@@ -26,10 +26,6 @@ export const getNativeModule = (moduleName: string) => {
 };
 
 // Native Module types
-export interface GetContextConfig {
-  collectDeviceId: boolean;
-}
-
 export interface AnalyticsReactNativeModuleConstants {
   SET_ANONYMOUS_ID: string;
   SET_DEEPLINK: string;
@@ -37,13 +33,16 @@ export interface AnalyticsReactNativeModuleConstants {
 
 export type AnalyticsReactNativeModuleType = NativeModule &
   TurboModule & {
-    getContextInfo: (config: GetContextConfig) => Promise<NativeContextInfo>;
+    getContextInfo: DeviceInfoProvider;
   };
 
 export const AnalyticsReactNativeModule = (() => {
   const nativeModule = getNativeModule('AnalyticsReactNative');
 
-  if (nativeModule === undefined) {
+  if (
+    nativeModule === undefined &&
+    (Platform.OS === 'android' || Platform.OS === 'ios')
+  ) {
     warnMissingNativeModule();
     return;
   }

--- a/packages/core/src/plugins/__tests__/consent/idfa.test.ts
+++ b/packages/core/src/plugins/__tests__/consent/idfa.test.ts
@@ -49,7 +49,7 @@ describe('IDFA x Consent', () => {
 
     const idfaPlugin = new IdfaPlugin(false);
     client.add({
-      plugin: idfaPlugin,
+      plugin: idfaPlugin as Plugin,
     });
 
     await client.init();

--- a/packages/core/src/plugins/__tests__/consent/idfa.test.ts
+++ b/packages/core/src/plugins/__tests__/consent/idfa.test.ts
@@ -49,7 +49,9 @@ describe('IDFA x Consent', () => {
 
     const idfaPlugin = new IdfaPlugin(false);
     client.add({
-      plugin: idfaPlugin as Plugin,
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      plugin: idfaPlugin,
     });
 
     await client.init();

--- a/packages/core/src/storage/__tests__/sovranStorage.test.ts
+++ b/packages/core/src/storage/__tests__/sovranStorage.test.ts
@@ -79,7 +79,10 @@ describe('sovranStorage', () => {
   }
 
   it('works', async () => {
-    const sovran = new SovranStorage({ storeId: 'test' });
+    const sovran = new SovranStorage({
+      storeId: 'test',
+      uuidProvider: () => 'mocked-uuid',
+    });
     await commonAssertions(sovran);
   });
 
@@ -97,12 +100,17 @@ describe('sovranStorage', () => {
     const sovran = new SovranStorage({
       storeId: 'custom-persistor',
       storePersistor: CustomPersistor,
+      uuidProvider: () => 'mocked-uuid',
     });
     await commonAssertions(sovran);
   });
 
   it('adds/removes pending events', async () => {
-    const sovran = new SovranStorage({ storeId: 'test' });
+    const sovran = new SovranStorage({
+      storeId: 'test',
+      uuidProvider: () => 'mocked-uuid',
+    });
+
     expect(sovran.pendingEvents.get().length).toBe(0);
 
     const event: SegmentEvent = {

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -8,6 +8,7 @@ import type {
   RoutingRule,
   SegmentAPIIntegrations,
   SegmentEvent,
+  UUIDProvider,
   UserInfoState,
 } from '../types';
 
@@ -98,4 +99,5 @@ export type StorageConfig = {
   storeId: string;
   storePersistor?: Persistor;
   storePersistorSaveDelay?: number;
+  uuidProvider: UUIDProvider;
 };

--- a/packages/core/src/test-helpers/setupSegmentClient.ts
+++ b/packages/core/src/test-helpers/setupSegmentClient.ts
@@ -26,6 +26,7 @@ export const createTestClient = (
     },
     logger: getMockLogger(),
     store: store,
+    uuidProvider: () => 'mocked-uuid',
   };
 
   const client = new SegmentClient(clientArgs);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -148,6 +148,16 @@ export type Config = {
   proxy?: string;
   cdnProxy?: string;
   errorHandler?: (error: SegmentError) => void;
+  /**
+   * DeviceInfoProvider lets you override the default device information provider that retrieves the device data like device id, device model, etc.
+   * This is useful for extending to new platforms or for testing purposes.
+   */
+  deviceInfoProvider?: DeviceInfoProvider;
+  /**
+   * UUIDProvider lets you override the default UUID provider that generates UUIDs
+   * UUIDs are used for anonymousId, messageId and instanceId.
+   */
+  uuidProvider?: UUIDProvider;
 };
 
 export type ClientMethods = {
@@ -353,3 +363,19 @@ export type UserInfoState = {
   userId?: string;
   traits?: UserTraits | GroupTraits;
 };
+
+export interface GetContextConfig {
+  collectDeviceId: boolean;
+}
+
+/**
+ * Provider that retrieves the device native information
+ */
+export type DeviceInfoProvider = (
+  config: GetContextConfig
+) => Promise<NativeContextInfo>;
+
+/**
+ * UUIDProvider generates the unique identifiers for messages and anonymousIDs
+ */
+export type UUIDProvider = () => string;

--- a/packages/core/src/uuid.ts
+++ b/packages/core/src/uuid.ts
@@ -1,7 +1,34 @@
-import 'react-native-get-random-values';
-import { v4 as uuidv4 } from 'uuid';
+// Note that we only import the type for Typescript purposes
+// The library is import dynamically to detect if it's installed first
+import type { v4 } from 'uuid';
+
+let uuidv4: typeof v4 | undefined;
+try {
+  // Try getting
+  require('react-native-get-random-values');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  uuidv4 = require('uuid')?.v4;
+} catch (error) {
+  console.warn(
+    "Segment: Tried to use the default UUID Generator but couldn't find package react-native-get-random-values.\n\
+        - Install 'react-native-get-random-values' to use the default UUID Generator\n\
+        - You might be missing the 'uuidProvider' argument in your client configuration to use your own UUID generator\n\
+        Execution will continue but will rely on an insecure UUID Generator. This warning will only show once."
+  );
+}
 
 export const getUUID = (): string => {
-  const UUID = uuidv4().toString();
-  return UUID;
+  return uuidv4?.().toString() ?? insecureRandomValues();
+};
+
+const insecureRandomValues = (): string => {
+  let d = new Date().getTime();
+  const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    // eslint-disable-next-line no-bitwise
+    const r = (d + Math.random() * 16) % 16 | 0;
+    d = Math.floor(d / 16);
+    // eslint-disable-next-line no-bitwise
+    return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
+  });
+  return uuid;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3608,12 +3608,12 @@ __metadata:
     jest: "npm:^29.7.0"
     js-base64: "npm:^3.7.5"
     typescript: "npm:^5.2.2"
-    uuid: "npm:^9.0.1"
   peerDependencies:
     "@react-native-async-storage/async-storage": 1.x
     react: "*"
     react-native: "*"
     react-native-get-random-values: 1.x
+    uuid: 9.x
   peerDependenciesMeta:
     "@react-native-async-storage/async-storage":
       optional: true
@@ -15176,15 +15176,6 @@ __metadata:
   version: 1.0.1
   resolution: "utils-merge@npm:1.0.1"
   checksum: 10c0/02ba649de1b7ca8854bfe20a82f1dfbdda3fb57a22ab4a8972a63a34553cf7aa51bc9081cf7e001b035b88186d23689d69e71b510e610a09a4c66f68aa95b672
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "uuid@npm:9.0.1"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/1607dd32ac7fc22f2d8f77051e6a64845c9bce5cd3dd8aa0070c074ec73e666a1f63c7b4e0f4bf2bc8b9d59dc85a15e17807446d9d2b17c8485fbc2147b27f9b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# feat: add uuid and device info provider config

Adds 2 new configuration options: `uuidProvider` and `deviceInfoProvider` to provide extensibility to other platforms like Windows, Web, Expo, etc.

## uuidProvider

```ts
export type UUIDProvider = () => string;
```

Supplies a simple UUID generator. By default it will try to use `react-native-get-random-values` unless one specific provider is passed. If the lib is not installed it will rely on JS random generators and log a warning

## deviceInfoProvider

```ts
export type DeviceInfoProvider = (
  config: GetContextConfig
) => Promise<NativeContextInfo>;
```

A function that returns the device context information. By default we will use our own native module if there's one available for the platform (Android & iOS).
