### PR TITLE
Fix the destination key for Branch plugin

### DIFF
--- a/packages/plugins/plugin-branch/src/BranchPlugin.ts
+++ b/packages/plugins/plugin-branch/src/BranchPlugin.ts
@@ -14,7 +14,7 @@ import reset from './methods/reset';
 
 export class BranchPlugin extends DestinationPlugin {
   type = PluginType.destination;
-  key = 'Branch';
+  key = 'Branch Metrics';
 
   identify(event: IdentifyEventType) {
     identify(event);


### PR DESCRIPTION
Issue - The plugin does not get activated

Fix - Update the destination key for the branch plugin