### PR TITLE
Fix for error: Type mismatch: inferred type is String? but String was expected

### DIFF
--- a/packages/core/android/src/main/java/com/segmentanalyticsreactnative/AnalyticsReactNativeModule.kt
+++ b/packages/core/android/src/main/java/com/segmentanalyticsreactnative/AnalyticsReactNativeModule.kt
@@ -125,7 +125,7 @@ class AnalyticsReactNativeModule : ReactContextBaseJavaModule, ActivityEventList
   @ReactMethod
   fun getContextInfo(config: ReadableMap, promise: Promise) {
     val appName: String = reactApplicationContext.applicationInfo.loadLabel(reactApplicationContext.packageManager).toString()
-    val appVersion: String = pInfo.versionName
+    val appVersion: String? = pInfo.versionName
     val buildNumber = getBuildNumber()
     val bundleId = reactApplicationContext.packageName
 


### PR DESCRIPTION
`node_modules/@segment/analytics-react-native/android/src/main/java/com/segmentanalyticsreactnative/AnalyticsReactNativeModule.kt:128:30 Type mismatch: inferred type is String? but String was expected`
