### PR TITLE
fix: example syntax is invalid

### DIFF
--- a/packages/sovran/README.md
+++ b/packages/sovran/README.md
@@ -99,7 +99,7 @@ const messages = createStore<MessageQueue>({
 
 // Action to add new events
 const addMessage = (message: Message) => (state: MessageQueue) =>
-  { messages: [...state.messages, message] };
+  ({ messages: [...state.messages, message] });
 
 // Register the store to listen to native events
 registerBridgeStore({


### PR DESCRIPTION
In js/ts, if you want an arrow function to return an object in an inline manner, it needs to be surrounded by parenthesis.