### PR TITLE
Fix: Pass `valueToSum` correctly to the Facebook SDK

### DIFF
--- a/packages/plugins/plugin-facebook-app-events/src/FacebookAppEventsPlugin.ts
+++ b/packages/plugins/plugin-facebook-app-events/src/FacebookAppEventsPlugin.ts
@@ -168,6 +168,8 @@ export class FacebookAppEventsPlugin extends DestinationPlugin {
       const purchasePrice = safeProps._valueToSum as number;
 
       AppEventsLogger.logPurchase(purchasePrice, currency, safeProps);
+    } else if (typeof safeProps._valueToSum === "number") {
+      AppEventsLogger.logEvent(safeName, safeProps._valueToSum, safeProps);
     } else {
       AppEventsLogger.logEvent(safeName, safeProps);
     }


### PR DESCRIPTION
**Changes list**
- The `_valueToSum` attribute is mapped to properties however the `logEvent` method gets `valueToSum` [from the second argument](https://github.com/thebergamo/react-native-fbsdk-next/blob/bfd6d6e6c5a3d5e6e15b0e8acececd4cf0703ec0/src/FBAppEventsLogger.ts#L156)

**Demo instructions**
Using this plugin, send an event with the `price` or `value` field. You should see that value in the `_valueToSum` field in the corresponding Facebook event

