### PR TITLE
feat(ci): support branch-based prerelease without managing beta branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,12 +53,6 @@ jobs:
           fetch-depth: 0
           token: ${{ github.token }}
 
-      - name: Point beta branch at current commit
-        if: inputs.type == 'beta'
-        run: |
-          git checkout -B beta HEAD
-          git push origin beta --force
-
       - name: Install devbox
         uses: jetify-com/devbox-install-action@v0.14.0
 
@@ -70,7 +64,9 @@ jobs:
 
       - name: Release (beta)
         if: inputs.type == 'beta'
-        run: devbox run -e GITHUB_REF=refs/heads/beta release
+        run: |
+          BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+          devbox run -e GITHUB_REF=refs/heads/$BRANCH_NAME release
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/multi-release.config.js
+++ b/multi-release.config.js
@@ -1,5 +1,9 @@
 module.exports = {
-  branches: ['master', { name: 'beta', prerelease: true }],
+  branches: [
+    'master',
+    { name: '+([0-9])?(.{+([0-9]),x}).x', prerelease: true }, // support branches (e.g., 1.x, 1.2.x)
+    { name: '*', prerelease: true }, // any other branch = prerelease
+  ],
   tagFormat: '${name}-v${version}',
   deps: {
     bump: 'satisfy', // Do not trigger a release for every package if the only change is a minor/patch upgrade of dependencies

--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,9 @@
 module.exports = {
-  branches: ['master', { name: 'beta', prerelease: true }],
+  branches: [
+    'master',
+    { name: '+([0-9])?(.{+([0-9]),x}).x', prerelease: true }, // support branches (e.g., 1.x, 1.2.x)
+    { name: '*', prerelease: true }, // any other branch = prerelease
+  ],
   tagFormat: '${name}-v${version}',
   plugins: [
     ['@semantic-release/commit-analyzer', { preset: 'conventionalcommits' }],

--- a/wiki/release.md
+++ b/wiki/release.md
@@ -1,6 +1,6 @@
 ## Release guide
 
-This repo uses semantic-release with multi-semantic-release to version and publish all public workspaces. Tags follow `${name}-v${version}` and releases are cut from `master` (stable) and `beta` (prerelease).
+This repo uses semantic-release with multi-semantic-release to version and publish all public workspaces. Tags follow `${name}-v${version}` and releases are cut from `master` (stable) or any feature branch (prerelease).
 
 ### Prerequisites
 
@@ -16,9 +16,21 @@ This repo uses semantic-release with multi-semantic-release to version and publi
 
 ### CI/CD path (recommended)
 
-1. Ensure `master`/`beta` are green. Merges must use conventional commits.
-2. Trigger `Release` workflow in Actions. Choose type: `dry-run`, `beta`, or `production`.
+1. Ensure target branch is green. Merges must use conventional commits.
+2. Trigger `Release` workflow in Actions:
+   - **Production release**: Run from `master` with type `production` → publishes stable versions (e.g., `2.23.0`)
+   - **Fix candidate/beta**: Run from any feature branch with type `beta` → publishes prerelease versions (e.g., `2.23.0-fix-retry-bug.1`)
+   - **Dry run**: Run from any branch with type `dry-run` to preview what would be published
 3. Outputs: package tags (`${name}-vX.Y.Z`), npm publishes, and GitHub releases.
+
+**Beta/fix candidate workflow:**
+
+- Push your feature branch (e.g., `fix/customer-issue-123`)
+- Run Release workflow from that branch with type `beta`
+- Publishes with branch name in version: `2.23.0-fix-customer-issue-123.1`
+- Customer installs with: `npm install @segment/analytics-react-native@fix-customer-issue-123`
+- No branch management or syncing required
+- Each feature branch gets its own npm dist-tag
 
 Note: version bumps and changelogs are **not** committed back to the repo. The source of truth for versions is the git tags and npm registry. To sync the repo's `package.json` versions with npm, run `devbox run --config=shells/devbox-fast.json sync-versions` and include the changes in a PR.
 
@@ -31,6 +43,7 @@ Note: version bumps and changelogs are **not** committed back to the repo. The s
 
 - Only public packages release; private workspaces (e.g., `packages/shared`) are ignored.
 - Tag pattern is important: keep `${name}-v${version}` if you create manual tags for debugging.
-- If adding a new branch for releases, update both `release.config.js` and `multi-release.config.js`.
+- Branch name becomes part of prerelease identifier: use descriptive branch names (e.g., `fix/retry-logic` not `fix123`).
 - Keep yarn.lock in sync before releasing to avoid install differences between CI and local.
 - `.npmrc` contains `workspaces-update=false` to prevent `npm version` from failing on Yarn's `workspace:` protocol.
+- Multiple fix candidates can coexist on npm simultaneously with different dist-tags.


### PR DESCRIPTION
## Summary

Replace the beta branch force-push workflow with branch-based prereleases. Any feature branch can now publish prerelease versions without managing or syncing a secondary branch.

**Key changes:**
- Remove beta branch force-push step from release workflow
- Use current branch name for `GITHUB_REF` instead of hardcoded `beta`
- Configure semantic-release to treat any non-master branch as prerelease
- Update documentation with new fix candidate workflow

## Benefits

- ✅ No branch management or syncing required
- ✅ Clear traceability: branch name appears in version (e.g., `2.23.0-fix-retry-bug.1`)
- ✅ Multiple fix candidates can exist simultaneously on npm
- ✅ Each feature branch gets its own npm dist-tag
- ✅ Simpler mental model: branch = prerelease, master = stable

## How it works

**Publishing a fix candidate:**
1. Push your feature branch (e.g., `fix/customer-issue-123`)
2. Go to Actions → Release workflow → Run workflow
3. Select your feature branch from dropdown
4. Choose `beta` as release type
5. Workflow publishes with branch name in version: `2.23.0-fix-customer-issue-123.1`

**Customer installation:**
```bash
# Install latest from that branch's dist-tag
npm install @segment/analytics-react-native@fix-customer-issue-123

# Or pin to specific version
npm install @segment/analytics-react-native@2.23.0-fix-customer-issue-123.1
```

## Test plan
- [ ] Run dry-run release from feature branch to verify version format
- [ ] Run beta release from feature branch and verify npm publish
- [ ] Verify customer can install using branch dist-tag
- [ ] Confirm multiple feature branches can have simultaneous prereleases

🤖 Generated with [Claude Code](https://claude.com/claude-code)