### PR TITLE
fix(ci): use github.token instead of GH_TOKEN PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ inputs.type != 'dry-run' && secrets.GH_TOKEN || github.token }}
+          token: ${{ github.token }}
 
       - name: Point beta branch at current commit
         if: inputs.type == 'beta'
@@ -68,13 +68,13 @@ jobs:
         if: inputs.type == 'beta'
         run: devbox run --config=shells/devbox-fast.json release
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Release (production)
         if: inputs.type == 'production'
         run: devbox run --config=shells/devbox-fast.json release
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Update Apps
         if: inputs.type == 'production'


### PR DESCRIPTION
## Summary
- Replace `secrets.GH_TOKEN` with `github.token` in the release workflow
- The PAT was missing/expired, causing beta release checkout to fail with `fatal: could not read Username`
- The default `github.token` has sufficient permissions (`contents:write`, `issues:write`, `pull-requests:write`, `id-token:write`) already declared in the workflow

## Test plan
- [ ] Merge and run dry-run release to verify it still passes
- [ ] Run beta release to verify checkout and publish work with `github.token`

🤖 Generated with [Claude Code](https://claude.com/claude-code)