### PR TITLE
fix(ci): use Publish environment for all release types

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
     name: Release (${{ inputs.type }})
     needs: [fast-checks]
     runs-on: ubuntu-latest
-    environment: ${{ inputs.type != 'dry-run' && 'Publish' || '' }}
+    environment: Publish
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
## Summary

npm trusted publishing OIDC tokens include the GitHub environment name. Since all 17 packages were configured on npmjs.com with environment `Publish`, the dry-run was failing because it ran without an environment — the OIDC token didn't match.

Changed from conditional environment to always using `Publish` for all release types (dry-run, beta, production).

## Test plan

- [ ] Trigger Release workflow with type=dry-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)