### PR TITLE
fix(release): fix CWD issue and add beta pre-release workflow

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -1,0 +1,57 @@
+name: Release Beta (Pre-release)
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: release-beta
+  cancel-in-progress: true
+
+jobs:
+  fast-checks:
+    name: Build + Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: devbox installer
+        uses: jetify-com/devbox-install-action@v0.14.0
+        with:
+          project-path: shells/devbox-fast.json
+          enable-cache: 'false'
+      - name: build
+        run: devbox run --config=shells/devbox-fast.json build
+
+  publish-beta:
+    name: Publish Beta to npm
+    environment: Publish
+    needs: [fast-checks]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Point beta branch at current commit
+        run: |
+          git checkout -B beta HEAD
+          git push origin beta --force
+
+      - name: devbox installer
+        uses: jetify-com/devbox-install-action@v0.14.0
+        with:
+          project-path: shells/devbox-fast.json
+          enable-cache: 'false'
+
+      - name: Config, Build, Release (BETA)
+        run: |
+          echo "Publishing beta pre-release from $(git rev-parse --short HEAD) to npm @beta dist-tag"
+          devbox run --config=shells/devbox-fast.json release
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint .",
     "format": "treefmt --clear-cache",
     "format:check": "treefmt --clear-cache --fail-on-change",
-    "release": "yarn multi-semantic-release --ignore-packages shells"
+    "release": "yarn multi-semantic-release"
   },
   "devDependencies": {
     "@anolilab/multi-semantic-release": "^1.0.3",

--- a/shells/devbox-fast.json
+++ b/shells/devbox-fast.json
@@ -12,15 +12,17 @@
     "scripts": {
       "build": ["bash $SCRIPTS_DIR/build.sh"],
       "release": [
+        "cd \"$PROJECT_ROOT\"",
         "npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}",
         "yarn install --immutable",
         "yarn build",
-        "yarn multi-semantic-release --ignore-packages shells"
+        "yarn multi-semantic-release"
       ],
       "release-dry-run": [
+        "cd \"$PROJECT_ROOT\"",
         "yarn install --immutable",
         "yarn build",
-        "yarn multi-semantic-release --dry-run --ignore-packages shells"
+        "yarn multi-semantic-release --dry-run"
       ],
       "format": ["treefmt"],
       "lint": ["treefmt --fail-on-change"],

--- a/shells/devbox.lock
+++ b/shells/devbox.lock
@@ -1,34 +1,6 @@
 {
   "lockfile_version": "1",
   "packages": {
-    "cocoapods@latest": {
-      "last_modified": "2025-12-31T03:27:36Z",
-      "resolved": "github:NixOS/nixpkgs/f665af0cdb70ed27e1bd8f9fdfecaf451260fc55#cocoapods",
-      "source": "devbox-search",
-      "version": "1.16.2",
-      "systems": {
-        "aarch64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/av5g6hfp0yiir3iavg72js70ian8hxyf-cocoapods-1.16.2",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/av5g6hfp0yiir3iavg72js70ian8hxyf-cocoapods-1.16.2"
-        },
-        "x86_64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/har71589bwmh6h6skisd20b3c6lrwmz7-cocoapods-1.16.2",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/har71589bwmh6h6skisd20b3c6lrwmz7-cocoapods-1.16.2"
-        }
-      }
-    },
     "github:NixOS/nixpkgs/nixpkgs-unstable": {
       "last_modified": "2026-01-27T15:18:14Z",
       "resolved": "github:NixOS/nixpkgs/afce96367b2e37fc29afb5543573cd49db3357b7?lastModified=1769527094"
@@ -146,6 +118,150 @@
             }
           ],
           "store_path": "/nix/store/zssasryipb2x4gk2ahzacl4mvvcmk48j-jq-1.8.1-bin"
+        }
+      }
+    },
+    "nixfmt@latest": {
+      "last_modified": "2026-02-23T15:40:43Z",
+      "resolved": "github:NixOS/nixpkgs/80d901ec0377e19ac3f7bb8c035201e2e098cc97#nixfmt",
+      "source": "devbox-search",
+      "version": "1.2.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/igl44md7ljf5c3hx6s6ys6325fkpldny-nixfmt-1.2.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/igl44md7ljf5c3hx6s6ys6325fkpldny-nixfmt-1.2.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/s250gfxr6v1bmxdx9l8z4sn5fjf2bllb-nixfmt-1.2.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/s250gfxr6v1bmxdx9l8z4sn5fjf2bllb-nixfmt-1.2.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/jb1qw3g5hcslahl02v7mjaixwfw725g8-nixfmt-1.2.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/jb1qw3g5hcslahl02v7mjaixwfw725g8-nixfmt-1.2.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ihzhi2cgjfhvqbap36fx91hbj524ym5l-nixfmt-1.2.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/ihzhi2cgjfhvqbap36fx91hbj524ym5l-nixfmt-1.2.0"
+        }
+      }
+    },
+    "shfmt@latest": {
+      "last_modified": "2026-02-23T15:40:43Z",
+      "resolved": "github:NixOS/nixpkgs/80d901ec0377e19ac3f7bb8c035201e2e098cc97#shfmt",
+      "source": "devbox-search",
+      "version": "3.12.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/sc8kb91395fw69qcmij89m3bxdmj8gwb-shfmt-3.12.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/sc8kb91395fw69qcmij89m3bxdmj8gwb-shfmt-3.12.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/a80kl3brskqmq8k861x8hjwnlw94kyfn-shfmt-3.12.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/a80kl3brskqmq8k861x8hjwnlw94kyfn-shfmt-3.12.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/hax40r2y50jv8z0rlryfc11gvnhfx7hz-shfmt-3.12.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/hax40r2y50jv8z0rlryfc11gvnhfx7hz-shfmt-3.12.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/822axjnnxnscgxwval6lrc1bp5q4n9li-shfmt-3.12.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/822axjnnxnscgxwval6lrc1bp5q4n9li-shfmt-3.12.0"
+        }
+      }
+    },
+    "treefmt@latest": {
+      "last_modified": "2026-02-23T15:40:43Z",
+      "resolved": "github:NixOS/nixpkgs/80d901ec0377e19ac3f7bb8c035201e2e098cc97#treefmt",
+      "source": "devbox-search",
+      "version": "2.4.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/gza41a4j5hypl5vl6f7x5s0xgnx0g06h-treefmt-2.4.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/gza41a4j5hypl5vl6f7x5s0xgnx0g06h-treefmt-2.4.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/rz6d1w4a8gkkrd9gk4nfadskzyz75h4v-treefmt-2.4.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/rz6d1w4a8gkkrd9gk4nfadskzyz75h4v-treefmt-2.4.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/h7xb3dssb16yny6wg713w78lawivzjay-treefmt-2.4.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/h7xb3dssb16yny6wg713w78lawivzjay-treefmt-2.4.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/vp95nd69hq59rqpdlgrg63wncy4yw8fd-treefmt-2.4.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/vp95nd69hq59rqpdlgrg63wncy4yw8fd-treefmt-2.4.0"
         }
       }
     },


### PR DESCRIPTION
## Summary

- **Fix release ENOENT error**: When devbox runs scripts via `--config=shells/devbox-fast.json`, the CWD is set to `shells/`, not the project root. `multi-semantic-release` uses `process.cwd()` as the monorepo root, so `@semrel-extra/topo` tried to read `shells/package.json` which doesn't exist. Fixed by adding `cd "$PROJECT_ROOT"` as the first step in both `release` and `release-dry-run` scripts.

- **Add beta pre-release workflow**: New `release-beta.yml` workflow (manual trigger only) that publishes pre-release versions to the `@beta` npm dist-tag from the current `master` commit. It creates a temporary `beta` branch pointer so semantic-release produces versions like `2.22.0-beta.1`. To promote to stable, run the existing production release workflow.

- **Clean up git tags**: Created missing tags for 7 packages that were manually published to npm without going through semantic-release. Deleted orphaned `plugin-idfa-v0.7.3` tag (publish had failed, npm only has `0.7.2`). All 17 packages now have git tags aligned with their latest npm versions.

## Tags pushed separately

| Tag | Commit | Action |
|-----|--------|--------|
| `plugin-adjust-v0.8.0` | `9cd342c4` | Created |
| `plugin-advertising-id-v1.3.5` | `6e14e85c` | Created |
| `plugin-advertising-id-v1.3.6` | `409f9541` | Created |
| `plugin-amplitude-session-v0.4.1` | `71234792` | Created |
| `plugin-branch-v1.1.2` | `e079c719` | Created |
| `plugin-braze-v0.7.0` | `e079c719` | Created |
| `plugin-braze-v0.8.0` | `e4a90b64` | Created |
| `plugin-braze-v0.9.0` | `409f9541` | Created |
| `plugin-firebase-v0.4.3` | `6ffd96d3` | Created |
| `plugin-idfa-v0.7.3` | `7e9023a9` | Deleted |

## Test plan

- [x] Verified `release-dry-run` completes successfully locally with the CWD fix
- [ ] Merge and trigger Release (Dry Run) workflow in CI
- [ ] Test beta workflow by triggering it manually on master

🤖 Generated with [Claude Code](https://claude.com/claude-code)