### PR TITLE
feat: Refactor API uploadEvents function

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -9,12 +9,17 @@ export const uploadEvents = async ({
   url: string;
   events: SegmentEvent[];
 }) => {
+  const context = events.find((event) => !!event.context)?.context;
+  const integrations = events.find((event) => !!event.integrations)?.integrations;
+  let sentEvents = events.map(({context,integrations, ...event}) => (event));
   return await fetch(url, {
     method: 'POST',
     body: JSON.stringify({
-      batch: events,
+      batch: sentEvents,
       sentAt: new Date().toISOString(),
       writeKey: writeKey,
+      context: context,
+      integrations: integrations,
     }),
     headers: {
       'Content-Type': 'application/json; charset=utf-8',


### PR DESCRIPTION
as suggested here: https://github.com/segmentio/analytics-react-native/issues/961#event-13380371229

This greatly limits the size of the payloads sent 

We have been using it in production for 3 weeks without any problem