### PR TITLE
fix(ci): override GITHUB_REF for beta releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
         run: devbox run --config=shells/devbox-fast.json release
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_REF: refs/heads/beta
 
       - name: Release (production)
         if: inputs.type == 'production'


### PR DESCRIPTION
## Summary
- Override `GITHUB_REF=refs/heads/beta` in the beta release step
- semantic-release uses `env-ci` which reads `GITHUB_REF` to determine the branch. Since `workflow_dispatch` runs from master, `GITHUB_REF=refs/heads/master` even after `git checkout -B beta`, causing beta releases to publish as stable versions

## Also fixed (outside this PR)
- Created missing git tag `@segment/analytics-react-native-plugin-appsflyer-v0.8.0` (manual npm publish had no tag)
- The `latest` dist-tag on npm for `@segment/analytics-react-native-plugin-appsflyer` still points to 0.6.1 instead of 0.8.0 — needs manual fix: `npm dist-tag add @segment/analytics-react-native-plugin-appsflyer@0.8.0 latest`

## Test plan
- [ ] Merge and run beta release
- [ ] Verify packages publish with `-beta.X` suffix and `@beta` dist-tag (not `@latest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)