### PR TITLE
Added the missing property mappings for the firebase plugin

### DIFF
--- a/packages/plugins/plugin-firebase/src/methods/parameterMapping.ts
+++ b/packages/plugins/plugin-firebase/src/methods/parameterMapping.ts
@@ -27,6 +27,12 @@ export const mapEventProps: { [key: string]: string } = {
   productId: 'item_id',
   category: 'item_category',
   query: 'search_term',
+  order_id: 'transaction_id',
+  quantity: 'quantity',
+  shipping: 'shipping',
+  tax: 'tax',
+  revenue: 'revenue',
+  currency: 'currency',
 };
 
 export const transformMap: { [key: string]: (value: unknown) => unknown } = {


### PR DESCRIPTION
Issue : A customer wrote in with an issue about order_id not getting mapped to transaction_id as expected. From our external documentation it seems as though some mappings are missing with our React Native Firebase plugin.

Fix : Added the missing property mappings for the firebase plugin