### PR TITLE
feat: configure Dependabot to group dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,85 @@
+version: 2
+updates:
+  # Root workspace
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      production-dependencies:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "*-dev"
+          - "*-test"
+      development-dependencies:
+        patterns:
+          - "*-dev"
+          - "*-test"
+
+  # Example app
+  - package-ecosystem: "npm"
+    directory: "/examples/AnalyticsReactNativeExample"
+    schedule:
+      interval: "weekly"
+    groups:
+      example-dependencies:
+        patterns:
+          - "*"
+
+  # E2E apps
+  - package-ecosystem: "npm"
+    directory: "/examples/E2E-compat"
+    schedule:
+      interval: "weekly"
+    groups:
+      e2e-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/examples/E2E-latest"
+    schedule:
+      interval: "weekly"
+    groups:
+      e2e-dependencies:
+        patterns:
+          - "*"
+
+  # E2E CLI
+  - package-ecosystem: "npm"
+    directory: "/e2e-cli"
+    schedule:
+      interval: "weekly"
+    groups:
+      e2e-cli-dependencies:
+        patterns:
+          - "*"
+
+  # Bundler (Ruby dependencies)
+  - package-ecosystem: "bundler"
+    directory: "/examples/E2E-compat"
+    schedule:
+      interval: "weekly"
+    groups:
+      ruby-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "bundler"
+    directory: "/examples/E2E-latest"
+    schedule:
+      interval: "weekly"
+    groups:
+      ruby-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "bundler"
+    directory: "/examples/AnalyticsReactNativeExample"
+    schedule:
+      interval: "weekly"
+    groups:
+      ruby-dependencies:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,85 +1,85 @@
 version: 2
 updates:
   # Root workspace
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     groups:
       production-dependencies:
         patterns:
-          - "*"
+          - '*'
         exclude-patterns:
-          - "*-dev"
-          - "*-test"
+          - '*-dev'
+          - '*-test'
       development-dependencies:
         patterns:
-          - "*-dev"
-          - "*-test"
+          - '*-dev'
+          - '*-test'
 
   # Example app
-  - package-ecosystem: "npm"
-    directory: "/examples/AnalyticsReactNativeExample"
+  - package-ecosystem: 'npm'
+    directory: '/examples/AnalyticsReactNativeExample'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     groups:
       example-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   # E2E apps
-  - package-ecosystem: "npm"
-    directory: "/examples/E2E-compat"
+  - package-ecosystem: 'npm'
+    directory: '/examples/E2E-compat'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     groups:
       e2e-dependencies:
         patterns:
-          - "*"
+          - '*'
 
-  - package-ecosystem: "npm"
-    directory: "/examples/E2E-latest"
+  - package-ecosystem: 'npm'
+    directory: '/examples/E2E-latest'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     groups:
       e2e-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   # E2E CLI
-  - package-ecosystem: "npm"
-    directory: "/e2e-cli"
+  - package-ecosystem: 'npm'
+    directory: '/e2e-cli'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     groups:
       e2e-cli-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   # Bundler (Ruby dependencies)
-  - package-ecosystem: "bundler"
-    directory: "/examples/E2E-compat"
+  - package-ecosystem: 'bundler'
+    directory: '/examples/E2E-compat'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     groups:
       ruby-dependencies:
         patterns:
-          - "*"
+          - '*'
 
-  - package-ecosystem: "bundler"
-    directory: "/examples/E2E-latest"
+  - package-ecosystem: 'bundler'
+    directory: '/examples/E2E-latest'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     groups:
       ruby-dependencies:
         patterns:
-          - "*"
+          - '*'
 
-  - package-ecosystem: "bundler"
-    directory: "/examples/AnalyticsReactNativeExample"
+  - package-ecosystem: 'bundler'
+    directory: '/examples/AnalyticsReactNativeExample'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     groups:
       ruby-dependencies:
         patterns:
-          - "*"
+          - '*'


### PR DESCRIPTION
## Summary
Configure Dependabot to group dependency updates into ~6-8 PRs instead of 25+ individual PRs.

## Changes
- Add `.github/dependabot.yml` with grouped update configuration
- Group dependencies by workspace: root (prod/dev), examples, E2E apps, CLI
- Set weekly schedule for all dependency groups
- Separate prod vs dev dependencies in root workspace

## Why
Currently have 25 open Dependabot PRs, each for a single dependency. This creates PR noise, tedious reviews, more CI runs, and merge conflicts.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)