### PR TITLE
fix(release): ignore shells directory in multi-semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint .",
     "format": "treefmt --clear-cache",
     "format:check": "treefmt --clear-cache --fail-on-change",
-    "release": "yarn multi-semantic-release"
+    "release": "yarn multi-semantic-release --ignore-packages shells"
   },
   "devDependencies": {
     "@anolilab/multi-semantic-release": "^1.0.3",

--- a/shells/devbox-fast.json
+++ b/shells/devbox-fast.json
@@ -15,12 +15,12 @@
         "npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}",
         "yarn install --immutable",
         "yarn build",
-        "yarn release"
+        "yarn multi-semantic-release --ignore-packages shells"
       ],
       "release-dry-run": [
         "yarn install --immutable",
         "yarn build",
-        "yarn multi-semantic-release --dry-run"
+        "yarn multi-semantic-release --dry-run --ignore-packages shells"
       ],
       "format": ["treefmt"],
       "lint": ["treefmt --fail-on-change"],


### PR DESCRIPTION
Add --ignore-packages shells flag to prevent multi-semantic-release from treating the shells/ directory as a package to be released.

The shells/ directory contains devbox environment configurations (devbox.json files), not npm packages, so it should be excluded from the release process.

Multi-semantic-release aggressively scans all directories for potential packages, not just those in the workspaces field. When it encounters shells/, it expects a package.json and fails with ENOENT.

Changes:
- Add --ignore-packages shells to release script in package.json
- Add --ignore-packages shells to both release and release-dry-run scripts in shells/devbox-fast.json

This fixes the release dry-run workflow failure.