### PR TITLE
fix(ci): skip e2e-tests workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,8 +22,8 @@ on:
 
 jobs:
   e2e-tests:
-    # Skip on fork PRs where repo secrets aren't available
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    # Skip on fork PRs and Dependabot PRs where repo secrets aren't available
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
Skip e2e-tests workflow for Dependabot PRs, which don't have access to repository secrets.

## Changes
- Update e2e-tests workflow condition to exclude Dependabot PRs
- Add `github.actor != 'dependabot[bot]'` check alongside existing fork PR check

## Why
All 25 Dependabot PRs failing with "Input required and not supplied: token" because they can't access `secrets.E2E_TESTS_TOKEN` for security reasons.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)