### PR TITLE
fix(e2e-cli): use config timeout for queue drain wait

### DIFF
--- a/e2e-cli/src/cli.ts
+++ b/e2e-cli/src/cli.ts
@@ -46,6 +46,7 @@ interface CLIConfig {
   flushAt?: number;
   flushInterval?: number;
   maxRetries?: number;
+  timeout?: number;
 }
 
 interface CLIInput {
@@ -229,7 +230,8 @@ async function main() {
     }
 
     await client.flush();
-    const drained = await waitForQueueDrain(client);
+    const drainTimeoutMs = (input.config?.timeout ?? 120) * 1000;
+    const drained = await waitForQueueDrain(client, drainTimeoutMs);
 
     const finalPending = drained ? 0 : await client.pendingEvents();
     const totalEvents = input.sequences.reduce(


### PR DESCRIPTION
## Summary
- The e2e-cli was using a hardcoded 30s timeout for `waitForQueueDrain`, which is shorter than a single `Retry-After: 60` cycle from server-side rate limiting
- Events rate-limited near the end of a test run were dropped because the process exited before the retry fired
- Now passes `config.timeout` (default 120s) to the drain wait, ensuring at least one full retry cycle completes
- Also adds `timeout` to the `CLIConfig` interface

## Test plan
- [x] Verified 20/20 events delivered through staging rate limiting (1 event/min, `Retry-After: 60`)
- [x] Without fix: last event(s) dropped (`success: false`, 19/20 batches)
- [x] With fix: all events delivered (`success: true`, 20/20 batches)