### PR TITLE
fix: remove void promises from appsflyer plugin

### DIFF
--- a/packages/plugins/plugin-appsflyer/src/AppsflyerPlugin.tsx
+++ b/packages/plugins/plugin-appsflyer/src/AppsflyerPlugin.tsx
@@ -134,11 +134,11 @@ export class AppsflyerPlugin extends DestinationPlugin {
       }
       if (Boolean(is_first_launch) && JSON.parse(is_first_launch) === true) {
         if (af_status === 'Non-organic') {
-          void this.analytics?.track('Install Attributed', properties);
+          this.analytics?.track('Install Attributed', properties).then(() => this.analytics?.logger.info("Sent Install Attributed event to Segment"));
         } else {
-          void this.analytics?.track('Organic Install', {
+          this.analytics?.track('Organic Install', {
             provider: 'AppsFlyer',
-          });
+          }).then(() => this.analytics?.logger.info("Sent Organic Install event to Segment"));
         }
       }
     });


### PR DESCRIPTION
Hi there!

Opening a PR here to solve an issue we've been having when trying to integrate with the Segment Appsflyer plugin.
We're running an Expo app using React Native 0.74.5 with Hermes.

When adding the plugin to our Segment instance (and going through the rest of the integration steps as described in the documentation), we'd see the attribution data on Appsflyer, together with all of our Segment tracking events, indicating the integration went well. What was missing, though, were the `Install Attributed` and `Organic Install` events on Segment. Interestingly, this was only the case on production builds, development clients were working just fine.

After diving into this issue, I figured out that the `onInstallConversionData` callback is called as expected with the right data, but the `analytics.track` calls for emitting those missing events never end up getting called. 

I ended up patching the library on our side, adding `.then` handler to the `track()` calls, which suddenly made the Install events appear on Segment.

My hypothesis is that Hermes does some sort of performance optimization on production builds that keeps it from calling the promises all together, thinking they are not in use because of the lack of a promise handler (like `then` or `catch`). I used the `then` handler for an info log, but technically the content of it shouldn't matter here.

I'd love to get this merged so that we can remove the patch from our repo! Let me know what you think :)