### PR TITLE
fix: sanitize branch names for semantic-release prerelease

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -2,7 +2,7 @@ module.exports = {
   branches: [
     'master',
     { name: '+([0-9])?(.{+([0-9]),x}).x', prerelease: true }, // support branches (e.g., 1.x, 1.2.x)
-    { name: '*', prerelease: true }, // any other branch = prerelease
+    { name: '*', prerelease: 'beta' }, // any other branch = beta prerelease (fixes SemVer compliance)
   ],
   tagFormat: '${name}-v${version}',
   plugins: [


### PR DESCRIPTION
## Summary

Fixes the semantic-release configuration to prevent branch names with underscores from breaking releases.

## Problem

The wildcard branch config (`{ name: '*', prerelease: true }`) uses the raw branch name as the prerelease identifier. Branch names with underscores (e.g., `leanplum_plugin_integration`) violate the [SemVer specification](https://semver.org/#spec-item-9) which only allows `[0-9A-Za-z-]` in prerelease identifiers.

This caused the beta channel release to fail with:
```
EPRERELEASEBRANCH A pre-release branch configuration is invalid in the `branches` configuration.
```

## Solution

Changed the wildcard branch config to use a fixed prerelease identifier (`'beta'`) instead of the branch name:

```javascript
{ name: '*', prerelease: 'beta' }
```

This ensures:
- All feature/fix branches publish as beta prereleases (e.g., `1.2.3-beta.1`)
- SemVer compliance regardless of branch naming
- Releases work even with branches containing underscores

## Test Plan

- [x] Verified configuration syntax
- [ ] Test beta release from a branch with underscores
- [ ] Test beta release from the `fix/ios-zero-second-sessions` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)