### PR TITLE
chore(deps): bump react-native-get-random-values from 1.11.0 to 2.0.0

### DIFF
--- a/examples/AnalyticsReactNativeExample/package.json
+++ b/examples/AnalyticsReactNativeExample/package.json
@@ -25,7 +25,7 @@
     "react": "18.3.1",
     "react-native": "0.76.1",
     "react-native-gesture-handler": "^2.20.2",
-    "react-native-get-random-values": "^1.11.0",
+    "react-native-get-random-values": "^2.0.0",
     "react-native-safe-area-context": "^4.14.0",
     "react-native-safe-area-view": "^1.1.1"
   },

--- a/examples/E2E-73/package.json
+++ b/examples/E2E-73/package.json
@@ -27,7 +27,7 @@
     "react": "18.2.0",
     "react-native": "0.73.0",
     "react-native-gesture-handler": "^2.13.4",
-    "react-native-get-random-values": "^1.9.0",
+    "react-native-get-random-values": "^2.0.0",
     "react-native-safe-area-context": "^4.7.4",
     "react-native-screens": "^3.27.0"
   },

--- a/examples/E2E/package.json
+++ b/examples/E2E/package.json
@@ -27,7 +27,7 @@
     "react": "18.2.0",
     "react-native": "0.72.9",
     "react-native-gesture-handler": "^2.13.4",
-    "react-native-get-random-values": "^1.9.0",
+    "react-native-get-random-values": "^2.0.0",
     "react-native-safe-area-context": "^4.7.4",
     "react-native-screens": "^3.27.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,7 @@
     "@segment/sovran-react-native": "^1.1.0",
     "react": "*",
     "react-native": "*",
-    "react-native-get-random-values": "1.x"
+    "react-native-get-random-values": "2.x"
   },
   "peerDependenciesMeta": {
     "@react-native-async-storage/async-storage": {

--- a/packages/sovran/package.json
+++ b/packages/sovran/package.json
@@ -78,7 +78,7 @@
   "dependencies": {
     "ansi-regex": "5.0.1",
     "deepmerge": "^4.2.2",
-    "react-native-get-random-values": "1.x",
+    "react-native-get-random-values": "2.x",
     "shell-quote": "1.8.0",
     "uuid": "^9.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4573,7 +4573,7 @@ __metadata:
     "@segment/sovran-react-native": ^1.1.0
     react: "*"
     react-native: "*"
-    react-native-get-random-values: 1.x
+    react-native-get-random-values: 2.x
   peerDependenciesMeta:
     "@react-native-async-storage/async-storage":
       optional: true
@@ -4601,7 +4601,7 @@ __metadata:
     ansi-regex: "npm:5.0.1"
     deepmerge: "npm:^4.2.2"
     jest: "npm:^29.7.0"
-    react-native-get-random-values: "npm:1.x"
+    react-native-get-random-values: "npm:2.x"
     semantic-release: "npm:^22.0.8"
     shell-quote: "npm:1.8.0"
     typescript: "npm:^5.2.2"
@@ -15192,14 +15192,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-get-random-values@npm:1.x":
-  version: 1.11.0
-  resolution: "react-native-get-random-values@npm:1.11.0"
+"react-native-get-random-values@npm:2.x":
+  version: 2.0.0
+  resolution: "react-native-get-random-values@npm:2.0.0"
   dependencies:
     fast-base64-decode: "npm:^1.0.0"
   peerDependencies:
-    react-native: ">=0.56"
-  checksum: 10c0/2ce71f1ab7f5b36d4a9dd59cc80b4aa75526f047c6680a7f1a388fa8b9a62efdacaf7b7de3be593c73e882773b2eee74916b00f7c8b158e40b46388998218586
+    react-native: ">=0.81"
+  checksum: 10c0/fd2e10ab3bca54bff8f5844e3314b797e02822e86663bc2dafe00a511b8a8e1c05d96aa0b8dc1ffad428387d44bbf458ce770a429858433d36f58a16e6e52986
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Updates `react-native-get-random-values` dependency constraint
- All existing test suites pass with the updated dependency

Fixes #1102

## Test plan
- [x] All existing test suites pass