### PR TITLE
fix(deps): resolve 3rd-party vulnerabilities (MBL-1676, MBL-1679)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   cancel_previous:
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.12.1
+      - uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
         with:
           workflow_id: ${{ github.event.workflow.id }}
   build-and-test:
@@ -42,7 +42,7 @@ jobs:
   run-e2e-ios:
     runs-on: 'macos-13'
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
           xcode-version: latest-stable
       - name: Install applesimutils
@@ -108,7 +108,7 @@ jobs:
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@324029e2f414c084d8b15ba075288885e74aef9c # v2.34.0
         with:
           api-level: ${{ matrix.api-level }}
           profile: ${{matrix.profile}}
@@ -141,7 +141,7 @@ jobs:
         run: RCT_NO_LAUNCH_PACKAGER=1 yarn e2e build:android
 
       - name: Detox - Test
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@324029e2f414c084d8b15ba075288885e74aef9c # v2.34.0
         with:
           api-level: ${{ matrix.api-level }}
           profile: ${{matrix.profile}}

--- a/.github/workflows/create_jira.yml
+++ b/.github/workflows/create_jira.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
       - name: Login
-        uses: atlassian/gajira-login@master
+        uses: atlassian/gajira-login@c22a5debd482401472b285de4f6deedf70ddbb92 # master
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
@@ -22,7 +22,7 @@ jobs:
 
       - name: Create
         id: create
-        uses: atlassian/gajira-create@master
+        uses: atlassian/gajira-create@1c54357fdde9dab6273a0e26d67cb175ffffe498 # master
         with:
           project: LIBWEB
           issuetype: Bug

--- a/examples/AnalyticsReactNativeExample/Gemfile
+++ b/examples/AnalyticsReactNativeExample/Gemfile
@@ -4,4 +4,5 @@ source 'https://rubygems.org'
 ruby ">= 2.6.10"
 
 gem 'cocoapods', '~> 1.13'
-gem 'activesupport', '>= 6.1.7.3', '< 7.1.0'
+gem 'activesupport', '~> 8.0.4', '>= 8.0.4.1'
+gem 'rexml', '>= 3.2.7'

--- a/examples/E2E-73/Gemfile
+++ b/examples/E2E-73/Gemfile
@@ -4,4 +4,5 @@ source 'https://rubygems.org'
 ruby ">= 2.6.10"
 
 gem 'cocoapods', '~> 1.13'
-gem 'activesupport', '>= 6.1.7.3', '< 7.1.0'
+gem 'activesupport', '~> 8.0.4', '>= 8.0.4.1'
+gem 'rexml', '>= 3.2.7'

--- a/examples/E2E/Gemfile
+++ b/examples/E2E/Gemfile
@@ -4,4 +4,5 @@ source 'https://rubygems.org'
 ruby ">= 2.6.10"
 
 gem 'cocoapods', '~> 1.13'
-gem 'activesupport', '>= 6.1.7.3', '< 7.1.0'
+gem 'activesupport', '~> 8.0.4', '>= 8.0.4.1'
+gem 'rexml', '>= 3.2.7'

--- a/package.json
+++ b/package.json
@@ -59,5 +59,26 @@
     "ts-jest": "^29.1.1",
     "typescript": "^5.2.2"
   },
-  "packageManager": "yarn@4.1.0"
+  "packageManager": "yarn@4.1.0",
+  "resolutions": {
+    "ip": "2.0.1",
+    "picomatch": "4.0.4",
+    "brace-expansion": "5.0.5",
+    "minimatch": "10.2.5",
+    "js-yaml": "4.1.1",
+    "ws": "8.20.0",
+    "yaml": "2.8.3",
+    "fast-xml-parser": "4.5.6",
+    "lodash": "4.18.1",
+    "braces": "3.0.3",
+    "flatted": "3.4.2",
+    "@babel/helpers": "7.29.2",
+    "micromatch": "4.0.8",
+    "cross-spawn": "7.0.6",
+    "nanoid": "3.3.11",
+    "ajv": "6.15.0",
+    "on-headers": "1.1.0",
+    "serve-static": "1.16.3",
+    "send": "0.19.2"
+  }
 }


### PR DESCRIPTION
## Summary

Combined fix for [MBL-1676](https://linear.app/customerio/issue/MBL-1676) (Breaking) and [MBL-1679](https://linear.app/customerio/issue/MBL-1679) (Non-Breaking) in `analytics-react-native`.

### Yarn resolutions (root package.json)

Pins transitive deps to patched versions. Yarn berry (4.1.0) workspaces — resolutions cascade across all workspace packages.

| Package | From | To | Class |
|---|---|---|---|
| ip | 1.1.8 | 2.0.1 | breaking |
| picomatch | 2.3.1 | 4.0.4 | breaking |
| brace-expansion | 1.1.11 / 2.0.1 | 5.0.5 | breaking |
| minimatch | 3.1.2 / 5.1.6 | 10.2.5 | breaking |
| ws | 6.2.2 / 7.5.9 | 8.20.0 | breaking |
| js-yaml | 3.14.1 / 4.1.0 | 4.1.1 | non-breaking* |
| yaml | 2.3.4 | 2.8.3 | non-breaking |
| fast-xml-parser | 4.3.2 | 4.5.6 | non-breaking |
| lodash | 4.17.21 | 4.18.1 | non-breaking |
| braces | 3.0.2 | 3.0.3 | non-breaking |
| flatted | 3.2.9 | 3.4.2 | non-breaking |
| @babel/helpers | 7.23.4 / 7.23.5 | 7.29.2 | non-breaking |
| micromatch | 4.0.5 | 4.0.8 | non-breaking |
| cross-spawn | 7.0.3 | 7.0.6 | non-breaking |
| nanoid | 3.3.7 | 3.3.11 | non-breaking |
| ajv | 6.12.6 | 6.15.0 | non-breaking |
| on-headers | 1.0.2 | 1.1.0 | non-breaking |
| serve-static | 1.15.0 | 1.16.3 | non-breaking |
| send | 0.18.0 | 0.19.2 | non-breaking |

\* `js-yaml` 3.x has no patched release.

### Ruby gems (example Gemfiles)

`activesupport` and `rexml` updated in all three example Gemfiles
(`examples/E2E/`, `examples/E2E-73/`, `examples/AnalyticsReactNativeExample/`):

| Gem | From | To | CVEs |
|---|---|---|---|
| activesupport | `>= 6.1.7.3, < 7.1.0` | `~> 8.0.4, >= 8.0.4.1` | CVE-2026-33169, CVE-2026-33176, CVE-2026-33170 |
| rexml | (transitive) | `>= 3.2.7` | CVE-2024-43398, CVE-2024-41946, CVE-2024-41123, CVE-2024-39908, CVE-2024-49761, CVE-2024-35176 |

### Notes

- Versions chosen are the latest patched releases that fix the referenced CVEs (avoids the literal downgrade-style targets, e.g. ws 8→7, yaml 2→1, ajv 8→6).
- `yarn install` was not run locally; CI will regenerate `yarn.lock` and `Gemfile.lock` files.
- Releasable repo (semantic-release via `Publish` workflow_dispatch). The `fix(deps):` commits will produce a patch release on the next workflow run.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, run the `Publish` workflow to release a patch version with the security fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)