### PR TITLE
fix: remove remaining void promises from appsflyer plugin

### DIFF
--- a/packages/plugins/plugin-appsflyer/src/AppsflyerPlugin.tsx
+++ b/packages/plugins/plugin-appsflyer/src/AppsflyerPlugin.tsx
@@ -167,7 +167,13 @@ export class AppsflyerPlugin extends DestinationPlugin {
             source: media_source,
           },
         };
-        void this.analytics?.track('Deep Link Opened', properties);
+        this.analytics
+          ?.track('Deep Link Opened', properties)
+          .then(() =>
+            this.analytics?.logger.info(
+              'Sent Deep Link Opened event to Segment'
+            )
+          );
       }
     });
   };
@@ -183,7 +189,13 @@ export class AppsflyerPlugin extends DestinationPlugin {
             source: media_source,
           },
         };
-        void this.analytics?.track('Deep Link Opened', properties);
+        this.analytics
+          ?.track('Deep Link Opened', properties)
+          .then(() =>
+            this.analytics?.logger.info(
+              'Sent Deep Link Opened event to Segment'
+            )
+          );
       }
     });
   };


### PR DESCRIPTION
This PR is following up on #1025 - in that PR, I removed some usages of `void` Promises in the AppsFlyer plugin that weren't properly triggered in my project. I missed some of them in the same project, so following up here.

Let me know if you have any questions about this!