### PR TITLE
feat: add callbacks to appsflyer plugin

### DIFF
--- a/packages/plugins/plugin-appsflyer/src/AppsflyerPlugin.tsx
+++ b/packages/plugins/plugin-appsflyer/src/AppsflyerPlugin.tsx
@@ -9,7 +9,11 @@ import {
   ErrorType,
 } from '@segment/analytics-react-native';
 import type { SegmentAppsflyerSettings } from './types';
-import appsFlyer from 'react-native-appsflyer';
+import appsFlyer, {
+  ConversionData,
+  OnAppOpenAttributionData,
+  UnifiedDeepLinkData,
+} from 'react-native-appsflyer';
 import identify from './methods/identify';
 import track from './methods/track';
 
@@ -19,6 +23,9 @@ export class AppsflyerPlugin extends DestinationPlugin {
     is_adset: boolean;
     is_adset_id: boolean;
     is_ad_id: boolean;
+    onDeepLink?: (data: UnifiedDeepLinkData) => void;
+    onInstallConversionData?: (data: ConversionData) => void;
+    onAppOpenAttribution?: (data: OnAppOpenAttributionData) => void;
   }) {
     super();
     if (props != null) {
@@ -28,6 +35,9 @@ export class AppsflyerPlugin extends DestinationPlugin {
       this.is_ad_id = props.is_ad_id === undefined ? false : props.is_ad_id;
       this.is_adset_id =
         props.is_adset_id === undefined ? false : props.is_adset_id;
+      this.onDeepLink = props.onDeepLink;
+      this.onInstallConversionData = props.onInstallConversionData;
+      this.onAppOpenAttribution = props.onAppOpenAttribution;
     }
   }
   type = PluginType.destination;
@@ -35,6 +45,9 @@ export class AppsflyerPlugin extends DestinationPlugin {
   is_adset = false;
   is_adset_id = false;
   is_ad_id = false;
+  onDeepLink?: (data: UnifiedDeepLinkData) => void;
+  onInstallConversionData?: (data: ConversionData) => void;
+  onAppOpenAttribution?: (data: OnAppOpenAttributionData) => void;
   private settings: SegmentAppsflyerSettings | null = null;
   private hasRegisteredInstallCallback = false;
   private hasRegisteredDeepLinkCallback = false;
@@ -153,6 +166,7 @@ export class AppsflyerPlugin extends DestinationPlugin {
             );
         }
       }
+      this.onInstallConversionData?.(res);
     });
   };
 
@@ -169,6 +183,7 @@ export class AppsflyerPlugin extends DestinationPlugin {
         };
         void this.analytics?.track('Deep Link Opened', properties);
       }
+      this.onAppOpenAttribution?.(res);
     });
   };
 
@@ -185,6 +200,7 @@ export class AppsflyerPlugin extends DestinationPlugin {
         };
         void this.analytics?.track('Deep Link Opened', properties);
       }
+      this.onDeepLink?.(res);
     });
   };
 }


### PR DESCRIPTION
This PR passes the three callbacks used in the appsflyer plugin out of the plugin as props.
[Appsflyer docs](https://dev.appsflyer.com/hc/docs/rn_unifieddeeplink) mention that the `onDeepLink` callback must be configured before initializing the SDK and as far as my testing goes, the callback cannot be defined more than once per SDK instance.

By adding props for the used callbacks, it's possible to use the callback logic used by the plugin and still specify custom deep link handlers.

Let me know if I'm missing something or if there is a better or easier way to solve this!