### PR TITLE
fix: Prevent potential crash in Android SDK 35 by handling nullable versionName

### DIFF
--- a/packages/core/android/src/main/java/com/segmentanalyticsreactnative/AnalyticsReactNativeModule.kt
+++ b/packages/core/android/src/main/java/com/segmentanalyticsreactnative/AnalyticsReactNativeModule.kt
@@ -125,7 +125,7 @@ class AnalyticsReactNativeModule : ReactContextBaseJavaModule, ActivityEventList
   @ReactMethod
   fun getContextInfo(config: ReadableMap, promise: Promise) {
     val appName: String = reactApplicationContext.applicationInfo.loadLabel(reactApplicationContext.packageManager).toString()
-    val appVersion: String = pInfo.versionName
+    val appVersion: String = pInfo.versionName.toString()
     val buildNumber = getBuildNumber()
     val bundleId = reactApplicationContext.packageName
 
@@ -224,7 +224,7 @@ class AnalyticsReactNativeModule : ReactContextBaseJavaModule, ActivityEventList
       ?.getNativeModule(SovranModule::class.java)
     sovran?.dispatch("add-deepLink-data", properties)
 
-    
+
   }
 
   fun setAnonymousId(anonymousId: String) {


### PR DESCRIPTION
# Overview

<img width="679" alt="image" src="https://github.com/user-attachments/assets/7ad97af3-7c28-4ac8-8ceb-bea41f0e31f4">

This PR fixes a potential crash in Android SDK 35 by ensuring that versionName, which is now nullable, is safely converted to a string. This prevents crashes when versionName is null during app initialization.