### PR TITLE
Update timeToWaitForATTUserAuthorization in appsflyer plugin to be configurable

### DIFF
--- a/packages/plugins/plugin-appsflyer/src/AppsflyerPlugin.tsx
+++ b/packages/plugins/plugin-appsflyer/src/AppsflyerPlugin.tsx
@@ -14,6 +14,13 @@ import identify from './methods/identify';
 import track from './methods/track';
 
 export class AppsflyerPlugin extends DestinationPlugin {
+  constructor(props?: { timeToWaitForATTUserAuthorization: number }) {
+    super();
+    if (props != null) {
+      this.timeToWaitForATTUserAuthorization =
+        props.timeToWaitForATTUserAuthorization;
+    }
+  }
   type = PluginType.destination;
   key = 'AppsFlyer';
 
@@ -21,14 +28,14 @@ export class AppsflyerPlugin extends DestinationPlugin {
   private hasRegisteredInstallCallback = false;
   private hasRegisteredDeepLinkCallback = false;
   private hasInitialized = false;
+  timeToWaitForATTUserAuthorization = 60;
 
   async update(settings: SegmentAPISettings, _: UpdateType): Promise<void> {
     const defaultOpts = {
       isDebug: false,
-      timeToWaitForATTUserAuthorization: 60,
+      timeToWaitForATTUserAuthorization: this.timeToWaitForATTUserAuthorization,
       onInstallConversionDataListener: true,
     };
-
     const appsflyerSettings = settings.integrations[
       this.key
     ] as SegmentAppsflyerSettings;

--- a/packages/plugins/plugin-appsflyer/src/__tests__/AppsflyerPlugin.test.ts
+++ b/packages/plugins/plugin-appsflyer/src/__tests__/AppsflyerPlugin.test.ts
@@ -1,0 +1,17 @@
+import { AppsflyerPlugin } from '../AppsflyerPlugin';
+
+describe('#appsflyerPlugin', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('Appsflyer plugin without timeToWait', () => {
+    const plugin = new AppsflyerPlugin();
+    expect(plugin.timeToWaitForATTUserAuthorization).toEqual(60);
+  });
+  it('Appsflyer plugin with timeToWait', () => {
+    const plugin = new AppsflyerPlugin({
+      timeToWaitForATTUserAuthorization: 90,
+    });
+    expect(plugin.timeToWaitForATTUserAuthorization).toEqual(90);
+  });
+});


### PR DESCRIPTION
Issue - Cannot configure `timeToWaitForATTUserAuthorization` for `AppsflyerPlugin`

Fix - Update the code for timeToWaitForATTUserAuthorization in AppsflyerPlugin to be configurable and if do not pass then it will pick the default added value of timeToWaitForATTUserAuthorization.

Tested the updated code on android emulator.