### PR TITLE
fix: separate beta and production release environments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,60 @@ jobs:
       - name: Test
         run: devbox run test
 
-  release:
-    name: Release (${{ inputs.type }})
+  release-dryrun:
+    name: Release (dry-run)
+    if: inputs.type == 'dry-run'
+    needs: [ci]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@v0.14.0
+
+      - name: Release (dry-run)
+        run: devbox run release-dry-run
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  release-beta:
+    name: Release (beta)
+    if: inputs.type == 'beta'
+    needs: [ci]
+    runs-on: ubuntu-latest
+    environment: Publish-Beta
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@v0.14.0
+
+      - name: Release (beta)
+        run: |
+          BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+          devbox run -e GITHUB_REF=refs/heads/$BRANCH_NAME release
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  release-production:
+    name: Release (production)
+    if: inputs.type == 'production'
     needs: [ci]
     runs-on: ubuntu-latest
     environment: Publish
@@ -56,26 +108,10 @@ jobs:
       - name: Install devbox
         uses: jetify-com/devbox-install-action@v0.14.0
 
-      - name: Release (dry-run)
-        if: inputs.type == 'dry-run'
-        run: devbox run release-dry-run
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Release (beta)
-        if: inputs.type == 'beta'
-        run: |
-          BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-          devbox run -e GITHUB_REF=refs/heads/$BRANCH_NAME release
-        env:
-          GH_TOKEN: ${{ github.token }}
-
       - name: Release (production)
-        if: inputs.type == 'production'
         run: devbox run release
         env:
           GH_TOKEN: ${{ github.token }}
 
       - name: Update Apps
-        if: inputs.type == 'production'
         run: devbox run update-apps


### PR DESCRIPTION
## Summary
Split release workflow to use different GitHub environments for beta vs production releases.

## Problem
Currently, all releases (beta and production) use the same "Publish" environment which requires manual approval from reviewers. This prevents team members from self-publishing beta releases for customer testing.

## Solution
Created two separate environments with different protection rules:

### Publish-Beta (New)
- ✅ No reviewer approval required
- ✅ Restricted to `*` branches (any branch from Segment org members)
- ✅ Team members can self-publish betas for testing
- ❌ External contributors cannot publish

### Publish (Existing)
- ✅ Requires reviewer approval (secondary check)
- ✅ Used for production releases only
- ✅ Maintains safety for stable releases

## Changes
- Split `release` job into three separate jobs:
  - `release-dryrun` - No environment (no publishing)
  - `release-beta` - Uses `Publish-Beta` environment
  - `release-production` - Uses `Publish` environment
- Each job runs conditionally based on `inputs.type`

## Workflow
**Beta releases (self-service for team):**
1. Push feature/fix branch
2. Actions → Release → Beta
3. Publishes immediately (no approval needed)

**Production releases (requires approval):**
1. Ensure code is on master
2. Actions → Release → Production
3. Waits for reviewer approval
4. Publishes after approval

## Security
- ✅ Only Segment org members can trigger workflows
- ✅ Both environments restricted to org members
- ✅ Production still requires secondary approval
- ✅ NPM provenance enabled for all releases

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)