### PR TITLE
fix: fixed native module to get advertisingID

### DIFF
--- a/packages/plugins/plugin-advertising-id/android/src/main/java/com/reactnativeanalyticsreactnativepluginadvertisingid/AnalyticsReactNativePluginAdvertisingIdModule.kt
+++ b/packages/plugins/plugin-advertising-id/android/src/main/java/com/reactnativeanalyticsreactnativepluginadvertisingid/AnalyticsReactNativePluginAdvertisingIdModule.kt
@@ -1,64 +1,64 @@
 package com.analyticsreactnativepluginadvertisingid
 
-import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactContextBaseJavaModule
-import com.facebook.react.bridge.ReactMethod
-import com.facebook.react.bridge.Promise
-import com.facebook.react.ReactApplication
-import com.google.android.gms.ads.identifier.AdvertisingIdClient
-import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
+import com.facebook.react.bridge.*
 import com.facebook.react.module.annotations.ReactModule
-import android.util.Log
-import java.io.IOException;
+import com.google.android.gms.ads.identifier.AdvertisingIdClient
+import kotlinx.coroutines.*
 
+@ReactModule(name = "AnalyticsReactNativePluginAdvertisingId")
 
-@ReactModule(name="AnalyticsReactNativePluginAdvertisingId")
-class AnalyticsReactNativePluginAdvertisingIdModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
-  override fun getName(): String {
-      return "AnalyticsReactNativePluginAdvertisingId"
-  }
+class AnalyticsReactNativePluginAdvertisingIdModule(
+    private val reactContext: ReactApplicationContext
+) : ReactContextBaseJavaModule(reactContext) {
 
- @ReactMethod
-  fun getAdvertisingId(promise: Promise) {
-    getAdvertisingIdInfo(promise) { advertisingInfo ->
-            val id = advertisingInfo.id
-            promise.resolve(id.toString())
-        }
- }
+    override fun getName(): String {
+        return "AnalyticsReactNativePluginAdvertisingId"
+    }
 
- @ReactMethod
-  fun getIsLimitAdTrackingEnableStatus(promise: Promise) {
-    getAdvertisingIdInfo(promise) { advertisingInfo ->
-            val isLimitAdTrackingEnabled = advertisingInfo.isLimitAdTrackingEnabled
-            promise.resolve(isLimitAdTrackingEnabled)
-        }
- }
+   /**
+     * Return only the advertising ID string
+     */
+    @ReactMethod
+    fun getAdvertisingId(promise: Promise) {
+        Thread {
+            try {
+                val info = AdvertisingIdClient.getAdvertisingIdInfo(reactContext)
+                promise.resolve(info.id ?: "")
+            } catch (e: Exception) {
+                promise.reject("ERROR", e)
+            }
+        }.start()
+    }
+    /**
+     * Return only the "is limit ad tracking enabled" status
+     */
+    @ReactMethod
+    fun getIsLimitAdTrackingEnableStatus(promise: Promise) {
+        Thread {
+            try {
+                val info = AdvertisingIdClient.getAdvertisingIdInfo(reactContext)
+                promise.resolve(info.isLimitAdTrackingEnabled ?: false)
+            } catch (e: Exception) {
+                promise.reject("ERROR", e)
+            }
+        }.start()
+    }
 
- private fun getAdvertisingIdInfo(promise: Promise, callback: (AdvertisingIdClient.Info) -> Unit) {
-        if (currentActivity?.application == null) {
-            promise.resolve(null)
-            return
-        }
-
-        val reactContext = (currentActivity?.application as ReactApplication)
-            ?.reactNativeHost
-            ?.reactInstanceManager
-            ?.currentReactContext
-
-        if (reactContext == null) {
-            promise.resolve(null)
-            return
-        }
-
-        try {
-            val advertisingInfo = AdvertisingIdClient.getAdvertisingIdInfo(reactContext)
-            callback(advertisingInfo)
-        } catch (e: GooglePlayServicesNotAvailableException) {
-            Log.d(name, e.toString())
-            promise.resolve(null)
-        } catch (e: IOException) {
-            Log.d(name, e.toString())
-            promise.resolve(null)
-        }
+    /**
+     * Return both values together
+     */
+    @ReactMethod
+    fun getAdvertisingInfo(promise: Promise) {
+        Thread {
+            try {
+                val info = AdvertisingIdClient.getAdvertisingIdInfo(reactContext)
+                val result = Arguments.createMap()
+                result.putString("advertisingId", info.id ?: "")
+                result.putBoolean("isLimitAdTrackingEnabled", info.isLimitAdTrackingEnabled ?: false)
+                promise.resolve(result)
+            } catch (e: Exception) {
+                promise.reject("ERROR", e)
+            }
+        }.start()
     }
 }


### PR DESCRIPTION
Changes are done to fix the github issue raised [here](https://github.com/segmentio/analytics-react-native/issues/1088)
Background: 
In December 2024, RN released v0.75, which had major architectural changes. One of the biggest changes was how RN 0.75+ pipe data between the RN Javascript layer, vs. native layer. 

Problem Statement:
Our native module started failing after 0.76 RN version

Fix:
Right now we had made changes to provide the quick fix by updating the native module. But this is short term solution, in long run, it's better we convert our legacy bridge-based native module to Turbo Module

