### PR TITLE
Upgrade braze react native sdk to 10.x

### DIFF
--- a/packages/plugins/plugin-braze/package.json
+++ b/packages/plugins/plugin-braze/package.json
@@ -46,11 +46,11 @@
   },
   "homepage": "https://github.com/segmentio/analytics-react-native/tree/master/packages/plugins/plugin-braze#readme",
   "peerDependencies": {
-    "@braze/react-native-sdk": "^8.x",
+    "@braze/react-native-sdk": "^10.x",
     "@segment/analytics-react-native": "^2.18.0"
   },
   "devDependencies": {
-    "@braze/react-native-sdk": "^8.x",
+    "@braze/react-native-sdk": "^10.x",
     "@segment/analytics-react-native": "^2.18.0",
     "@segment/analytics-rn-shared": "workspace:^",
     "@segment/sovran-react-native": "^1.1.0",

--- a/packages/plugins/plugin-braze/package.json
+++ b/packages/plugins/plugin-braze/package.json
@@ -46,11 +46,11 @@
   },
   "homepage": "https://github.com/segmentio/analytics-react-native/tree/master/packages/plugins/plugin-braze#readme",
   "peerDependencies": {
-    "@braze/react-native-sdk": "^5.x",
+    "@braze/react-native-sdk": "^8.x",
     "@segment/analytics-react-native": "^2.18.0"
   },
   "devDependencies": {
-    "@braze/react-native-sdk": "^5.x",
+    "@braze/react-native-sdk": "^8.x",
     "@segment/analytics-react-native": "^2.18.0",
     "@segment/analytics-rn-shared": "workspace:^",
     "@segment/sovran-react-native": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3411,7 +3411,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@segment/analytics-react-native-plugin-branch@workspace:^, @segment/analytics-react-native-plugin-branch@workspace:packages/plugins/plugin-branch":
+"@segment/analytics-react-native-plugin-branch@workspace:packages/plugins/plugin-branch":
   version: 0.0.0-use.local
   resolution: "@segment/analytics-react-native-plugin-branch@workspace:packages/plugins/plugin-branch"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1702,10 +1702,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@braze/react-native-sdk@npm:^8.x":
-  version: 8.4.0
-  resolution: "@braze/react-native-sdk@npm:8.4.0"
-  checksum: 10c0/b5516157d5ebee6e7a0ea6c54b596aefa3f2c54670900b60e41141911e4386cda5783affd889a1c2395f0ede40775854f0f7c4397375f4d7ee066ce84a7cf4a1
+"@braze/react-native-sdk@npm:^10.x":
+  version: 10.0.0
+  resolution: "@braze/react-native-sdk@npm:10.0.0"
+  checksum: 10c0/711eceb505225536db32066a9c39433706c0d5de15f501fadf0dfe17d56e4f81a20f88e3256df38c39880617d6046391094b675ffc04445b4d3306f87d8796ef
   languageName: node
   linkType: hard
 
@@ -3411,7 +3411,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@segment/analytics-react-native-plugin-branch@workspace:packages/plugins/plugin-branch":
+"@segment/analytics-react-native-plugin-branch@workspace:^, @segment/analytics-react-native-plugin-branch@workspace:packages/plugins/plugin-branch":
   version: 0.0.0-use.local
   resolution: "@segment/analytics-react-native-plugin-branch@workspace:packages/plugins/plugin-branch"
   dependencies:
@@ -3450,7 +3450,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@segment/analytics-react-native-plugin-braze@workspace:packages/plugins/plugin-braze"
   dependencies:
-    "@braze/react-native-sdk": "npm:^8.x"
+    "@braze/react-native-sdk": "npm:^10.x"
     "@segment/analytics-react-native": "npm:^2.18.0"
     "@segment/analytics-rn-shared": "workspace:^"
     "@segment/sovran-react-native": "npm:^1.1.0"
@@ -3459,7 +3459,7 @@ __metadata:
     rimraf: "npm:^5.0.5"
     typescript: "npm:^5.2.2"
   peerDependencies:
-    "@braze/react-native-sdk": ^8.x
+    "@braze/react-native-sdk": ^10.x
     "@segment/analytics-react-native": ^2.18.0
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -1702,10 +1702,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@braze/react-native-sdk@npm:^5.x":
-  version: 5.2.0
-  resolution: "@braze/react-native-sdk@npm:5.2.0"
-  checksum: 10c0/5b3eb46d9a3b1df58a8aeff80ae09eae9d0f68dac3402d6168272fae258625dfddab212729861494e940d457bccc4e15828604e4bb09ec7bc8432f1fc59aaa89
+"@braze/react-native-sdk@npm:^8.x":
+  version: 8.4.0
+  resolution: "@braze/react-native-sdk@npm:8.4.0"
+  checksum: 10c0/b5516157d5ebee6e7a0ea6c54b596aefa3f2c54670900b60e41141911e4386cda5783affd889a1c2395f0ede40775854f0f7c4397375f4d7ee066ce84a7cf4a1
   languageName: node
   linkType: hard
 
@@ -3450,7 +3450,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@segment/analytics-react-native-plugin-braze@workspace:packages/plugins/plugin-braze"
   dependencies:
-    "@braze/react-native-sdk": "npm:^5.x"
+    "@braze/react-native-sdk": "npm:^8.x"
     "@segment/analytics-react-native": "npm:^2.18.0"
     "@segment/analytics-rn-shared": "workspace:^"
     "@segment/sovran-react-native": "npm:^1.1.0"
@@ -3459,7 +3459,7 @@ __metadata:
     rimraf: "npm:^5.0.5"
     typescript: "npm:^5.2.2"
   peerDependencies:
-    "@braze/react-native-sdk": ^5.x
+    "@braze/react-native-sdk": ^8.x
     "@segment/analytics-react-native": ^2.18.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Updated the braze react native sdk from 5.x to 10.x (latest version).

The latest version of braze react native sdk supports react native version 0.73 which is not supported in barze sdk 5.x.

Tested from local system using emulator.