### PR TITLE
feat(core): Enable keepalive for fetch requests

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -11,6 +11,7 @@ export const uploadEvents = async ({
 }) => {
   return await fetch(url, {
     method: 'POST',
+    keepalive: true,
     body: JSON.stringify({
       batch: events,
       sentAt: new Date().toISOString(),


### PR DESCRIPTION
Add the [`keepalive`](https://developer.mozilla.org/en-US/docs/Web/API/Request/keepalive) option so that, when used in web contexts, incomplete requests don't get cancelled if the page unloads before the request completes.