### PR TITLE
fix: advertising id being sent for Android application installed events using analytics-react-native-plugin-advertsing-id

### DIFF
--- a/packages/core/src/plugins/QueueFlushingPlugin.ts
+++ b/packages/core/src/plugins/QueueFlushingPlugin.ts
@@ -84,15 +84,15 @@ export class QueueFlushingPlugin extends UtilityPlugin {
       }
     } catch (e) {
       // If the queue is not restored before the timeout, we will notify but not block flushing events
-      this.analytics?.reportInternalError(
-        new SegmentError(
-          ErrorType.InitializationError,
-          'Queue restoration timeout',
-          e
-        )
-      );
-
       if (this.timeoutWarned === false) {
+        this.analytics?.reportInternalError(
+          new SegmentError(
+            ErrorType.InitializationError,
+            'Queue restoration timeout',
+            e
+          )
+        );
+
         this.analytics?.logger.warn(
           'Flush triggered but queue restoration and settings loading not complete. Flush will be retried.',
           e


### PR DESCRIPTION
Fix for - Advertising Id not being sent for Android Application Installed events using analytics-react-native-plugin-advertising-id #995