### PR TITLE
fix(adjust-plugin): update for compatibility with Adjust SDK v5

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -271,11 +271,8 @@ type SegmentAmplitudeIntegration = {
 export type SegmentAdjustSettings = {
   appToken: string;
   setEnvironmentProduction?: boolean;
-  setEventBufferingEnabled?: boolean;
   trackAttributionData?: boolean;
-  setDelay?: boolean;
   customEvents?: { [key: string]: string };
-  delayTime?: number;
 };
 
 export type SegmentBrazeSettings = {

--- a/packages/plugins/plugin-adjust/package.json
+++ b/packages/plugins/plugin-adjust/package.json
@@ -44,15 +44,15 @@
   },
   "homepage": "https://github.com/segmentio/analytics-react-native/tree/master/packages/plugins/plugin-adjust#readme",
   "peerDependencies": {
-    "@segment/analytics-react-native": "^2.18.0",
-    "react-native-adjust": "^4.33.0"
+    "@segment/analytics-react-native": "^2.20.3",
+    "react-native-adjust": "^5.0.4"
   },
   "devDependencies": {
-    "@segment/analytics-react-native": "^2.18.0",
+    "@segment/analytics-react-native": "^2.20.3",
     "@segment/analytics-rn-shared": "workspace:^",
     "@segment/sovran-react-native": "^1.1.0",
     "jest": "^29.7.0",
-    "react-native-adjust": "^4.33.0",
+    "react-native-adjust": "^5.0.4",
     "react-native-builder-bob": "^0.23.1",
     "rimraf": "^5.0.5",
     "typescript": "^5.2.2"

--- a/packages/plugins/plugin-adjust/src/AdjustPlugin.tsx
+++ b/packages/plugins/plugin-adjust/src/AdjustPlugin.tsx
@@ -38,7 +38,7 @@ export class AdjustPlugin extends DestinationPlugin {
     const adjustConfig = new AdjustConfig(this.settings.appToken, environment);
 
     if (this.hasRegisteredCallback === false) {
-      adjustConfig.setAttributionCallbackListener((attribution) => {
+      adjustConfig.setAttributionCallback((attribution) => {
         const trackPayload = {
           provider: 'Adjust',
           trackerToken: attribution.trackerToken,
@@ -56,20 +56,7 @@ export class AdjustPlugin extends DestinationPlugin {
       this.hasRegisteredCallback = true;
     }
 
-    const bufferingEnabled = this.settings.setEventBufferingEnabled;
-    if (bufferingEnabled === true) {
-      adjustConfig.setEventBufferingEnabled(bufferingEnabled);
-    }
-
-    const useDelay = this.settings.setDelay;
-    if (useDelay === true) {
-      const delayTime = this.settings.delayTime;
-      if (delayTime !== null && delayTime !== undefined) {
-        adjustConfig.setDelayStart(delayTime);
-      }
-    }
-
-    Adjust.create(adjustConfig);
+    Adjust.initSdk(adjustConfig);
   }
   identify(event: IdentifyEventType) {
     identify(event);

--- a/packages/plugins/plugin-adjust/src/methods/__mocks__/react-native-adjust.ts
+++ b/packages/plugins/plugin-adjust/src/methods/__mocks__/react-native-adjust.ts
@@ -1,10 +1,10 @@
-export const resetSessionPartnerParameters = jest.fn();
-export const addSessionPartnerParameter = jest.fn();
+export const removeGlobalPartnerParameters = jest.fn();
+export const addGlobalPartnerParameter = jest.fn();
 export const trackEvent = jest.fn();
 
 export const Adjust = {
-  resetSessionPartnerParameters,
-  addSessionPartnerParameter,
+  removeGlobalPartnerParameters,
+  addGlobalPartnerParameter,
   trackEvent,
 };
 

--- a/packages/plugins/plugin-adjust/src/methods/__tests__/identify.test.ts
+++ b/packages/plugins/plugin-adjust/src/methods/__tests__/identify.test.ts
@@ -1,6 +1,6 @@
 import identify from '../identify';
 import type { IdentifyEventType } from '@segment/analytics-react-native';
-import { addSessionPartnerParameter } from '../__mocks__/react-native-adjust';
+import { addGlobalPartnerParameter } from '../__mocks__/react-native-adjust';
 
 describe('#identify', () => {
   beforeEach(() => {
@@ -15,7 +15,7 @@ describe('#identify', () => {
 
     identify(payload as IdentifyEventType);
 
-    expect(addSessionPartnerParameter).toHaveBeenCalledWith('user_id', 'user');
+    expect(addGlobalPartnerParameter).toHaveBeenCalledWith('user_id', 'user');
   });
 
   it('sets the anonymous_id', () => {
@@ -26,7 +26,7 @@ describe('#identify', () => {
 
     identify(payload as IdentifyEventType);
 
-    expect(addSessionPartnerParameter).toHaveBeenCalledWith(
+    expect(addGlobalPartnerParameter).toHaveBeenCalledWith(
       'anonymous_id',
       'anon'
     );

--- a/packages/plugins/plugin-adjust/src/methods/__tests__/reset.test.ts
+++ b/packages/plugins/plugin-adjust/src/methods/__tests__/reset.test.ts
@@ -1,5 +1,5 @@
 import reset from '../reset';
-import { resetSessionPartnerParameters } from '../__mocks__/react-native-adjust';
+import { removeGlobalPartnerParameters } from '../__mocks__/react-native-adjust';
 
 describe('#reset', () => {
   beforeEach(() => {
@@ -9,7 +9,7 @@ describe('#reset', () => {
   it('calls resetSessionPartnerParameters', () => {
     reset();
 
-    expect(resetSessionPartnerParameters).toHaveBeenCalledTimes(1);
-    expect(resetSessionPartnerParameters).toHaveBeenCalledWith();
+    expect(removeGlobalPartnerParameters).toHaveBeenCalledTimes(1);
+    expect(removeGlobalPartnerParameters).toHaveBeenCalledWith();
   });
 });

--- a/packages/plugins/plugin-adjust/src/methods/__tests__/track.test.ts
+++ b/packages/plugins/plugin-adjust/src/methods/__tests__/track.test.ts
@@ -28,7 +28,7 @@ describe('#track', () => {
 
     track(event as TrackEventType, settings);
 
-    expect(Adjust.addSessionPartnerParameter).toHaveBeenCalledWith(
+    expect(Adjust.addGlobalPartnerParameter).toHaveBeenCalledWith(
       'anonymous_id',
       'anon'
     );
@@ -54,7 +54,7 @@ describe('#track', () => {
 
     track(event as TrackEventType, settings);
 
-    expect(Adjust.addSessionPartnerParameter).toHaveBeenCalledWith(
+    expect(Adjust.addGlobalPartnerParameter).toHaveBeenCalledWith(
       'anonymous_id',
       'anon'
     );
@@ -85,7 +85,7 @@ describe('#track', () => {
 
     track(event as TrackEventType, settings);
 
-    expect(Adjust.addSessionPartnerParameter).toHaveBeenCalledWith(
+    expect(Adjust.addGlobalPartnerParameter).toHaveBeenCalledWith(
       'anonymous_id',
       'anon'
     );
@@ -114,7 +114,7 @@ describe('#track', () => {
 
     track(event as TrackEventType, settings);
 
-    expect(Adjust.addSessionPartnerParameter).toHaveBeenCalledWith(
+    expect(Adjust.addGlobalPartnerParameter).toHaveBeenCalledWith(
       'anonymous_id',
       'anon'
     );

--- a/packages/plugins/plugin-adjust/src/methods/identify.ts
+++ b/packages/plugins/plugin-adjust/src/methods/identify.ts
@@ -4,11 +4,11 @@ import type { IdentifyEventType } from '@segment/analytics-react-native';
 export default (event: IdentifyEventType) => {
   const userId = event.userId;
   if (userId !== undefined && userId !== null && userId.length > 0) {
-    Adjust.addSessionPartnerParameter('user_id', userId);
+    Adjust.addGlobalPartnerParameter('user_id', userId);
   }
 
   const anonId = event.anonymousId;
   if (anonId !== undefined && anonId !== null && anonId.length > 0) {
-    Adjust.addSessionPartnerParameter('anonymous_id', anonId);
+    Adjust.addGlobalPartnerParameter('anonymous_id', anonId);
   }
 };

--- a/packages/plugins/plugin-adjust/src/methods/reset.ts
+++ b/packages/plugins/plugin-adjust/src/methods/reset.ts
@@ -1,5 +1,5 @@
 import { Adjust } from 'react-native-adjust';
 
 export default () => {
-  Adjust.resetSessionPartnerParameters();
+  Adjust.removeGlobalPartnerParameters();
 };

--- a/packages/plugins/plugin-adjust/src/methods/track.ts
+++ b/packages/plugins/plugin-adjust/src/methods/track.ts
@@ -8,7 +8,7 @@ import { extract, mappedCustomEventToken } from '../util';
 export default (event: TrackEventType, settings: SegmentAdjustSettings) => {
   const anonId = event.anonymousId;
   if (anonId !== undefined && anonId !== null && anonId.length > 0) {
-    Adjust.addSessionPartnerParameter('anonymous_id', anonId);
+    Adjust.addGlobalPartnerParameter('anonymous_id', anonId);
   }
 
   const token = mappedCustomEventToken(event.event, settings);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3346,17 +3346,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@segment/analytics-react-native-plugin-adjust@workspace:packages/plugins/plugin-adjust"
   dependencies:
-    "@segment/analytics-react-native": "npm:^2.18.0"
+    "@segment/analytics-react-native": "npm:^2.20.3"
     "@segment/analytics-rn-shared": "workspace:^"
     "@segment/sovran-react-native": "npm:^1.1.0"
     jest: "npm:^29.7.0"
-    react-native-adjust: "npm:^4.33.0"
+    react-native-adjust: "npm:^5.0.4"
     react-native-builder-bob: "npm:^0.23.1"
     rimraf: "npm:^5.0.5"
     typescript: "npm:^5.2.2"
   peerDependencies:
-    "@segment/analytics-react-native": ^2.18.0
-    react-native-adjust: ^4.33.0
+    "@segment/analytics-react-native": ^2.20.3
+    react-native-adjust: ^5.0.4
   languageName: unknown
   linkType: soft
 
@@ -3615,7 +3615,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@segment/analytics-react-native@npm:^2.18.0, @segment/analytics-react-native@workspace:packages/core":
+"@segment/analytics-react-native@npm:^2.18.0, @segment/analytics-react-native@npm:^2.20.3, @segment/analytics-react-native@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@segment/analytics-react-native@workspace:packages/core"
   dependencies:
@@ -13096,10 +13096,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-adjust@npm:^4.33.0":
-  version: 4.37.1
-  resolution: "react-native-adjust@npm:4.37.1"
-  checksum: 10c0/463ddb7284bebe7a88d969e0a2dc4a84e039216f016d764ad916078b0fac060ba4cf275ac84d7e32c0b020632c2d9755791603118ee9cee84cba8336e94ca18b
+"react-native-adjust@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "react-native-adjust@npm:5.0.4"
+  checksum: 10c0/8df9e475e48c11b493b873d585407e7747c8858923d808108e98080b77afd3b6502496875bc98f9eaadf86004d93001df67a7d75394bae870bcd219f3ef2d3e3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Fix Adjust Plugin Compatibility with Adjust React Native SDK v5  

**Summary**  
Adjust released v5 of its [[React Native SDK](https://github.com/adjust/react_native_sdk)](https://github.com/adjust/react_native_sdk), introducing some breaking changes. The Adjust team has provided a [[migration guide](https://dev.adjust.com/en/sdk/migration/react-native/v4-to-v5)](https://dev.adjust.com/en/sdk/migration/react-native/v4-to-v5) detailing these changes.  

Currently, these breaking changes cause the `analytics-react-native` Adjust plugin to fail, as reported in [[issue #1036](https://github.com/segmentio/analytics-react-native/issues/1036)](https://github.com/segmentio/analytics-react-native/issues/1036).  

This PR updates the Adjust plugin to be compatible with Adjust React Native SDK v5 while ensuring continued functionality.  

**Changes**  
- Refactored the Adjust integration to align with Adjust v5 API changes.  
- Updated method calls, event handling, and initialization flow to match the new SDK requirements.  
- Ensured backward compatibility where feasible.  
- Added necessary adjustments to maintain proper tracking and attribution behavior.  

**Testing**  
- Verified that the plugin correctly initializes and communicates with Adjust.  
- Ensured events are tracked as expected.  
- Checked for regressions in existing functionality.  

**Notes**  
This update is necessary for users who want to upgrade to Adjust SDK v5 while continuing to use `analytics-react-native`.  

Fixes #1036. 