### PR TITLE
fix(ci): pass GITHUB_REF via devbox -e flag for beta releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,9 @@ jobs:
 
       - name: Release (beta)
         if: inputs.type == 'beta'
-        run: devbox run --config=shells/devbox-fast.json release
+        run: devbox run -e GITHUB_REF=refs/heads/beta --config=shells/devbox-fast.json release
         env:
           GH_TOKEN: ${{ github.token }}
-          GITHUB_REF: refs/heads/beta
 
       - name: Release (production)
         if: inputs.type == 'production'


### PR DESCRIPTION
The step-level env override GITHUB_REF=refs/heads/beta was not being picked up by semantic-release inside the devbox nix shell. Use devbox's -e flag to explicitly inject the env var into the shell environment.