### PR TITLE
fix(ci): grant write permission to dry-run release workflow

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -26,7 +26,7 @@ jobs:
     needs: [fast-checks]
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- semantic-release runs `git push --dry-run` even in dry-run mode to verify push permissions
- The workflow had `contents: read` which caused a 403 from `github-actions[bot]`
- Changed to `contents: write` so the permission check passes

No PAT (`GH_TOKEN` secret) is needed — the default `GITHUB_TOKEN` with write permission is sufficient since nothing is actually pushed.

## Test plan

- [ ] Trigger Release (Dry Run) workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)