### PR TITLE
fix: check enrichment closure type before calling it

### DIFF
--- a/packages/core/src/timeline.ts
+++ b/packages/core/src/timeline.ts
@@ -75,7 +75,7 @@ export class Timeline {
       if (key !== PluginType.destination) {
         if (result === undefined) {
           return;
-        } else if (key === PluginType.enrichment && pluginResult?.enrichment) {
+        } else if (key === PluginType.enrichment && pluginResult?.enrichment && typeof pluginResult.enrichment === 'function') {
           result = pluginResult.enrichment(pluginResult);
         } else {
           result = pluginResult;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -153,12 +153,12 @@ export type Config = {
 };
 
 export type ClientMethods = {
-  screen: (name: string, properties?: JsonMap) => Promise<void>;
-  track: (event: string, properties?: JsonMap) => Promise<void>;
-  identify: (userId?: string, userTraits?: UserTraits) => Promise<void>;
+  screen: (name: string, properties?: JsonMap, enrichment?: EnrichmentClosure) => Promise<void>;
+  track: (event: string, properties?: JsonMap, enrichment?: EnrichmentClosure) => Promise<void>;
+  identify: (userId?: string, userTraits?: UserTraits, enrichment?: EnrichmentClosure) => Promise<void>;
   flush: () => Promise<void>;
-  group: (groupId: string, groupTraits?: GroupTraits) => Promise<void>;
-  alias: (newUserId: string) => Promise<void>;
+  group: (groupId: string, groupTraits?: GroupTraits, enrichment?: EnrichmentClosure) => Promise<void>;
+  alias: (newUserId: string, enrichment?: EnrichmentClosure) => Promise<void>;
   reset: (resetAnonymousId?: boolean) => Promise<void>;
 };
 


### PR DESCRIPTION
* fix enrichment closure crash mentioned in #1011. the closure somehow gets injected as an object
* add enrichment closure to `userAnalytics` hook