### PR TITLE
chore: relax firebase peer dependency constraint

### DIFF
--- a/packages/plugins/plugin-firebase/package.json
+++ b/packages/plugins/plugin-firebase/package.json
@@ -44,8 +44,8 @@
   },
   "homepage": "https://github.com/segmentio/analytics-react-native/tree/master/packages/plugins/plugin-firebase#readme",
   "peerDependencies": {
-    "@react-native-firebase/analytics": "^18.4.0",
-    "@react-native-firebase/app": "^18.4.0",
+    "@react-native-firebase/analytics": ">=18.4.0",
+    "@react-native-firebase/app": ">=18.4.0",
     "@segment/analytics-react-native": "^2.18.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3555,8 +3555,8 @@ __metadata:
     rimraf: "npm:^5.0.5"
     typescript: "npm:^5.2.2"
   peerDependencies:
-    "@react-native-firebase/analytics": ^18.4.0
-    "@react-native-firebase/app": ^18.4.0
+    "@react-native-firebase/analytics": ">=18.4.0"
+    "@react-native-firebase/app": ">=18.4.0"
     "@segment/analytics-react-native": ^2.18.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Current peer dependency constraint is several major versions out of sync with latest and cause noisy warnings despite working fine. This PR relaxes them. 