### PR TITLE
Bumping minor version for new release

### DIFF
--- a/packages/sovran/package.json
+++ b/packages/sovran/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/sovran-react-native",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A cross-platform state management system",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Many are stuck on sovran-react-native because the version in main has not yet been published. I don't know if you have automation to automatically publish on a version bump, but I'm hoping you do.

Fixes: #1006 