### PR TITLE
feat(ci): add devbox plugin integration testing

### DIFF
--- a/.claude/policies/twilio-genai-policy.md
+++ b/.claude/policies/twilio-genai-policy.md
@@ -1,0 +1,336 @@
+# Twilio Generative AI Policy
+
+**Status:** Published  
+**Effective Date:** 24 February 2025  
+**Policy Version:** v.2  
+**Policy Owner(s):**
+
+- Tony Arous - Chief Information Security Officer
+- Amy Holcroft - Chief Privacy Officer
+- Zachary Hanif - VP, Group Architecture, AI
+
+**Policy Review Dates:** Annually - 29 April 2026
+
+## Overview
+
+At Twilio, we recognize that Artificial Intelligence (AI) has the potential to transform the way we work, live and interact with the world around us.
+
+Generative AI (GenAI), for example OpenAI, is very much in focus as a powerful tool that has the potential to create significant advantages for our business through the generation of a wide variety of data, such as text, code, images, audio, video or 3D content. We believe that its use will give us the ability to improve our products and services and create new opportunities for our customers, partners and employees. GenAI can also help us make more informed decisions, save time and resources by automating and optimizing processes and avoid mistakes and "human error".
+
+However, GenAI comes with risks and challenges and, if not used appropriately, can have a significant negative impact on our business, individuals, communities, and potentially society as a whole. We are committed to using GenAI in an ethical, legal and responsible way that respects human, intellectual property and privacy rights, values diversity and promotes social responsibility.
+
+Twilio is actively exploring different use cases related to the use of GenAI in our products and internal business functions.
+
+## Scope
+
+This policy applies globally to all Team Members with respect to the use of GenAI for any business-related purpose.
+
+The purpose of this policy is to set out some basic rules and guidelines for using GenAI that enables the exploration and adoption of GenAI use cases without creating legal risk to the company or to the interests and rights of our employees, business partners, customers and third parties.
+
+You are reminded of the need to ensure all GenAI use cases comply with applicable corporate policies and complete all required reviews and approvals.
+
+It should be noted that there is a great deal of legal uncertainty surrounding the use and capabilities of GenAI and this policy will be adapted on an on-going basis to address new developments.
+
+## Policy
+
+### Basic Ground Rules
+
+#### Use of GenAI That Has Not Been Acquired Through Procurement
+
+GenAI that is available on a free or freemium basis, open source or otherwise acquired outside the corporate procurement process (Non-Approved GenAI) must be used in a limited way. The free version of ChatGPT is Non-Approved GenAI.
+
+Non-Approved GenAI may only be used with Prompt Data that is classified as Public Data in the Data Classification Policy (see extract below).
+
+Non-Approved GenAI may also be used by R&D teams:
+
+- with source code or product research and development data that contains no material intellectual property or trade secrets (i.e. proprietary algorithms). The Open Source Policy provides a useful guide and, as a general rule, if we would release the code or data as open source, it can be used with Non-Approved GenAI; and
+- for limited code use cases, including to generate test code, refactoring existing code to be cleaner, generating boilerplate common code, writing explanatory documentation and how-tos for code and answering questions across Twilio's publicly available technical knowledge base.
+
+**Public Data:** This is the lowest level of data classification. Public data is intended for external release, use by non-employees, or has been downloaded from publicly available sources free of charge. Unauthorized disclosure of Public Data would result in little or no risk to Twilio, its customers, and/or end users.
+
+Examples:
+
+- Published Twilio corporate information
+- Publicly Available Regulatory Filings: information such as any Twilio Securities and Exchange Commission (SEC) filings.
+- Published Marketing Content: white papers and/or public facing blogs.
+- Press Releases
+- Product Brochures
+- Public Presentations
+
+If the Prompt Data you are considering using is not listed or you are unsure of the correct classification, please submit a question to the Privacy team via the Privacy ServiceNow form.
+
+#### Use of Approved GenAI Products
+
+We are setting up enterprise accounts with selected GenAI Service Providers to use certain products (Approved GenAI). This is managed through the procurement process to ensure that the products have been fully vetted and can be used in an appropriate, safe and legal manner. The following GenAI Service Provider products are approved for general use:
+
+| GenAI Service Provider    | Approved GenAI Products                                          |
+| ------------------------- | ---------------------------------------------------------------- |
+| Open AI Inc.              | GPT4/GPT5 API, Reasoning Model API, DALL E-2 and Whisper         |
+| Amazon Web Services, Inc. | CodeWhisperer for coding usage, Comprehend, Personalise, Bedrock |
+| Google                    | Google Vertex AI, Dialogflow                                     |
+| Github                    | Github AI - Copilot                                              |
+| Microsoft                 | Azure Open AI                                                    |
+
+**Please note that the free version of ChatGPT is Non-Approved GenAI for security reasons and can only be used with Public Data as Prompt Data.**
+
+You may only use approved Generative AI tools with prompt data classified as Restricted or Confidential under the Data Classification & Data Handling Policy. Before use, you must ensure your use case complies with all relevant corporate policies and that you have completed any required approvals, including privacy impact assessments, and legal or security reviews. Text-to-image generation is provided by our existing enterprise OpenAI license; use of generated images in customer-facing Twilio products must go through business justification and appropriate marketing approvals.
+
+### Input Data
+
+Particular care must be taken when dealing with Input Data because GenAI may process data differently from other types of software and the use of Input Data can be considered a disclosure of such data. Therefore, using Input Data can create particular risks related to personal data, confidentiality, security and intellectual property rights. Input Data must not include any unauthorised or private personal data, confidential, or proprietary information.
+
+You are reminded of your obligation to maintain confidentiality under the terms of your employment contract, your Proprietary Information, Inventions, Non-Competition and Non- Solicitation Agreement (and any other similar agreement you executed), or terms of engagement with Twilio and Twilio's Code of Conduct.
+
+#### Personal Data
+
+To avoid violating privacy laws, our Binding Corporate Rules and customer contracts when using personal data of our employees, customers or business partners as Input Data, you must comply with the following requirements:
+
+##### 1. Data Protection Agreement
+
+There must be a Data Protection Agreement ("DPA") in place with the GenAI Service Provider. The term Personal Data is to be understood very broadly and, depending on the type of Input Data, includes the following information:
+
+- **Text:** Names, addresses, telephone numbers, unique identifiers, message content and any other information that can be attributed to an individual person.
+- **Images and video:** Images or videos of persons who are recognisable as individuals, whether they are photographs, video footage, drawings or artificial images.
+- **Sound:** Recordings in which a certain person is named or the voice of a certain person that can be attributed to him or her.
+
+If there is no DPA in place or we are unable to enter into a DPA with the GenAI Service Provider, you are prohibited from using Personal Data as Input Data.
+
+##### 2. Consultation with the Privacy team and Privacy Impact Assessments
+
+You must consult with the Privacy team and complete a Privacy Impact Assessment if necessary prior to using GenAI. This is needed to ensure compliance with applicable privacy laws and our Binding Corporate Rules and that we are not creating unacceptable risk for individuals. This will include:
+
+- Checking Twilio has a legal basis for processing personal data through GenAI as Input Data. In some cases, we will be able to rely on Twilio's legitimate interest in the processing, but the consent of an individual or our customer may be required to be able to use personal data as Input Data.
+- Ensuring Twilio is not using GenAI to make automated decisions about someone that directly affects them, e.g. profiling, assessing or rating someone
+- Updating Twilio's Privacy Notice, Global Employee Privacy or other notices to provide transparency about how we use GenAI.
+
+#### Intellectual Property and Confidentiality
+
+Improper use of third-party data as Input Data could violate the third party's confidentiality or intellectual property (IP) rights. Likewise, improper use of our own data could damage Twilio's IP rights. This is of particular risk when Input Data is used as Training Data and parts or patterns of it can be regenerated elsewhere as Output Data. Whenever possible, obtain the GenAI Service Provider's agreement not to use Input Data as Training Data.
+
+Do not use third-party IP or confidential data (e.g., data shared with Twilio under a nondisclosure agreement and designated as confidential by the third party) as Input Data without the third party's express permission, and use it only to the extent authorised. For example, usage rights we have to third-party data often will not cover use of such data as Training Data. Accordingly, we may not use such third-party data as Input Data if the GenAI Service Provider will then use it as Training Data.
+
+To protect Twilio's own IP and confidentiality interests, use our confidential data only as outlined in the section above. Exercise caution when using Twilio IP as Prompt Data if the GenAI Service Provider may use it as Training Data. In that case, we lose control over the GenAI Service Provider's further use of our IP. This makes it easier for others to use our IP and hinders our ability to enforce our rights in it. If in doubt, you should consult with the IP Legal team via ServiceNow about the specific use of protected content as Prompt Data.
+
+#### Multi-client fine-tuning
+
+When using Fine-Tuning Data, ensure that the GenAI Service Provider only uses the data for training our models for our and/or our customers' exclusive use. This data must not be used for other purposes (e.g., general software development).
+
+### Output Data
+
+As a general rule, Output Data should only be used internally or made available to customers through usage of a product or service.
+
+#### Intellectual Property
+
+Twilio's use of Output Data presents legal challenges with respect to third-party IP, which must be addressed as follows:
+
+##### Acquisition of commercial usage rights from GenAI Service Provider
+
+It is important that we obtain the necessary rights to use Output Data for our business purposes. Make sure that the GenAI Service Provider assigns the Output Data or grants a broad license to all usage rights, as are necessary to carry out our business purposes, to Twilio. In particular, the usage rights must cover commercial use. Whenever possible, ensure that the GenAI Service Provider's agreement will not use our Output Data as Training Data. Note that this does not release Twilio from the obligation to independently check whether the Output Data violates third-party rights before using it.
+
+##### Review for third-party intellectual property
+
+Even if the GenAI Service Provider assigns or grants a licence to the Output Data, there may be relevant third-party rights to consider, especially copyrights. Most GenAI Service Providers expressly disclaim any warranty that the Output Data will not infringe third-party IP rights. Therefore, the onus is on Twilio to review and ensure that Output Data is not infringing.
+
+The GenAI we use can be steered to create Output Data that resembles preexisting works. If the Output Data is too similar to a copyrighted work, then Twilio's use of the Output Data exposes Twilio to the risk of IP infringement liability.
+
+To reduce the risk of liability for misusing third-party IP, take the following steps:
+
+- Never use GenAI intentionally to generate copies, reproductions, or derivatives of pre-existing works.
+- Review Output Data that will be used externally for substantial similarity to preexisting works. You are not expected to vet against all prior content, but use your best judgment based on the nature and purpose of the Output Data as well as your prior knowledge and experience. You can use tools like Google to search for identical or similar text and images or plagiarism checking tools (your queries are Input Data in this context, so keep in mind the guidelines for using confidential data outlined above). Consult with the IP Legal team via ServiceNow for assistance.
+- If possible, make adjustments to Output Data (such as changing or adding new creative content) before we use it externally.
+- If available, check configurations for GenAI to minimize use of or identify third party IP or references in the Output Data.
+- Where possible, please keep a record of Output Data in case we need to review it to determine whether Twilio or a third party have IP rights in the data.
+
+#### Personal Data
+
+Output Data can constitute personal data, for example, where it allows us to create artificial images of a person, recreate a person's voice or generate a text about a person. Even if the information generated is not real, but can be attributed to that person, Twilio must comply with privacy laws when using this data. To address this you must seek advice from the Privacy team if the Output Data creates personal data.
+
+#### Output Accuracy, Security and Bias
+
+GenAI is prone to errors and can also produce biased, illegal, abusive, unsafe content that can cause harm to individuals and our business. To address this the following requirements must be met:
+
+- **Human Review** - Output Data must be subject to a human review to make sure it is accurate, suited for its intended purpose, and free from illegal or harmful content before being used.
+- **Security Testing** - If GenAI is used to generate code this must be extensively tested in a secure environment before it is used to ensure it does not create any security risks.
+- **Bias Review** - To avoid Output Data being used in a way that results in unlawful bias or discrimination, it must be routinely reviewed to check whether the content contains patterns indicative of bias and addressed through adaptations to the Input Data.
+
+### Transparency
+
+Twilio's customers, business partners and employees have an interest in knowing when their data is being processed by GenAI. Where appropriate, transparency about the use of GenAI must be provided to impacted groups, via a privacy notice or product documentation. If customers are communicating directly with a GenAI product, this must be clearly communicated to them at the outset.
+
+## Monitoring & Compliance
+
+Reporting violations of this policy is an obligation of all Team Members under the Code of Conduct. Any Team Member found to be in violation of this policy may be subject to disciplinary action, up to and including termination of employment, or contractual agreement.
+
+Where a violation of the policy may also constitute a data breach, for example because Critical Personal Data has been used as Prompt Data in Non-Approved GenAI, please go to Slack and type `/page-security-sirt` along with a brief message explaining what the incident involves.
+
+## Exceptions
+
+Any exceptions to this policy must be approved by the Chief Privacy Officer.
+
+## Questions
+
+If you have any questions about this Policy please contact the Privacy team via ServiceNow form.
+
+## Approved AI Tools
+
+For more information about what specific Generative AI Tools are approved for use by employees, please review the AI Toolkit or reach out to the IT Team. Twilio has an enterprise agreement with OpenAI and employees can access all products and API's available in the OpenAI platform (specifically https://platform.openai.com/), once that user is logged in via Okta SSO. All AI models available in Amazon Bedrock are also available to use, pending any necessary additional reviews.
+
+## Data Classifications
+
+### Restricted Data
+
+**Customer Content (Personal Data and non-Personal Data)**
+
+- Contents of voice, video, email, SMS, MMS, RCS, chat or fax communications traffic whether in-flight or stored prior to or post delivery
+- Subject lines of customer emails
+- Transcriptions of any communications
+- Recordings of any communications
+
+**Communications Usage Data (Meta data)**
+
+- Phone Numbers/caller ID
+- Call Detail Records - to and from number, date time and duration of communication
+
+**Customer Proprietary Network Information (CPNI)**
+
+- US customers (individual or corporate) call detail records
+- Certain call metadata: destination numbers and locations, call duration, time/date of calls
+
+**Location Data**
+
+- Geo-location data that allows tracking individual end user devices
+- Coarse location data allowing general vicinity of an end user device
+
+**Current or former employee data relating to:**
+
+- Work contracts, performance data, termination data
+- Accommodations, medical/disability data
+- Authentication/credentials, geo-location data
+- Recordings or transcripts of internal/external meetings, customer interactions
+- PHI or medical/health data, misconduct investigations
+- Grievances, whistleblowing
+
+**Sensitive Personal Data**
+
+- Financial information, bank account numbers
+- Employment, genetic, biometric or health/medical information (including PHI)
+- Racial, ethnic, political, or religious affiliation
+- Trade union membership, sexual orientation information
+- Account passwords, mother's maiden name, date of birth
+- Criminal history
+
+**Identification Data**
+
+- Identification documents (passports, driver's licenses, national identity cards)
+- Unique government identifiers (SSN, passport numbers, driver's license numbers)
+- Original signatures
+- Date of Birth (when combined with other identifying information)
+
+**Authentication Data or Credentials**
+
+- Data used to validate an entity (person, process or service)
+
+**Non-proprietary data covered by NDA**
+
+**Financial Data**
+
+- Non-public financial statements and disclosures
+- M&A Strategy, Planning & Due diligence records
+- Strategic & Company wide financial plans, forecasts, and budgets
+- Tax strategy and unfiled tax documents
+
+**Legal Proceedings**
+
+- Documentation related to contemplated or actual legal proceedings
+
+**Strategy / Planning Documentation**
+
+- Strategic plans and roadmaps (corporate and business unit level)
+- Annual and multi-year business plans
+- Market and competitive analysis reports
+- Investment and capital allocation strategies
+
+**Non-Public data**
+
+- Securities filings prior to publication
+- Changes in leadership or corporate structure
+- Product launches, strategic partnerships
+- Internal reports on security, ethics, regulatory investigations
+
+**Attorney/Client Privileged Communications**
+
+**Material Non-Public Information (MNPI)**
+
+**Communications with Regulators and Law Enforcement**
+
+### Confidential Data
+
+**Internal communications**
+
+- Any communication created by a Team Member in writing, email or via other communications tools
+
+**Personal Data about current or former employees that is not Restricted Data**
+
+- Tenure, name, job title, job location, work email
+
+**Job Applicant Data**
+
+- CVs and covering letters, interview scorecards
+- Rejection criteria/reason, job offers
+
+**Proprietary Data Intended for Internal Use**
+
+- Source code
+- Twilio trade secrets
+- Twilio intellectual property
+- Product research and development
+- Proprietary computer software
+- AI/ML models
+- Fraud Ops processes and monitoring information
+- SecOps processes and monitoring information
+
+**Non-Public Confidential Financial Data**
+
+- Financial records (Tax Records)
+- Departmental / product level P&L statements
+- Departmental/product level financial reporting and metrics
+
+**Sales and Marketing Data**
+
+- Leads, sales or marketing contacts and profiles
+
+**Customer Account Data**
+
+- Subscriber Records (name, address, IP address)
+- 10DLC registration data
+
+**Feedback**
+
+- Customer feedback through surveys, questionnaires, support interactions
+- Employee feedback in surveys and questionnaires
+
+**Audit & Enterprise Risk Management**
+
+- Audit scoping/planning files
+- Audit fieldwork tests/workpapers
+- Issue logs and remediation tracking
+- Internal audit reports
+- Certifications & attestations
+
+**Internal Procedures and/or Internal Operating Manuals**
+
+**Pseudonymized Data**
+
+**Anonymized Data**
+
+**Any other data produced by Twilio that is not classified as Restricted Data or Public Data**
+
+## Definitions
+
+**GenAI** is developed and pre-trained by third parties (GenAI Service Provider) and learns patterns from existing data (Training Data). This knowledge is then used to generate new and unique output (Output Data). Usually, this Output Data is generated based on a specific command, often called a "prompt", that contains a specific work instruction for the GenAI (Prompt Data). In this way, GenAI is capable of creating complex content that mimics human creativity or offers solutions to specific problems. For some use cases, we may fine-tune the GenAI with our own or a customer's data (Fine-Tuning Data). With the help of this data, it is possible to better adapt and tailor the software to complete specific tasks that meet the needs of Twilio or our customers. In this policy, Prompt Data and Fine-Tuning Data are referred to collectively as Input Data.
+
+**Data** means recorded information, regardless of form, the media on which it is recorded, or the method of recording and includes source code and Personal Data.
+
+**Personal Data** means information relating to an identified or identifiable natural person (data subject). An identifiable natural person is one who can be identified, directly or indirectly, in particular by reference to an identifier, such as a name, an identification number, location data, an online identifier, or one or more factors specific to the physical, psychological, genetic, mental, economic, cultural or social identity of that natural person.
+
+**Team Member** means any Twilio employee, director and Board member, as well as members of our extended workforce, including non-executive directors, independent contractors, contingent, or agency workers and interns.

--- a/.github/workflows/devbox-plugin-integration.yml
+++ b/.github/workflows/devbox-plugin-integration.yml
@@ -1,0 +1,312 @@
+name: Devbox Plugin Integration Tests
+
+on:
+  # Run on PRs that modify devbox plugin integration
+  pull_request:
+    branches:
+      - feat/rn-devbox-plugin
+    paths:
+      - 'examples/E2E-compat/devbox.json'
+      - 'examples/E2E-compat/devbox.lock'
+      - 'examples/E2E-latest/devbox.json'
+      - 'examples/E2E-latest/devbox.lock'
+      - '.github/workflows/devbox-plugin-integration.yml'
+
+  # Weekly schedule - Monday at 10am UTC
+  schedule:
+    - cron: '0 10 * * 1'
+
+  # Manual trigger
+  workflow_dispatch:
+    inputs:
+      example:
+        description: 'Which example to test (E2E-compat, E2E-latest, all)'
+        required: false
+        default: 'all'
+      platform:
+        description: 'Which platform to test (android, ios, both)'
+        required: false
+        default: 'both'
+
+  # Called from release workflow as prerequisite
+  workflow_call:
+    inputs:
+      example:
+        type: string
+        description: 'Which example to test'
+        default: 'all'
+
+concurrency:
+  group: devbox-plugin-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Validate devbox configuration
+  validate-config:
+    name: Validate Devbox Configuration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@v0.15.0
+
+      - name: Validate E2E-compat devbox.json
+        working-directory: examples/E2E-compat
+        run: |
+          echo "Validating devbox.json..."
+          devbox version
+          devbox info
+
+          # Check if mobile-devtools plugin is included
+          if ! grep -q "mobile-devtools" devbox.json; then
+            echo "ERROR: mobile-devtools plugin not found in devbox.json"
+            exit 1
+          fi
+          echo "✓ Configuration valid"
+
+      - name: Validate E2E-latest devbox.json
+        working-directory: examples/E2E-latest
+        run: |
+          echo "Validating devbox.json..."
+          devbox version
+          devbox info
+
+          # Check if mobile-devtools plugin is included
+          if ! grep -q "mobile-devtools" devbox.json; then
+            echo "ERROR: mobile-devtools plugin not found in devbox.json"
+            exit 1
+          fi
+          echo "✓ Configuration valid"
+
+  # Test Android integration
+  test-android-compat:
+    name: Android E2E-compat Build Test
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' && 
+      (inputs.example == 'E2E-compat' || inputs.example == 'all') &&
+      (inputs.platform == 'android' || inputs.platform == 'both') ||
+      github.event_name != 'workflow_dispatch'
+    needs: validate-config
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+          cache-dependency-path: examples/E2E-compat/yarn.lock
+
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@v0.15.0
+
+      - name: Test devbox shell initialization
+        working-directory: examples/E2E-compat
+        run: |
+          echo "Testing devbox shell initialization..."
+          devbox run --pure echo "Shell initialized successfully"
+
+      - name: Verify Android tools available
+        working-directory: examples/E2E-compat
+        run: |
+          echo "Checking Android tools..."
+          devbox run --pure android.sh version || echo "Android tools will be installed on first use"
+
+      - name: Test yarn install
+        working-directory: examples/E2E-compat
+        run: |
+          echo "Testing yarn install..."
+          devbox run install
+
+      - name: Test Android build
+        working-directory: examples/E2E-compat
+        run: |
+          echo "Testing Android build..."
+          devbox run build:android
+
+  test-android-latest:
+    name: Android E2E-latest Build Test
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' && 
+      (inputs.example == 'E2E-latest' || inputs.example == 'all') &&
+      (inputs.platform == 'android' || inputs.platform == 'both') ||
+      github.event_name != 'workflow_dispatch'
+    needs: validate-config
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+          cache-dependency-path: examples/E2E-latest/yarn.lock
+
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@v0.15.0
+
+      - name: Test devbox shell initialization
+        working-directory: examples/E2E-latest
+        run: |
+          echo "Testing devbox shell initialization..."
+          devbox run --pure echo "Shell initialized successfully"
+
+      - name: Verify Android tools available
+        working-directory: examples/E2E-latest
+        run: |
+          echo "Checking Android tools..."
+          devbox run --pure android.sh version || echo "Android tools will be installed on first use"
+
+      - name: Test yarn install
+        working-directory: examples/E2E-latest
+        run: |
+          echo "Testing yarn install..."
+          devbox run install
+
+      - name: Test Android build
+        working-directory: examples/E2E-latest
+        run: |
+          echo "Testing Android build..."
+          devbox run build:android
+
+  # Test iOS integration
+  test-ios-compat:
+    name: iOS E2E-compat Build Test
+    runs-on: macos-14
+    if: |
+      github.event_name == 'workflow_dispatch' && 
+      (inputs.example == 'E2E-compat' || inputs.example == 'all') &&
+      (inputs.platform == 'ios' || inputs.platform == 'both') ||
+      github.event_name != 'workflow_dispatch'
+    needs: validate-config
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+          cache-dependency-path: examples/E2E-compat/yarn.lock
+
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@v0.15.0
+
+      - name: Test devbox shell initialization
+        working-directory: examples/E2E-compat
+        run: |
+          echo "Testing devbox shell initialization..."
+          devbox run --pure echo "Shell initialized successfully"
+
+      - name: Verify iOS tools available
+        working-directory: examples/E2E-compat
+        run: |
+          echo "Checking iOS tools..."
+          devbox run --pure ios.sh version
+
+      - name: Test yarn install
+        working-directory: examples/E2E-compat
+        run: |
+          echo "Testing yarn install..."
+          devbox run install
+
+      - name: Test pod install
+        working-directory: examples/E2E-compat
+        run: |
+          echo "Testing pod install..."
+          devbox run install:pods
+
+      - name: Test iOS build
+        working-directory: examples/E2E-compat
+        run: |
+          echo "Testing iOS build..."
+          devbox run build:ios
+
+  test-ios-latest:
+    name: iOS E2E-latest Build Test
+    runs-on: macos-14
+    if: |
+      github.event_name == 'workflow_dispatch' && 
+      (inputs.example == 'E2E-latest' || inputs.example == 'all') &&
+      (inputs.platform == 'ios' || inputs.platform == 'both') ||
+      github.event_name != 'workflow_dispatch'
+    needs: validate-config
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+          cache-dependency-path: examples/E2E-latest/yarn.lock
+
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@v0.15.0
+
+      - name: Test devbox shell initialization
+        working-directory: examples/E2E-latest
+        run: |
+          echo "Testing devbox shell initialization..."
+          devbox run --pure echo "Shell initialized successfully"
+
+      - name: Verify iOS tools available
+        working-directory: examples/E2E-latest
+        run: |
+          echo "Checking iOS tools..."
+          devbox run --pure ios.sh version
+
+      - name: Test yarn install
+        working-directory: examples/E2E-latest
+        run: |
+          echo "Testing yarn install..."
+          devbox run install
+
+      - name: Test pod install
+        working-directory: examples/E2E-latest
+        run: |
+          echo "Testing pod install..."
+          devbox run install:pods
+
+      - name: Test iOS build
+        working-directory: examples/E2E-latest
+        run: |
+          echo "Testing iOS build..."
+          devbox run build:ios
+
+  # Summary job
+  integration-summary:
+    name: Integration Test Summary
+    runs-on: ubuntu-latest
+    needs:
+      - validate-config
+      - test-android-compat
+      - test-android-latest
+      - test-ios-compat
+      - test-ios-latest
+    if: always()
+    steps:
+      - name: Check results
+        run: |
+          echo "Integration Test Results:"
+          echo "========================="
+          echo "Validation: ${{ needs.validate-config.result }}"
+          echo "Android E2E-compat: ${{ needs.test-android-compat.result }}"
+          echo "Android E2E-latest: ${{ needs.test-android-latest.result }}"
+          echo "iOS E2E-compat: ${{ needs.test-ios-compat.result }}"
+          echo "iOS E2E-latest: ${{ needs.test-ios-latest.result }}"
+
+          # Fail if any job failed
+          if [[ "${{ needs.validate-config.result }}" == "failure" ]] || \
+             [[ "${{ needs.test-android-compat.result }}" == "failure" ]] || \
+             [[ "${{ needs.test-android-latest.result }}" == "failure" ]] || \
+             [[ "${{ needs.test-ios-compat.result }}" == "failure" ]] || \
+             [[ "${{ needs.test-ios-latest.result }}" == "failure" ]]; then
+            echo "One or more integration tests failed"
+            exit 1
+          fi
+
+          echo "All integration tests passed!"

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ AGENTS.md
 
 # Notes and research (not for commit)
 notes/
+examples/**/devbox.d/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,177 @@
+# Claude Code Instructions for analytics-react-native
+
+## Twilio GenAI Policy Compliance
+
+**CRITICAL:** This project is subject to Twilio's Generative AI Policy. You MUST comply with all policy requirements when assisting with this codebase.
+
+### Policy Location
+
+Full policy: `.claude/policies/twilio-genai-policy.md`
+
+### Key Policy Requirements
+
+#### 1. Data Classification - What Can Be Shared
+
+**✅ ALLOWED** - Public Data:
+
+- Published Twilio corporate information
+- Public SEC filings, press releases, product brochures
+- Public presentations, marketing content
+- Code that would be released as open source
+- Publicly available technical knowledge base content
+
+**⚠️ RESTRICTED - DO NOT SHARE:**
+
+- Customer data (names, phone numbers, email addresses, call records)
+- Employee personal data (SSN, health data, performance reviews, salaries)
+- Financial data (internal financial statements, M&A information)
+- Source code with proprietary algorithms or trade secrets
+- Internal communications (Slack messages, emails, meeting recordings)
+- Authentication credentials (passwords, API keys, tokens)
+- Legal documents, MNPI, privileged communications
+
+**See full data classification in policy document.**
+
+#### 2. Code Usage Guidelines
+
+**Permitted code use cases:**
+
+- Generate test code
+- Refactor existing code to be cleaner
+- Generate boilerplate common code
+- Write explanatory documentation and how-tos
+- Answer questions about Twilio's public technical docs
+
+**Prohibited:**
+
+- Sharing proprietary algorithms or trade secrets
+- Using customer data in prompts
+- Sharing code covered by NDA
+
+#### 3. Output Review Requirements
+
+- **Human review required** for all generated output before use
+- **Security testing required** for generated code
+- **Bias review** for any customer-facing or decision-making code
+
+### Compliance Monitoring Instructions
+
+#### Warning Triggers
+
+You MUST warn the user if they request:
+
+1. **Restricted Data Usage:**
+
+   - Using customer names, phone numbers, emails, or communications content
+   - Using employee personal data (SSN, health info, performance data)
+   - Sharing proprietary algorithms or trade secrets
+   - Using financial data, M&A information, or MNPI
+   - Sharing authentication credentials
+
+2. **Policy Violations:**
+   - Generating code that makes automated decisions about individuals
+   - Using third-party IP without permission
+   - Intentionally copying or reproducing pre-existing copyrighted works
+
+#### Example Warning Format
+
+```
+⚠️ POLICY VIOLATION ALERT ⚠️
+
+The request involves [specific violation, e.g., "customer phone numbers" or "employee health data"].
+
+This is classified as [Restricted/Confidential] Data under Twilio's GenAI Policy and cannot be used with this GenAI tool.
+
+ALLOWED ALTERNATIVE: [Suggest safe alternative, e.g., "use anonymized test data" or "work with publicly available examples"]
+
+See: .claude/policies/twilio-genai-policy.md for full policy.
+```
+
+#### Accidental Data Exposure Detection
+
+You MUST alert if the user accidentally pastes or shares:
+
+**Common patterns to detect:**
+
+- Phone numbers (E.164 format: +1-555-...)
+- Email addresses
+- SSNs (###-##-#### format)
+- API keys, tokens, credentials (strings like `sk-...`, `token=...`, `password=...`)
+- Customer names combined with other identifying info
+- Internal Twilio employee names in sensitive contexts
+
+#### Example Exposure Alert Format
+
+```
+🚨 POTENTIAL DATA EXPOSURE DETECTED 🚨
+
+I detected what appears to be [type of data, e.g., "phone numbers" or "API credentials"] in your message.
+
+DATA CLASSIFICATION: [Restricted/Confidential]
+
+IMMEDIATE ACTION REQUIRED:
+1. If this was accidental, do NOT include this data in further prompts
+2. For data breach incidents: Go to Slack and type `/page-security-sirt` with a brief explanation
+3. Contact the Privacy team via ServiceNow form if you're unsure
+
+NEXT STEPS:
+- Remove the sensitive data from your prompt
+- [Suggest sanitized alternative approach]
+
+See: .claude/policies/twilio-genai-policy.md section "Monitoring & Compliance"
+```
+
+### Incident Response & Remedy
+
+If a policy violation occurs:
+
+#### For Data Breach / Exposure Incidents:
+
+1. **IMMEDIATE:** Go to Slack and type `/page-security-sirt` with brief explanation of the incident
+2. Include: What data was exposed, when, and how
+3. Security Incident Response Team will coordinate response
+
+#### For Privacy-Related Questions:
+
+- Contact: Privacy team via ServiceNow form
+- Use for: Data classification questions, privacy impact assessments
+
+#### For Intellectual Property Questions:
+
+- Contact: IP Legal team via ServiceNow
+- Use for: Third-party IP usage, Output Data IP concerns
+
+#### For General Policy Questions:
+
+- Contact: Privacy team via ServiceNow form
+- Exception requests: Chief Privacy Officer approval required
+
+### User-Specific Instructions
+
+**Additional contacts/procedures (if provided by user):**
+
+- [User: please provide any specific Twilio contacts or procedures you want added]
+
+---
+
+## Project-Specific Instructions
+
+This is the Twilio Segment analytics-react-native SDK repository.
+
+### General Guidelines
+
+- Follow existing code style and conventions
+- Write tests for new features
+- Keep PRs focused and reviewable
+- Use conventional commits for commit messages
+
+### Testing
+
+- Run `yarn test` before committing
+- E2E tests are in `examples/E2E-compat` and `examples/E2E-latest`
+
+### CI/CD
+
+- All PRs must pass CI checks
+- Dependabot PRs are grouped weekly
+- E2E tests require enterprise secrets (not available for external PRs)

--- a/examples/E2E-compat/README-devbox.md
+++ b/examples/E2E-compat/README-devbox.md
@@ -1,0 +1,79 @@
+# Devbox Usage Guide
+
+## Quick Start
+
+### iOS Development
+
+```bash
+# Skip Android setup to speed up initialization
+devbox run -e ANDROID_SKIP_SETUP=1 start:ios
+devbox run -e ANDROID_SKIP_SETUP=1 build:ios
+```
+
+### Android Development
+
+```bash
+# Skip iOS setup to speed up initialization
+devbox run -e IOS_SKIP_SETUP=1 start:android
+devbox run -e IOS_SKIP_SETUP=1 build:android
+```
+
+### Both Platforms
+
+```bash
+# No skip flags needed
+devbox run install
+devbox run start:metro
+```
+
+## Available Scripts
+
+### Installation
+
+- `install` - Install yarn dependencies
+- `install:pods` - Install CocoaPods dependencies
+
+### Development
+
+- `start:ios` - Start iOS simulator
+- `start:android` - Start Android emulator
+- `start:metro` - Start Metro bundler
+- `start:app` - Start the app
+
+### Build
+
+- `build:ios` - Build iOS app
+- `build:android` - Build Android app
+
+### Testing
+
+- `test:e2e:ios` - Run iOS E2E tests
+- `test:e2e:android` - Run Android E2E tests
+
+### Cleanup
+
+- `stop:sim` - Stop iOS simulator
+- `stop:emu` - Stop Android emulator
+- `stop:metro` - Stop Metro bundler
+
+## Performance Tips
+
+**Android SDK Warning on macOS**
+If you see Android SDK Nix flake evaluation warnings on macOS when running iOS commands, use:
+
+```bash
+devbox run -e ANDROID_SKIP_SETUP=1 <command>
+```
+
+This skips the Android SDK evaluation which can fail on macOS but doesn't affect iOS development.
+
+**iOS-only or Android-only Development**
+Set the skip flag in your shell:
+
+```bash
+export ANDROID_SKIP_SETUP=1  # For iOS-only work
+# or
+export IOS_SKIP_SETUP=1      # For Android-only work
+```
+
+Then all devbox commands will skip the unnecessary platform setup.

--- a/examples/E2E-compat/android/build.gradle
+++ b/examples/E2E-compat/android/build.gradle
@@ -2,16 +2,18 @@
 
 buildscript {
     ext {
-        // Default to the build-tools pinned in devbox; allow override via ANDROID_BUILD_TOOLS_VERSION.
-        // Keep in sync with nix/flake.nix when ANDROID_BUILD_TOOLS_VERSION is unset.
+        def compileSdkEnv = System.getenv("ANDROID_COMPILE_SDK") ?: System.getenv("ANDROID_MAX_API") ?: "33"
+        def targetSdkEnv = System.getenv("ANDROID_TARGET_SDK") ?: System.getenv("ANDROID_MAX_API") ?: "33"
         buildToolsVersion = System.getenv("ANDROID_BUILD_TOOLS_VERSION") ?: "30.0.3"
         minSdkVersion = 21
-        compileSdkVersion = 33
-        targetSdkVersion = 33
+        compileSdkVersion = compileSdkEnv.toInteger()
+        targetSdkVersion = targetSdkEnv.toInteger()
         kotlinVersion="1.7.20"
 
-        // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
-        ndkVersion = "23.1.7779620"
+        def ndkVersionEnv = System.getenv("ANDROID_NDK_VERSION")
+        if (ndkVersionEnv) {
+            ndkVersion = ndkVersionEnv
+        }
     }
     repositories {
         google()

--- a/examples/E2E-compat/devbox.d/android/hash-overrides.json
+++ b/examples/E2E-compat/devbox.d/android/hash-overrides.json
@@ -1,0 +1,3 @@
+{
+  "https://dl.google.com/android/repository/platform-tools_r37.0.0-darwin.zip": "094a1395683c509fd4d48667da0d8b5ef4d42b2abfcd29f2e8149e2f989357c7"
+}

--- a/examples/E2E-compat/devbox.d/segment-integrations.mobile-devtools.android/devices/devices.lock
+++ b/examples/E2E-compat/devbox.d/segment-integrations.mobile-devtools.android/devices/devices.lock
@@ -1,0 +1,17 @@
+{
+  "devices": [
+    {
+      "name": "medium_phone_api36",
+      "api": 36,
+      "device": "medium_phone",
+      "tag": "google_apis"
+    },
+    {
+      "name": "pixel_api24",
+      "api": 24,
+      "device": "pixel",
+      "tag": "google_apis"
+    }
+  ],
+  "checksum": "9c9adf202cb494e4d6554d790fab9455481658cf70e7d0a0abcdb0ae9824ddc0"
+}

--- a/examples/E2E-compat/devbox.d/segment-integrations.mobile-devtools.android/devices/max.json
+++ b/examples/E2E-compat/devbox.d/segment-integrations.mobile-devtools.android/devices/max.json
@@ -1,0 +1,6 @@
+{
+  "name": "medium_phone_api36",
+  "api": 36,
+  "device": "medium_phone",
+  "tag": "google_apis"
+}

--- a/examples/E2E-compat/devbox.d/segment-integrations.mobile-devtools.android/devices/min.json
+++ b/examples/E2E-compat/devbox.d/segment-integrations.mobile-devtools.android/devices/min.json
@@ -1,0 +1,6 @@
+{
+  "name": "pixel_api24",
+  "api": 24,
+  "device": "pixel",
+  "tag": "google_apis"
+}

--- a/examples/E2E-compat/devbox.d/segment-integrations.mobile-devtools.ios/devices/devices.lock
+++ b/examples/E2E-compat/devbox.d/segment-integrations.mobile-devtools.ios/devices/devices.lock
@@ -1,0 +1,13 @@
+{
+  "devices": [
+    {
+      "name": "iPhone 17",
+      "runtime": "26.2"
+    },
+    {
+      "name": "iPhone 13",
+      "runtime": "15.4"
+    }
+  ],
+  "checksum": "4d5276f203d7ad62860bfc067f76194df53be449d4aa8a3b2d069855ec1f3232"
+}

--- a/examples/E2E-compat/devbox.d/segment-integrations.mobile-devtools.ios/devices/max.json
+++ b/examples/E2E-compat/devbox.d/segment-integrations.mobile-devtools.ios/devices/max.json
@@ -1,0 +1,4 @@
+{
+  "name": "iPhone 17",
+  "runtime": "26.2"
+}

--- a/examples/E2E-compat/devbox.d/segment-integrations.mobile-devtools.ios/devices/min.json
+++ b/examples/E2E-compat/devbox.d/segment-integrations.mobile-devtools.ios/devices/min.json
@@ -1,0 +1,4 @@
+{
+  "name": "iPhone 13",
+  "runtime": "15.4"
+}

--- a/examples/E2E-compat/devbox.json
+++ b/examples/E2E-compat/devbox.json
@@ -56,9 +56,18 @@
         "android.sh emulator start ${1:-${ANDROID_DEFAULT_DEVICE:-max}}"
       ],
       "stop:emu": ["android.sh emulator stop"],
-      "start:ios": ["ios.sh simulator start ${1:-${IOS_DEFAULT_DEVICE:-max}}"],
-      "start:android": [
-        "android.sh emulator start ${1:-${ANDROID_DEFAULT_DEVICE:-max}}"
+      "dev:ios": [
+        "export ANDROID_SKIP_SETUP=1",
+        "yarn install",
+        "(cd ios && pod install)",
+        "ios.sh run ${1:-max}"
+      ],
+      "dev:android": [
+        "export IOS_SKIP_SETUP=1",
+        "yarn install",
+        "(cd android && ./gradlew assembleDebug)",
+        "android.sh emulator start ${1:-max}",
+        "android.sh deploy"
       ]
     }
   }

--- a/examples/E2E-compat/devbox.json
+++ b/examples/E2E-compat/devbox.json
@@ -1,0 +1,58 @@
+{
+  "include": [
+    "github:segment-integrations/mobile-devtools?dir=plugins/react-native"
+  ],
+  "packages": [
+    "nodejs@20",
+    "yarn-berry@latest",
+    "watchman@latest",
+    "jdk17@latest",
+    "gradle@latest"
+  ],
+  "env": {
+    "IOS_APP_SCHEME": "AnalyticsReactNativeE2E",
+    "IOS_APP_BUNDLE_ID": "com.analyticsreactnativeexample",
+    "ANDROID_APP_ID": "com.analyticsreactnativeexample",
+    "ANDROID_APP_APK": "android/app/build/outputs/apk/release/app-release.apk",
+    "ANDROID_MAX_API": "35",
+    "ANDROID_SDK_REQUIRED": "0",
+    "ANDROID_BUILD_TOOLS_VERSION": "30.0.3",
+    "ANDROID_INCLUDE_NDK": "false",
+    "ANDROID_INCLUDE_CMAKE": "false",
+    "GRADLE_OPTS": "-Dorg.gradle.project.android.aapt2FromMavenOverride=$ANDROID_SDK_ROOT/build-tools/30.0.3/aapt2"
+  },
+  "shell": {
+    "scripts": {
+      "install": ["yarn install"],
+      "install:pods": ["(cd ios && pod install)"],
+      "build:android": [
+        "yarn install",
+        "(cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release)"
+      ],
+      "build:ios": [
+        "yarn install",
+        "(cd ios && pod install)",
+        "ios.sh xcodebuild -workspace ios/AnalyticsReactNativeE2E.xcworkspace -scheme AnalyticsReactNativeE2E -configuration Release -sdk iphonesimulator -derivedDataPath ios/build"
+      ],
+      "test:e2e:android": [
+        "yarn install",
+        "(cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release)",
+        "yarn detox test --configuration android.emu.release"
+      ],
+      "test:e2e:ios": [
+        "yarn install",
+        "(cd ios && pod install)",
+        "ios.sh xcodebuild -workspace ios/AnalyticsReactNativeE2E.xcworkspace -scheme AnalyticsReactNativeE2E -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
+        "yarn detox test --configuration ios.sim.release"
+      ],
+      "start:metro": ["metro.sh start ${1:-default}"],
+      "stop:metro": ["metro.sh stop ${1:-default}"],
+      "start:sim": ["ios.sh simulator start ${1:-${IOS_DEFAULT_DEVICE:-max}}"],
+      "stop:sim": ["ios.sh simulator stop"],
+      "start:emu": [
+        "android.sh emulator start ${1:-${ANDROID_DEFAULT_DEVICE:-max}}"
+      ],
+      "stop:emu": ["android.sh emulator stop"]
+    }
+  }
+}

--- a/examples/E2E-compat/devbox.json
+++ b/examples/E2E-compat/devbox.json
@@ -27,10 +27,12 @@
       "install:pods": ["(cd ios && pod install)"],
       "start:app": ["yarn start"],
       "build:android": [
+        "export IOS_SKIP_SETUP=1",
         "yarn install",
         "(cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release)"
       ],
       "build:ios": [
+        "export ANDROID_SKIP_SETUP=1",
         "yarn install",
         "(cd ios && pod install)",
         "ios.sh xcodebuild -workspace ios/AnalyticsReactNativeE2E.xcworkspace -scheme AnalyticsReactNativeE2E -configuration Release -sdk iphonesimulator -derivedDataPath ios/build"
@@ -53,7 +55,11 @@
       "start:emu": [
         "android.sh emulator start ${1:-${ANDROID_DEFAULT_DEVICE:-max}}"
       ],
-      "stop:emu": ["android.sh emulator stop"]
+      "stop:emu": ["android.sh emulator stop"],
+      "start:ios": ["ios.sh simulator start ${1:-${IOS_DEFAULT_DEVICE:-max}}"],
+      "start:android": [
+        "android.sh emulator start ${1:-${ANDROID_DEFAULT_DEVICE:-max}}"
+      ]
     }
   }
 }

--- a/examples/E2E-compat/devbox.json
+++ b/examples/E2E-compat/devbox.json
@@ -25,6 +25,7 @@
     "scripts": {
       "install": ["yarn install"],
       "install:pods": ["(cd ios && pod install)"],
+      "start:app": ["yarn start"],
       "build:android": [
         "yarn install",
         "(cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release)"

--- a/examples/E2E-compat/devbox.lock
+++ b/examples/E2E-compat/devbox.lock
@@ -1,0 +1,1083 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "bash@latest": {
+      "last_modified": "2026-04-10T03:55:24Z",
+      "resolved": "github:NixOS/nixpkgs/9d29d5f667d7467f98efc31881e824fa586c927e#bash",
+      "source": "devbox-search",
+      "version": "5.3p9",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/my9bsdsfxcaxkb400i4xvvh1ahb8pybs-bash-interactive-5.3p9",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/5nwbrxj440mxkv8sqzy3d9xsfpswhkkx-bash-interactive-5.3p9-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/047i8vx61kv70j0xahh65x1p0gs4bzp5-bash-interactive-5.3p9-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/p8v2kq7q82l8cz5axc9lvyj2klib1799-bash-interactive-5.3p9-doc"
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/bqh3ll20jibzdrc42lclk29k144fanak-bash-interactive-5.3p9-info"
+            }
+          ],
+          "store_path": "/nix/store/my9bsdsfxcaxkb400i4xvvh1ahb8pybs-bash-interactive-5.3p9"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/f6lsdzsgbh5mxaaa91gykyi8mqmlzpr2-bash-interactive-5.3p9",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/87ljrnbjn8w6iqf3bzirh6wd7lpmhvzp-bash-interactive-5.3p9-man",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/zyi5m4r7wma9vvvfzg7r99avh8sxg9m1-bash-interactive-5.3p9-debug"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/hkmlf3zy6brfn3xr3magif6c54ln3z4c-bash-interactive-5.3p9-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/l7bcjyprsmzdnrimjg8al47wsr4vsy6q-bash-interactive-5.3p9-doc"
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/cad8ahawmbf12gvh0bq7sf9rjjwbfzg9-bash-interactive-5.3p9-info"
+            }
+          ],
+          "store_path": "/nix/store/f6lsdzsgbh5mxaaa91gykyi8mqmlzpr2-bash-interactive-5.3p9"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/hzc40jxl7zhc1cikxri178a4w6f4fzd6-bash-interactive-5.3p9",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/8lp42ghh8l89v5kj6q5asbfdskssgcxn-bash-interactive-5.3p9-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/jfiwg11dqs0vzg45s58kkabjm0rm8d0c-bash-interactive-5.3p9-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/rlz86kfy3jxfi7ap587rhrm9ynbw2kvc-bash-interactive-5.3p9-doc"
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/d9y32zx4cxwm3h20c0zrzsabjmws3z0m-bash-interactive-5.3p9-info"
+            }
+          ],
+          "store_path": "/nix/store/hzc40jxl7zhc1cikxri178a4w6f4fzd6-bash-interactive-5.3p9"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/sfvyavxai6qvzmv9p9x6mp4wwdz4v41m-bash-interactive-5.3p9",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/lw0v8hggdjsqs9zpwwrxajcc4rbsmlfq-bash-interactive-5.3p9-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/832yrsfhq3z41zn9rqsvv0cv22mblv4c-bash-interactive-5.3p9-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/fy5pa2zv8g7l3v0nn6rpwib8nl4whdx1-bash-interactive-5.3p9-doc"
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/p9lkzmrvl0wqjs4mjv87h5lqcypgrzbp-bash-interactive-5.3p9-info"
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/h979dcfkxhswbsdqcwqbzynaqnz1n5a0-bash-interactive-5.3p9-debug"
+            }
+          ],
+          "store_path": "/nix/store/sfvyavxai6qvzmv9p9x6mp4wwdz4v41m-bash-interactive-5.3p9"
+        }
+      }
+    },
+    "cocoapods@latest": {
+      "last_modified": "2026-03-21T07:29:51Z",
+      "resolved": "github:NixOS/nixpkgs/09061f748ee21f68a089cd5d91ec1859cd93d0be#cocoapods",
+      "source": "devbox-search",
+      "version": "1.16.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/i35dcb5pq1a03ns5qh2d3jsrmfn610qc-cocoapods-1.16.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/i35dcb5pq1a03ns5qh2d3jsrmfn610qc-cocoapods-1.16.2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/9f32j7nxb1n3hdx3g4jl7ha45krrs55d-cocoapods-1.16.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/9f32j7nxb1n3hdx3g4jl7ha45krrs55d-cocoapods-1.16.2"
+        }
+      }
+    },
+    "coreutils@latest": {
+      "last_modified": "2026-03-21T07:29:51Z",
+      "resolved": "github:NixOS/nixpkgs/09061f748ee21f68a089cd5d91ec1859cd93d0be#coreutils",
+      "source": "devbox-search",
+      "version": "9.10",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/akih5l2yxpzqyh63xvyc6zsxl7kl2x4v-coreutils-9.10",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/rqr62g2a1dl14qg090lixy4kyalamxnc-coreutils-9.10-info"
+            }
+          ],
+          "store_path": "/nix/store/akih5l2yxpzqyh63xvyc6zsxl7kl2x4v-coreutils-9.10"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/f03gf7yy36rlr9n1wkblvikq12a3hg6c-coreutils-9.10",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/l7pb1mavzin4hmwpp87f6xisfprrgnr2-coreutils-9.10-debug"
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/802yhcvnd2kp712af4v48klcxqzjgdkp-coreutils-9.10-info"
+            }
+          ],
+          "store_path": "/nix/store/f03gf7yy36rlr9n1wkblvikq12a3hg6c-coreutils-9.10"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/33dari5qaqpza7z0yhyzrjg85xmclg8c-coreutils-9.10",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/mybh7m3jhp3hzp83hsz8aj6w7wr49hxv-coreutils-9.10-info"
+            }
+          ],
+          "store_path": "/nix/store/33dari5qaqpza7z0yhyzrjg85xmclg8c-coreutils-9.10"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/74sind1d6vf2bfwd7yklg8chsvzqxmmq-coreutils-9.10",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/hm1z5hlgc4p99s3vng7g69cqgdn1j93h-coreutils-9.10-debug"
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/c5dpvsjmin1cx3ma6jizdzb26bx2avdl-coreutils-9.10-info"
+            }
+          ],
+          "store_path": "/nix/store/74sind1d6vf2bfwd7yklg8chsvzqxmmq-coreutils-9.10"
+        }
+      }
+    },
+    "curl@latest": {
+      "last_modified": "2025-12-05T15:03:55Z",
+      "resolved": "github:NixOS/nixpkgs/a672be65651c80d3f592a89b3945466584a22069#curl",
+      "source": "devbox-search",
+      "version": "8.17.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/qfwqcndy8bji6xww0gizclf2nqi2qpph-curl-8.17.0-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/rk815zvrhwzbi7c6d589v2mhxzyzb400-curl-8.17.0-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/ydp55g2mbd6rk6lfw0krkk3jwgdiqj5d-curl-8.17.0-dev"
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/8s884m82fmrbiyz8malglqc4sd632dkc-curl-8.17.0-devdoc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/yxv8fxaz0fyhc31dv3rz89kc50zw5hgj-curl-8.17.0"
+            }
+          ],
+          "store_path": "/nix/store/qfwqcndy8bji6xww0gizclf2nqi2qpph-curl-8.17.0-bin"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/4x19j6zihdl6pya63xs8g360f2r614sx-curl-8.17.0-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/b29qbmbfvzkm34k0jnj8ykqg2gzj3rdy-curl-8.17.0-man",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/5hmbdk99knmbg8b0fzh96bv6bkcf6v5i-curl-8.17.0-debug"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/iqs9mjscns3h5npgkrhgr5xa7qzwd0si-curl-8.17.0-dev"
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/1fwncv08c8g78k3hj3cj375vx92ndrp8-curl-8.17.0-devdoc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/b0a6qc92vybjiggh0kg387cg0zp3kl6j-curl-8.17.0"
+            }
+          ],
+          "store_path": "/nix/store/4x19j6zihdl6pya63xs8g360f2r614sx-curl-8.17.0-bin"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/w2336wv560g1n58cwashmmczdn3bfkq1-curl-8.17.0-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/i6xmhcan8g4abda7ivv20nvwxrsssjqj-curl-8.17.0-man",
+              "default": true
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/ipa7v9z7pjcnnv0fmdya1fldcxv0a28z-curl-8.17.0-devdoc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/x9gyg634fi8mgcyay9mqa1ral7xg72fm-curl-8.17.0"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/39zfdgq9kg3mb4sycf8pj4pdssrzki6c-curl-8.17.0-dev"
+            }
+          ],
+          "store_path": "/nix/store/w2336wv560g1n58cwashmmczdn3bfkq1-curl-8.17.0-bin"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/0rfz69vp1nl0q2hxzig20hc60sk72z62-curl-8.17.0-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/ijd0yybyzwm98d3q6x7a9cyixgxk0i5d-curl-8.17.0-man",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/h1fxw0xrifxvbhcp7b8hxsgirxxxfzav-curl-8.17.0-debug"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/ikmdk37frjdblkba3wl3xws2wwgln17x-curl-8.17.0-dev"
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/jm6irg81cc0hqg43l39lkxr6pb0w2xk5-curl-8.17.0-devdoc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/8idis3j5l13c3x74jl8xly0k4qyk9mx6-curl-8.17.0"
+            }
+          ],
+          "store_path": "/nix/store/0rfz69vp1nl0q2hxzig20hc60sk72z62-curl-8.17.0-bin"
+        }
+      }
+    },
+    "findutils@latest": {
+      "last_modified": "2026-04-08T00:40:38Z",
+      "resolved": "github:NixOS/nixpkgs/9a01fad67a57e44e1b3e1d905c6881bcfb209e8a#findutils",
+      "source": "devbox-search",
+      "version": "4.10.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/f9ik2jdvk6shdnzr4l8mibqdiqjd9chb-findutils-4.10.0",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/akvsp7azczr07lxavfky6i25gkqx79n3-findutils-4.10.0-info"
+            },
+            {
+              "name": "locate",
+              "path": "/nix/store/fd90sp8fhlx7jlk18mfc72r11hs0d6rv-findutils-4.10.0-locate"
+            }
+          ],
+          "store_path": "/nix/store/f9ik2jdvk6shdnzr4l8mibqdiqjd9chb-findutils-4.10.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/y9vr3s3grrbzsqx5p17ykls2hpx941yx-findutils-4.10.0",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/f296wzyvi9vb9kp3rxrkj2yfx5am1hag-findutils-4.10.0-info"
+            },
+            {
+              "name": "locate",
+              "path": "/nix/store/878diy3kyyzws9j5nlfs7wapmrarracy-findutils-4.10.0-locate"
+            }
+          ],
+          "store_path": "/nix/store/y9vr3s3grrbzsqx5p17ykls2hpx941yx-findutils-4.10.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/54bjhnl1inrrj9id107ka7hwrl5mpsa1-findutils-4.10.0",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/dww6r3cz24vp29aa0jfi73vmf376qhli-findutils-4.10.0-info"
+            },
+            {
+              "name": "locate",
+              "path": "/nix/store/ssjy8hrfvmh62fbr89bm0s8qac00shqk-findutils-4.10.0-locate"
+            }
+          ],
+          "store_path": "/nix/store/54bjhnl1inrrj9id107ka7hwrl5mpsa1-findutils-4.10.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/c89zz4vh8v9dbs8169wk8ahwxvrdxgm5-findutils-4.10.0",
+              "default": true
+            },
+            {
+              "name": "locate",
+              "path": "/nix/store/l8w8fdc3c75bhd876c3i4s6fbc5i3k34-findutils-4.10.0-locate"
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/x64w9pnrp3yh1yvjb7cg8h7vliji2hfy-findutils-4.10.0-info"
+            }
+          ],
+          "store_path": "/nix/store/c89zz4vh8v9dbs8169wk8ahwxvrdxgm5-findutils-4.10.0"
+        }
+      }
+    },
+    "gawk@latest": {
+      "last_modified": "2026-03-21T07:29:51Z",
+      "resolved": "github:NixOS/nixpkgs/09061f748ee21f68a089cd5d91ec1859cd93d0be#gawk",
+      "source": "devbox-search",
+      "version": "5.3.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/bvrbfzyimpjxwn679252bhbbccnb43nr-gawk-5.3.2",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/xkhjp3qf8qq1pfac021y5llg7576wljk-gawk-5.3.2-man",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/mf63v415741ffpn5fh9hs6vxzhas3h8v-gawk-5.3.2-info"
+            }
+          ],
+          "store_path": "/nix/store/bvrbfzyimpjxwn679252bhbbccnb43nr-gawk-5.3.2"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/rzgfpccg7p882144kakc4b4mxv95zg3q-gawk-5.3.2",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/dgfmhcqbvnlfx2fs9w3w5dalmnr6djsz-gawk-5.3.2-man",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/y1l0b56ssf461yis5qrf5zk1733cm0yv-gawk-5.3.2-info"
+            }
+          ],
+          "store_path": "/nix/store/rzgfpccg7p882144kakc4b4mxv95zg3q-gawk-5.3.2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/i2lrb46rndpc2wdja6769xlfxhx05kw9-gawk-5.3.2",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/qlj30dbgp6xb9nn87yran3dj0znf1a2l-gawk-5.3.2-man",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/y2vvv0aw2413ndgm1qqcnrzx91cznv5h-gawk-5.3.2-info"
+            }
+          ],
+          "store_path": "/nix/store/i2lrb46rndpc2wdja6769xlfxhx05kw9-gawk-5.3.2"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/gg169kyil5vhsg5aqcpagyhs8fwl0r5r-gawk-5.3.2",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/jz0rb4ic9i9adr2ink52mxkn0wqv9qjc-gawk-5.3.2-man",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/3ki6zkzkq6fs2igixc8z4mjwrbm9k9dj-gawk-5.3.2-info"
+            }
+          ],
+          "store_path": "/nix/store/gg169kyil5vhsg5aqcpagyhs8fwl0r5r-gawk-5.3.2"
+        }
+      }
+    },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2026-04-05T15:42:39Z",
+      "resolved": "github:NixOS/nixpkgs/5e11f7acce6c3469bef9df154d78534fa7ae8b6c?lastModified=1775403759"
+    },
+    "gnugrep@latest": {
+      "last_modified": "2026-03-21T07:29:51Z",
+      "resolved": "github:NixOS/nixpkgs/09061f748ee21f68a089cd5d91ec1859cd93d0be#gnugrep",
+      "source": "devbox-search",
+      "version": "3.12",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/mwj8nml055g8w0c2yq1apajcwrqgsg9q-gnugrep-3.12",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/xfqf82s24sj4yp3ib6cpgj2cd52zg72y-gnugrep-3.12-info"
+            }
+          ],
+          "store_path": "/nix/store/mwj8nml055g8w0c2yq1apajcwrqgsg9q-gnugrep-3.12"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/cl5dx515i81xljb5197g2lswr74i07jn-gnugrep-3.12",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/mm4ga4334ibwdxi3k29z7y4vl7w8nfl6-gnugrep-3.12-info"
+            }
+          ],
+          "store_path": "/nix/store/cl5dx515i81xljb5197g2lswr74i07jn-gnugrep-3.12"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/wrqbf7x33xml20d3sbqvh7lzvp520vj9-gnugrep-3.12",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/6y2a1gpp7is7s5qrgrd7y4kkd6kbqn1x-gnugrep-3.12-info"
+            }
+          ],
+          "store_path": "/nix/store/wrqbf7x33xml20d3sbqvh7lzvp520vj9-gnugrep-3.12"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/h6hdbgkfh59np7bi7h8qa76pq27ixz8r-gnugrep-3.12",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/byw885lc6js6jjp78s92gadxvpb3lp9p-gnugrep-3.12-info"
+            }
+          ],
+          "store_path": "/nix/store/h6hdbgkfh59np7bi7h8qa76pq27ixz8r-gnugrep-3.12"
+        }
+      }
+    },
+    "gnused@latest": {
+      "last_modified": "2026-03-21T07:29:51Z",
+      "resolved": "github:NixOS/nixpkgs/09061f748ee21f68a089cd5d91ec1859cd93d0be#gnused",
+      "source": "devbox-search",
+      "version": "4.9",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/m188brzrrd4f0jdiy495vz8pz75j5kpn-gnused-4.9",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/bcfg0qm4y2dkrq5zac93y2gvbx3y2kg5-gnused-4.9-info"
+            }
+          ],
+          "store_path": "/nix/store/m188brzrrd4f0jdiy495vz8pz75j5kpn-gnused-4.9"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/h6b6hd5zrd460779nvb6vphjw9x6lpdw-gnused-4.9",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/rwxb7gp6667nga4j5vvdgmf7gwndhh09-gnused-4.9-info"
+            }
+          ],
+          "store_path": "/nix/store/h6b6hd5zrd460779nvb6vphjw9x6lpdw-gnused-4.9"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/b5q92jh7hdyy1h7dn173rq90mxv2x4gz-gnused-4.9",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/vknbizjry4yl1nhxzywsfidwqwb47jy8-gnused-4.9-info"
+            }
+          ],
+          "store_path": "/nix/store/b5q92jh7hdyy1h7dn173rq90mxv2x4gz-gnused-4.9"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/jpsqy47rdl0j0dvyyzb4kw8gqajw8nx0-gnused-4.9",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/pkqsmhlriqg0xpv5f1vaq3j7l7l8606q-gnused-4.9-info"
+            }
+          ],
+          "store_path": "/nix/store/jpsqy47rdl0j0dvyyzb4kw8gqajw8nx0-gnused-4.9"
+        }
+      }
+    },
+    "gradle@latest": {
+      "last_modified": "2026-03-21T07:29:51Z",
+      "plugin_version": "0.0.1",
+      "resolved": "github:NixOS/nixpkgs/09061f748ee21f68a089cd5d91ec1859cd93d0be#gradle",
+      "source": "devbox-search",
+      "version": "8.14.4",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/6c9g6kaxq56hjjgmh7ilgjc8yccb5m2m-gradle-8.14.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/6c9g6kaxq56hjjgmh7ilgjc8yccb5m2m-gradle-8.14.4"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/aknkvxp3897miwlpx09pwsd1lm8zg3km-gradle-8.14.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/aknkvxp3897miwlpx09pwsd1lm8zg3km-gradle-8.14.4"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/a556642gigy124iq27r5asb8glncnqbw-gradle-8.14.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/a556642gigy124iq27r5asb8glncnqbw-gradle-8.14.4"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/kp833bfvazvbddp3d42rz2h90q7m0gnm-gradle-8.14.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/kp833bfvazvbddp3d42rz2h90q7m0gnm-gradle-8.14.4"
+        }
+      }
+    },
+    "jdk17@latest": {
+      "last_modified": "2025-10-22T20:59:19Z",
+      "resolved": "github:NixOS/nixpkgs/01b6809f7f9d1183a2b3e081f0a1e6f8f415cb09#jdk17",
+      "source": "devbox-search",
+      "version": "17.0.12",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/hlm8a8cnp4hm8xkg0a2yy4kv7cq44jii-zulu-ca-jdk-17.0.12",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/hlm8a8cnp4hm8xkg0a2yy4kv7cq44jii-zulu-ca-jdk-17.0.12"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/i4zgq9685y6284hbf5a7ac9ysb88dvlz-zulu-ca-jdk-17.0.12",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/i4zgq9685y6284hbf5a7ac9ysb88dvlz-zulu-ca-jdk-17.0.12"
+        }
+      }
+    },
+    "jq@latest": {
+      "last_modified": "2026-04-10T03:55:24Z",
+      "resolved": "github:NixOS/nixpkgs/9d29d5f667d7467f98efc31881e824fa586c927e#jq",
+      "source": "devbox-search",
+      "version": "1.8.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/bb450vb2gl547zwba8sihcyilsg2rqfa-jq-1.8.1-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/vs96fwfhd5gjycxs5yc58wkrizscww92-jq-1.8.1-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/irxgyhi0rq34f2y721a26ii09nynq2ha-jq-1.8.1-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/rnkk37licxmcicz44sm368bk2fsrk52j-jq-1.8.1-doc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/y4gq3lbz2nq75cl3v28ixrqrr90pk4lf-jq-1.8.1"
+            }
+          ],
+          "store_path": "/nix/store/bb450vb2gl547zwba8sihcyilsg2rqfa-jq-1.8.1-bin"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/h68aklwk28xbrg7pqaw078w1hvvvf419-jq-1.8.1-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/l4npc0sgk51lz2d6jqnl4r18hmn6qckr-jq-1.8.1-man",
+              "default": true
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/5jf55qkwrnd769ri9wxiy7z9kp5zb4ca-jq-1.8.1"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/kzsszlf69lndqilpgysw1j9b4hrfwjfx-jq-1.8.1-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/rr0a4brsd47393640zn9zgw844rbkrsl-jq-1.8.1-doc"
+            }
+          ],
+          "store_path": "/nix/store/h68aklwk28xbrg7pqaw078w1hvvvf419-jq-1.8.1-bin"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/y699jyfkqhj7lm51zdxm1df28izg6zgj-jq-1.8.1-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/0h261wdn6mlrn564adwhyw52a2dfnbg5-jq-1.8.1-man",
+              "default": true
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/44i56yshwqwgw912idz0m9zx30d1xg8z-jq-1.8.1"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/681w0vijzacwyhcwylkvbppd4kps33fw-jq-1.8.1-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/2bvvha8apma6crzhsnpjrghnjbjj6hpm-jq-1.8.1-doc"
+            }
+          ],
+          "store_path": "/nix/store/y699jyfkqhj7lm51zdxm1df28izg6zgj-jq-1.8.1-bin"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/fc13hvlj7541i1xmwdka7f61qicdzr5a-jq-1.8.1-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/crwv17pim6csnfr4jmsd7kf60sp3c5dh-jq-1.8.1-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/plinh1rzkh83n4gfpkxl748zgaydpxll-jq-1.8.1-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/ihgrvb9w91mwbhxx3fi3gcwwx3qlsdfv-jq-1.8.1-doc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/s4w1j16dj8wyriv1ljfypr9s1r39yjwp-jq-1.8.1"
+            }
+          ],
+          "store_path": "/nix/store/fc13hvlj7541i1xmwdka7f61qicdzr5a-jq-1.8.1-bin"
+        }
+      }
+    },
+    "lsof@latest": {
+      "last_modified": "2026-03-21T07:29:51Z",
+      "resolved": "github:NixOS/nixpkgs/09061f748ee21f68a089cd5d91ec1859cd93d0be#lsof",
+      "source": "devbox-search",
+      "version": "4.99.5",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/62acjqa4jh4ahxjmpg23rk33lbzfhjc8-lsof-4.99.5",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/62acjqa4jh4ahxjmpg23rk33lbzfhjc8-lsof-4.99.5"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/81b2gqg2l1dsqa78xgysw4b0ph1vw6g9-lsof-4.99.5",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/81b2gqg2l1dsqa78xgysw4b0ph1vw6g9-lsof-4.99.5"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/9jzx3cnpqrx7wl30fkhiffxqswa8yh8h-lsof-4.99.5",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/9jzx3cnpqrx7wl30fkhiffxqswa8yh8h-lsof-4.99.5"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/fvld6vhdnpvqynigaj396s50mvsyv6wf-lsof-4.99.5",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/fvld6vhdnpvqynigaj396s50mvsyv6wf-lsof-4.99.5"
+        }
+      }
+    },
+    "nodejs@20": {
+      "last_modified": "2026-03-27T11:17:38Z",
+      "plugin_version": "0.0.2",
+      "resolved": "github:NixOS/nixpkgs/832efc09b4caf6b4569fbf9dc01bec3082a00611#nodejs_20",
+      "source": "devbox-search",
+      "version": "20.20.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/vamh3ysrfc0qz2mdhh6klyi5ngaffl0q-nodejs-20.20.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/vamh3ysrfc0qz2mdhh6klyi5ngaffl0q-nodejs-20.20.2"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/b1i1izsybrhzifbrr84nbmw62fl07ia2-nodejs-20.20.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/b1i1izsybrhzifbrr84nbmw62fl07ia2-nodejs-20.20.2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/yg5qivw8g8gxpc536kwc0fg73nviiv9l-nodejs-20.20.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/yg5qivw8g8gxpc536kwc0fg73nviiv9l-nodejs-20.20.2"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/1gw2r0h59vr5dzcilhg1xvzjqgn84f8b-nodejs-20.20.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/1gw2r0h59vr5dzcilhg1xvzjqgn84f8b-nodejs-20.20.2"
+        }
+      }
+    },
+    "process-compose@latest": {
+      "last_modified": "2026-04-09T02:28:59Z",
+      "resolved": "github:NixOS/nixpkgs/0f7663154ff2fec150f9dbf5f81ec2785dc1e0db#process-compose",
+      "source": "devbox-search",
+      "version": "1.103.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/nixhpjff0szv8d5fmddg0j05i1z6q043-process-compose-1.103.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/nixhpjff0szv8d5fmddg0j05i1z6q043-process-compose-1.103.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/w1clc7v7szz5358hv4acbrqrzkfab3vn-process-compose-1.103.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/w1clc7v7szz5358hv4acbrqrzkfab3vn-process-compose-1.103.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/7vv4g9023nbirl7mybvqm8cpyqr4mkw6-process-compose-1.103.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/7vv4g9023nbirl7mybvqm8cpyqr4mkw6-process-compose-1.103.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/sxjclxf77jkxyifxhkaar31507i12syv-process-compose-1.103.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/sxjclxf77jkxyifxhkaar31507i12syv-process-compose-1.103.0"
+        }
+      }
+    },
+    "watchman@latest": {
+      "last_modified": "2026-03-21T07:29:51Z",
+      "resolved": "github:NixOS/nixpkgs/09061f748ee21f68a089cd5d91ec1859cd93d0be#watchman",
+      "source": "devbox-search",
+      "version": "2026.01.19.00",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/3p7j7vzyzzvlldbdf4g0k9kdhcv641qx-watchman-2026.01.19.00",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/3p7j7vzyzzvlldbdf4g0k9kdhcv641qx-watchman-2026.01.19.00"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/aap3ns8dgy6pxmfvx4rkh6nrl9y345wk-watchman-2026.01.19.00",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/aap3ns8dgy6pxmfvx4rkh6nrl9y345wk-watchman-2026.01.19.00"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/0m1shdvd1x91w5nfskv3zds9i8d1jfav-watchman-2026.01.19.00",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/0m1shdvd1x91w5nfskv3zds9i8d1jfav-watchman-2026.01.19.00"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/lv1qzn9m2dc7fq6k0nx5azr370f1l73r-watchman-2026.01.19.00",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/lv1qzn9m2dc7fq6k0nx5azr370f1l73r-watchman-2026.01.19.00"
+        }
+      }
+    },
+    "yarn-berry@latest": {
+      "last_modified": "2026-03-21T07:29:51Z",
+      "resolved": "github:NixOS/nixpkgs/09061f748ee21f68a089cd5d91ec1859cd93d0be#yarn-berry",
+      "source": "devbox-search",
+      "version": "4.13.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/b1md6hp71c5lcgj7nn2iqm69qryry1nn-yarn-berry-4.13.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/b1md6hp71c5lcgj7nn2iqm69qryry1nn-yarn-berry-4.13.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/p64sf0mkrr5zp6ikaa5lq05554n4960s-yarn-berry-4.13.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/p64sf0mkrr5zp6ikaa5lq05554n4960s-yarn-berry-4.13.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/gd4bawwhkrvwxms96vq1z0vpy8j51fra-yarn-berry-4.13.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/gd4bawwhkrvwxms96vq1z0vpy8j51fra-yarn-berry-4.13.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/gr19h6hyx64amxbh334csgsqgjhljwyx-yarn-berry-4.13.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/gr19h6hyx64amxbh334csgsqgjhljwyx-yarn-berry-4.13.0"
+        }
+      }
+    }
+  }
+}

--- a/examples/E2E-compat/gradle.properties
+++ b/examples/E2E-compat/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.java.home=/nix/store/hlm8a8cnp4hm8xkg0a2yy4kv7cq44jii-zulu-ca-jdk-17.0.12

--- a/examples/E2E-compat/test_build.gradle
+++ b/examples/E2E-compat/test_build.gradle
@@ -1,0 +1,11 @@
+// Simulate the buildscript setup
+ext {
+    def ndkVersionEnv = System.getenv("ANDROID_NDK_VERSION")
+    if (ndkVersionEnv) {
+        ndkVersion = ndkVersionEnv
+    }
+}
+
+// Test accessing the property
+println "Has ndkVersion property: " + ext.has("ndkVersion")
+println "ndkVersion value: " + (ext.has("ndkVersion") ? ext.ndkVersion : "NOT SET")

--- a/examples/E2E-latest/README-devbox.md
+++ b/examples/E2E-latest/README-devbox.md
@@ -1,0 +1,79 @@
+# Devbox Usage Guide
+
+## Quick Start
+
+### iOS Development
+
+```bash
+# Skip Android setup to speed up initialization
+devbox run -e ANDROID_SKIP_SETUP=1 start:ios
+devbox run -e ANDROID_SKIP_SETUP=1 build:ios
+```
+
+### Android Development
+
+```bash
+# Skip iOS setup to speed up initialization
+devbox run -e IOS_SKIP_SETUP=1 start:android
+devbox run -e IOS_SKIP_SETUP=1 build:android
+```
+
+### Both Platforms
+
+```bash
+# No skip flags needed
+devbox run install
+devbox run start:metro
+```
+
+## Available Scripts
+
+### Installation
+
+- `install` - Install yarn dependencies
+- `install:pods` - Install CocoaPods dependencies
+
+### Development
+
+- `start:ios` - Start iOS simulator
+- `start:android` - Start Android emulator
+- `start:metro` - Start Metro bundler
+- `start:app` - Start the app
+
+### Build
+
+- `build:ios` - Build iOS app
+- `build:android` - Build Android app
+
+### Testing
+
+- `test:e2e:ios` - Run iOS E2E tests
+- `test:e2e:android` - Run Android E2E tests
+
+### Cleanup
+
+- `stop:sim` - Stop iOS simulator
+- `stop:emu` - Stop Android emulator
+- `stop:metro` - Stop Metro bundler
+
+## Performance Tips
+
+**Android SDK Warning on macOS**
+If you see Android SDK Nix flake evaluation warnings on macOS when running iOS commands, use:
+
+```bash
+devbox run -e ANDROID_SKIP_SETUP=1 <command>
+```
+
+This skips the Android SDK evaluation which can fail on macOS but doesn't affect iOS development.
+
+**iOS-only or Android-only Development**
+Set the skip flag in your shell:
+
+```bash
+export ANDROID_SKIP_SETUP=1  # For iOS-only work
+# or
+export IOS_SKIP_SETUP=1      # For Android-only work
+```
+
+Then all devbox commands will skip the unnecessary platform setup.

--- a/examples/E2E-latest/android/build.gradle
+++ b/examples/E2E-latest/android/build.gradle
@@ -2,16 +2,18 @@
 
 buildscript {
     ext {
-        // Default to the build-tools pinned in devbox; allow override via ANDROID_BUILD_TOOLS_VERSION.
-        // Keep in sync with nix/flake.nix when ANDROID_BUILD_TOOLS_VERSION is unset.
+        def compileSdkEnv = System.getenv("ANDROID_COMPILE_SDK") ?: System.getenv("ANDROID_MAX_API") ?: "33"
+        def targetSdkEnv = System.getenv("ANDROID_TARGET_SDK") ?: System.getenv("ANDROID_MAX_API") ?: "33"
         buildToolsVersion = System.getenv("ANDROID_BUILD_TOOLS_VERSION") ?: "30.0.3"
         minSdkVersion = 21
-        compileSdkVersion = 33
-        targetSdkVersion = 33
+        compileSdkVersion = compileSdkEnv.toInteger()
+        targetSdkVersion = targetSdkEnv.toInteger()
         kotlinVersion="1.7.20"
 
-        // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
-        ndkVersion = "23.1.7779620"
+        def ndkVersionEnv = System.getenv("ANDROID_NDK_VERSION")
+        if (ndkVersionEnv) {
+            ndkVersion = ndkVersionEnv
+        }
     }
     repositories {
         google()

--- a/examples/E2E-latest/devbox.d/android/hash-overrides.json
+++ b/examples/E2E-latest/devbox.d/android/hash-overrides.json
@@ -1,0 +1,3 @@
+{
+  "https://dl.google.com/android/repository/platform-tools_r37.0.0-darwin.zip": "094a1395683c509fd4d48667da0d8b5ef4d42b2abfcd29f2e8149e2f989357c7"
+}

--- a/examples/E2E-latest/devbox.json
+++ b/examples/E2E-latest/devbox.json
@@ -26,10 +26,12 @@
       "install:pods": ["(cd ios && pod install)"],
       "start:app": ["yarn start"],
       "build:android": [
+        "export IOS_SKIP_SETUP=1",
         "yarn install",
         "(cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release)"
       ],
       "build:ios": [
+        "export ANDROID_SKIP_SETUP=1",
         "yarn install",
         "(cd ios && pod install)",
         "ios.sh xcodebuild -workspace ios/AnalyticsReactNativeE2E.xcworkspace -scheme AnalyticsReactNativeE2E -configuration Release -sdk iphonesimulator -derivedDataPath ios/build"
@@ -52,7 +54,11 @@
       "start:emu": [
         "android.sh emulator start ${1:-${ANDROID_DEFAULT_DEVICE:-max}}"
       ],
-      "stop:emu": ["android.sh emulator stop"]
+      "stop:emu": ["android.sh emulator stop"],
+      "start:ios": ["ios.sh simulator start ${1:-${IOS_DEFAULT_DEVICE:-max}}"],
+      "start:android": [
+        "android.sh emulator start ${1:-${ANDROID_DEFAULT_DEVICE:-max}}"
+      ]
     }
   }
 }

--- a/examples/E2E-latest/devbox.json
+++ b/examples/E2E-latest/devbox.json
@@ -24,6 +24,7 @@
     "scripts": {
       "install": ["yarn install"],
       "install:pods": ["(cd ios && pod install)"],
+      "start:app": ["yarn start"],
       "build:android": [
         "yarn install",
         "(cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release)"

--- a/examples/E2E-latest/devbox.json
+++ b/examples/E2E-latest/devbox.json
@@ -1,0 +1,57 @@
+{
+  "include": [
+    "github:segment-integrations/mobile-devtools?dir=plugins/react-native"
+  ],
+  "packages": [
+    "nodejs@20",
+    "yarn-berry@latest",
+    "watchman@latest",
+    "jdk17@latest",
+    "gradle@latest"
+  ],
+  "env": {
+    "IOS_APP_SCHEME": "AnalyticsReactNativeE2E",
+    "IOS_APP_BUNDLE_ID": "com.analyticsreactnativeexample",
+    "ANDROID_APP_ID": "com.analyticsreactnativeexample",
+    "ANDROID_APP_APK": "android/app/build/outputs/apk/release/app-release.apk",
+    "ANDROID_MAX_API": "35",
+    "ANDROID_SDK_REQUIRED": "0",
+    "ANDROID_INCLUDE_NDK": "false",
+    "ANDROID_INCLUDE_CMAKE": "false",
+    "GRADLE_OPTS": "-Dorg.gradle.project.android.aapt2FromMavenOverride=$ANDROID_SDK_ROOT/build-tools/36.1.0/aapt2"
+  },
+  "shell": {
+    "scripts": {
+      "install": ["yarn install"],
+      "install:pods": ["(cd ios && pod install)"],
+      "build:android": [
+        "yarn install",
+        "(cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release)"
+      ],
+      "build:ios": [
+        "yarn install",
+        "(cd ios && pod install)",
+        "ios.sh xcodebuild -workspace ios/AnalyticsReactNativeE2E.xcworkspace -scheme AnalyticsReactNativeE2E -configuration Release -sdk iphonesimulator -derivedDataPath ios/build"
+      ],
+      "test:e2e:android": [
+        "yarn install",
+        "(cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release)",
+        "yarn detox test --configuration android.emu.release"
+      ],
+      "test:e2e:ios": [
+        "yarn install",
+        "(cd ios && pod install)",
+        "ios.sh xcodebuild -workspace ios/AnalyticsReactNativeE2E.xcworkspace -scheme AnalyticsReactNativeE2E -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
+        "yarn detox test --configuration ios.sim.release"
+      ],
+      "start:metro": ["metro.sh start ${1:-default}"],
+      "stop:metro": ["metro.sh stop ${1:-default}"],
+      "start:sim": ["ios.sh simulator start ${1:-${IOS_DEFAULT_DEVICE:-max}}"],
+      "stop:sim": ["ios.sh simulator stop"],
+      "start:emu": [
+        "android.sh emulator start ${1:-${ANDROID_DEFAULT_DEVICE:-max}}"
+      ],
+      "stop:emu": ["android.sh emulator stop"]
+    }
+  }
+}

--- a/examples/E2E-latest/devbox.json
+++ b/examples/E2E-latest/devbox.json
@@ -55,9 +55,18 @@
         "android.sh emulator start ${1:-${ANDROID_DEFAULT_DEVICE:-max}}"
       ],
       "stop:emu": ["android.sh emulator stop"],
-      "start:ios": ["ios.sh simulator start ${1:-${IOS_DEFAULT_DEVICE:-max}}"],
-      "start:android": [
-        "android.sh emulator start ${1:-${ANDROID_DEFAULT_DEVICE:-max}}"
+      "dev:ios": [
+        "export ANDROID_SKIP_SETUP=1",
+        "yarn install",
+        "(cd ios && pod install)",
+        "ios.sh run ${1:-max}"
+      ],
+      "dev:android": [
+        "export IOS_SKIP_SETUP=1",
+        "yarn install",
+        "(cd android && ./gradlew assembleDebug)",
+        "android.sh emulator start ${1:-max}",
+        "android.sh deploy"
       ]
     }
   }

--- a/examples/E2E-latest/devbox.lock
+++ b/examples/E2E-latest/devbox.lock
@@ -1,0 +1,1083 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "bash@latest": {
+      "last_modified": "2026-04-23T13:07:47Z",
+      "resolved": "github:NixOS/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30#bash",
+      "source": "devbox-search",
+      "version": "5.3p9",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/in4yc03diyvs2n2wgf3nva4hbvml8v1j-bash-interactive-5.3p9",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/1gjr5smhr73ya2bnvjr55ik4w8l9za9m-bash-interactive-5.3p9-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/6wxmagb455g12diam7bf305f5qs6j0pb-bash-interactive-5.3p9-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/vmqw6a17fkxb0h7cdkwwayv4zcr7ilrh-bash-interactive-5.3p9-doc"
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/2y400c3b7xxqaw7z9javmgzivb7p79dx-bash-interactive-5.3p9-info"
+            }
+          ],
+          "store_path": "/nix/store/in4yc03diyvs2n2wgf3nva4hbvml8v1j-bash-interactive-5.3p9"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/kqh7aw6sj1b0kzfkx2fxm8ij4lkc0735-bash-interactive-5.3p9",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/pqjf0sh448pfbnznf358c5shnz8gj9a3-bash-interactive-5.3p9-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/af91fyhrr83yjmv0hvmg8qwllw3qk5mg-bash-interactive-5.3p9-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/kna8sq16gxiw9qx5xnyd73l07pn7fymd-bash-interactive-5.3p9-doc"
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/8fx6ic9ajwmsyg5afrgyjpks2r2ibabp-bash-interactive-5.3p9-info"
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/ds70877s3ssafag7acjv694m8sjg3rjj-bash-interactive-5.3p9-debug"
+            }
+          ],
+          "store_path": "/nix/store/kqh7aw6sj1b0kzfkx2fxm8ij4lkc0735-bash-interactive-5.3p9"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/7i5gfqa19rj4sydhl2rbb6spcisis1c9-bash-interactive-5.3p9",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/k48vfj52w13xhqfs8rjkk25k5ian1xzs-bash-interactive-5.3p9-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/a5jlanqwr330df9f7wj231zwls57b2w9-bash-interactive-5.3p9-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/r32ymasfy6z5x0394hgifkfcqj175d4h-bash-interactive-5.3p9-doc"
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/syfrnwhbm2zlyilq14ks773h0yjrj5jc-bash-interactive-5.3p9-info"
+            }
+          ],
+          "store_path": "/nix/store/7i5gfqa19rj4sydhl2rbb6spcisis1c9-bash-interactive-5.3p9"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/4bwbk4an4bx7cb8xwffghvjjyfyl7m2i-bash-interactive-5.3p9",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/arys3dnblxv60q8b575scyd6b97s0yzi-bash-interactive-5.3p9-man",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/5lz4ynx0dvpx4rlq3h7ab82hbbkmfhp8-bash-interactive-5.3p9-debug"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/5bs057cgp4nxqff22jg0k1svs121z6a8-bash-interactive-5.3p9-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/ycaqnajbv2sb0hi0cm5hsg5ri8ywih7x-bash-interactive-5.3p9-doc"
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/cg59l95m74xywr3y3px4iir4jw09a3rp-bash-interactive-5.3p9-info"
+            }
+          ],
+          "store_path": "/nix/store/4bwbk4an4bx7cb8xwffghvjjyfyl7m2i-bash-interactive-5.3p9"
+        }
+      }
+    },
+    "cocoapods@latest": {
+      "last_modified": "2026-04-23T13:07:47Z",
+      "resolved": "github:NixOS/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30#cocoapods",
+      "source": "devbox-search",
+      "version": "1.16.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/sgbrbfkwi2zgnyk3sbnwasmfflqhivvv-cocoapods-1.16.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/sgbrbfkwi2zgnyk3sbnwasmfflqhivvv-cocoapods-1.16.2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/fgslxgfiillqi59zfhzbljl2dfz2pkl2-cocoapods-1.16.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/fgslxgfiillqi59zfhzbljl2dfz2pkl2-cocoapods-1.16.2"
+        }
+      }
+    },
+    "coreutils@latest": {
+      "last_modified": "2026-04-23T13:07:47Z",
+      "resolved": "github:NixOS/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30#coreutils",
+      "source": "devbox-search",
+      "version": "9.10",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/nixxlz2dfdwmy6r8da5sas4nrnj7sq3z-coreutils-9.10",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/g31k47nqwv2v7m236i5f16zv7v5xgwz9-coreutils-9.10-info"
+            }
+          ],
+          "store_path": "/nix/store/nixxlz2dfdwmy6r8da5sas4nrnj7sq3z-coreutils-9.10"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/xs45f7342j015kywha1dc0asbvvw1xfw-coreutils-9.10",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/20b5irws8z0cllddnwsbb844pms1akzs-coreutils-9.10-debug"
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/cyq8sccm08p8a7kiwclnf4dk3mkp0h54-coreutils-9.10-info"
+            }
+          ],
+          "store_path": "/nix/store/xs45f7342j015kywha1dc0asbvvw1xfw-coreutils-9.10"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/imxdgy6dqqmhb3mzzxg14zkfxx9vc1w0-coreutils-9.10",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/2x1zm1h7hxqkkd07xl5430xh66dgvncg-coreutils-9.10-info"
+            }
+          ],
+          "store_path": "/nix/store/imxdgy6dqqmhb3mzzxg14zkfxx9vc1w0-coreutils-9.10"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/jjxngswsb214vb58qx485jhmilf0kxxy-coreutils-9.10",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/klz3g7klbxdv03dk7vnp1j8g4188xz95-coreutils-9.10-info"
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/qxz76anix4lizckx1f438sii1m8xgyh2-coreutils-9.10-debug"
+            }
+          ],
+          "store_path": "/nix/store/jjxngswsb214vb58qx485jhmilf0kxxy-coreutils-9.10"
+        }
+      }
+    },
+    "curl@latest": {
+      "last_modified": "2025-12-05T15:03:55Z",
+      "resolved": "github:NixOS/nixpkgs/a672be65651c80d3f592a89b3945466584a22069#curl",
+      "source": "devbox-search",
+      "version": "8.17.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/qfwqcndy8bji6xww0gizclf2nqi2qpph-curl-8.17.0-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/rk815zvrhwzbi7c6d589v2mhxzyzb400-curl-8.17.0-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/ydp55g2mbd6rk6lfw0krkk3jwgdiqj5d-curl-8.17.0-dev"
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/8s884m82fmrbiyz8malglqc4sd632dkc-curl-8.17.0-devdoc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/yxv8fxaz0fyhc31dv3rz89kc50zw5hgj-curl-8.17.0"
+            }
+          ],
+          "store_path": "/nix/store/qfwqcndy8bji6xww0gizclf2nqi2qpph-curl-8.17.0-bin"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/4x19j6zihdl6pya63xs8g360f2r614sx-curl-8.17.0-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/b29qbmbfvzkm34k0jnj8ykqg2gzj3rdy-curl-8.17.0-man",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/5hmbdk99knmbg8b0fzh96bv6bkcf6v5i-curl-8.17.0-debug"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/iqs9mjscns3h5npgkrhgr5xa7qzwd0si-curl-8.17.0-dev"
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/1fwncv08c8g78k3hj3cj375vx92ndrp8-curl-8.17.0-devdoc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/b0a6qc92vybjiggh0kg387cg0zp3kl6j-curl-8.17.0"
+            }
+          ],
+          "store_path": "/nix/store/4x19j6zihdl6pya63xs8g360f2r614sx-curl-8.17.0-bin"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/w2336wv560g1n58cwashmmczdn3bfkq1-curl-8.17.0-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/i6xmhcan8g4abda7ivv20nvwxrsssjqj-curl-8.17.0-man",
+              "default": true
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/ipa7v9z7pjcnnv0fmdya1fldcxv0a28z-curl-8.17.0-devdoc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/x9gyg634fi8mgcyay9mqa1ral7xg72fm-curl-8.17.0"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/39zfdgq9kg3mb4sycf8pj4pdssrzki6c-curl-8.17.0-dev"
+            }
+          ],
+          "store_path": "/nix/store/w2336wv560g1n58cwashmmczdn3bfkq1-curl-8.17.0-bin"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/0rfz69vp1nl0q2hxzig20hc60sk72z62-curl-8.17.0-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/ijd0yybyzwm98d3q6x7a9cyixgxk0i5d-curl-8.17.0-man",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/h1fxw0xrifxvbhcp7b8hxsgirxxxfzav-curl-8.17.0-debug"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/ikmdk37frjdblkba3wl3xws2wwgln17x-curl-8.17.0-dev"
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/jm6irg81cc0hqg43l39lkxr6pb0w2xk5-curl-8.17.0-devdoc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/8idis3j5l13c3x74jl8xly0k4qyk9mx6-curl-8.17.0"
+            }
+          ],
+          "store_path": "/nix/store/0rfz69vp1nl0q2hxzig20hc60sk72z62-curl-8.17.0-bin"
+        }
+      }
+    },
+    "findutils@latest": {
+      "last_modified": "2026-04-23T13:07:47Z",
+      "resolved": "github:NixOS/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30#findutils",
+      "source": "devbox-search",
+      "version": "4.10.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/n97958y53ykgb2zlwa0sgq7crgi9lrgh-findutils-4.10.0",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/9rpy3c7qw4m8ksj0sbkckg786d0kd66v-findutils-4.10.0-info"
+            },
+            {
+              "name": "locate",
+              "path": "/nix/store/g896lgyqk0r3f3q4sffv51ch6hb5vlym-findutils-4.10.0-locate"
+            }
+          ],
+          "store_path": "/nix/store/n97958y53ykgb2zlwa0sgq7crgi9lrgh-findutils-4.10.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/2vawi33dp0n3rr6zhyzh1mva54gzb50y-findutils-4.10.0",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/yniq9cnn8nn12d7gbx9q0ylyi67izgj5-findutils-4.10.0-info"
+            },
+            {
+              "name": "locate",
+              "path": "/nix/store/657k0f4s1h1db1kcp3dhh5dwsidh75ds-findutils-4.10.0-locate"
+            }
+          ],
+          "store_path": "/nix/store/2vawi33dp0n3rr6zhyzh1mva54gzb50y-findutils-4.10.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/mprw66cb0p679kr60yf29bmk0c9zm9qr-findutils-4.10.0",
+              "default": true
+            },
+            {
+              "name": "locate",
+              "path": "/nix/store/7lmqqhg92k2dxdv64as3j6qmwj65r2g8-findutils-4.10.0-locate"
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/kjkhyvqzsa6cra848nynawf69c4gqckn-findutils-4.10.0-info"
+            }
+          ],
+          "store_path": "/nix/store/mprw66cb0p679kr60yf29bmk0c9zm9qr-findutils-4.10.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/vhsirn9m1ifmnw5g1qczzhvqkx6lw1if-findutils-4.10.0",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/rdw2hdlhs0nr6d7xmxy0m5vzpm5wlfvq-findutils-4.10.0-info"
+            },
+            {
+              "name": "locate",
+              "path": "/nix/store/70rrynqpcbwsiwkdv9dqcha4360nysc9-findutils-4.10.0-locate"
+            }
+          ],
+          "store_path": "/nix/store/vhsirn9m1ifmnw5g1qczzhvqkx6lw1if-findutils-4.10.0"
+        }
+      }
+    },
+    "gawk@latest": {
+      "last_modified": "2026-04-23T13:07:47Z",
+      "resolved": "github:NixOS/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30#gawk",
+      "source": "devbox-search",
+      "version": "5.4.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/2yp79k76hcqpwprz6lmxdyd63hpzbkch-gawk-5.4.0",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/xz53x9dc6y86i95and05b1nmbajgk1wc-gawk-5.4.0-man",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/4mf1zqqv0fpdmvv7cr3mjn0ksqrngyb0-gawk-5.4.0-info"
+            }
+          ],
+          "store_path": "/nix/store/2yp79k76hcqpwprz6lmxdyd63hpzbkch-gawk-5.4.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/28gh3qmd0c8bh2dnsrb33yhmfdcp6r4f-gawk-5.4.0",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/v23sp1fhxhp0iv5dnc23ix9q64v1c686-gawk-5.4.0-man",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/lcy8c9phrcdd3n0w9wdzvqln1r642qqx-gawk-5.4.0-info"
+            }
+          ],
+          "store_path": "/nix/store/28gh3qmd0c8bh2dnsrb33yhmfdcp6r4f-gawk-5.4.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/qyg1250nq4g17nrj7x6r7w4hqcccm4v6-gawk-5.4.0",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/94ad3w0fbs5yfkl9gyb9haha3ypsaxc7-gawk-5.4.0-man",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/7kz7gyxrxbrg292512ls4p3wlphy4d51-gawk-5.4.0-info"
+            }
+          ],
+          "store_path": "/nix/store/qyg1250nq4g17nrj7x6r7w4hqcccm4v6-gawk-5.4.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/lakv43kv98sl6h0ba6wnyg513mcq61vl-gawk-5.4.0",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/468b2h9fa3wdlf89175w1h8vhqm3ry64-gawk-5.4.0-man",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/2nwnpzy2sfj9a7bl7501r3hz48nhiszz-gawk-5.4.0-info"
+            }
+          ],
+          "store_path": "/nix/store/lakv43kv98sl6h0ba6wnyg513mcq61vl-gawk-5.4.0"
+        }
+      }
+    },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2026-04-16T08:46:55Z",
+      "resolved": "github:NixOS/nixpkgs/b86751bc4085f48661017fa226dee99fab6c651b?lastModified=1776329215"
+    },
+    "gnugrep@latest": {
+      "last_modified": "2026-04-23T13:07:47Z",
+      "resolved": "github:NixOS/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30#gnugrep",
+      "source": "devbox-search",
+      "version": "3.12",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/sk1la8r8sa1rlb8m9kwy5hi29f58sjd9-gnugrep-3.12",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/f0wssfswzm7rky5civpd1cag9psik322-gnugrep-3.12-info"
+            }
+          ],
+          "store_path": "/nix/store/sk1la8r8sa1rlb8m9kwy5hi29f58sjd9-gnugrep-3.12"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/g7mn7yzwavbs72dv6mcganlkqjj1bq9w-gnugrep-3.12",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/zgckk51kh2wpmh3sh4vx5k5haz0940sk-gnugrep-3.12-info"
+            }
+          ],
+          "store_path": "/nix/store/g7mn7yzwavbs72dv6mcganlkqjj1bq9w-gnugrep-3.12"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ggcs7dhvjza0pl1hnwg7h4gjx4brgnm1-gnugrep-3.12",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/0sbmyf08p8ha898qzqy0ns200pdvg960-gnugrep-3.12-info"
+            }
+          ],
+          "store_path": "/nix/store/ggcs7dhvjza0pl1hnwg7h4gjx4brgnm1-gnugrep-3.12"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/wf7lr2hf43546jc5kwqh3dbxnpcnw1mn-gnugrep-3.12",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/kh6klwv6zsmv2isid1n651yvmnndrw67-gnugrep-3.12-info"
+            }
+          ],
+          "store_path": "/nix/store/wf7lr2hf43546jc5kwqh3dbxnpcnw1mn-gnugrep-3.12"
+        }
+      }
+    },
+    "gnused@latest": {
+      "last_modified": "2026-04-23T13:07:47Z",
+      "resolved": "github:NixOS/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30#gnused",
+      "source": "devbox-search",
+      "version": "4.9",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/k6894r7p4545j4sbsyq698pqjwa8vfkh-gnused-4.9",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/5b8zpjp2bjs4pz6x32hk8b71k6dkfgph-gnused-4.9-info"
+            }
+          ],
+          "store_path": "/nix/store/k6894r7p4545j4sbsyq698pqjwa8vfkh-gnused-4.9"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/v5bw9inlszgv4wgas7009fia4l4n0dwv-gnused-4.9",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/hfvyqv0s69bakvrpj488ykzqa1x0g4sk-gnused-4.9-info"
+            }
+          ],
+          "store_path": "/nix/store/v5bw9inlszgv4wgas7009fia4l4n0dwv-gnused-4.9"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/jb94qnhpj9075naaw5d23qq4inclgrik-gnused-4.9",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/bqvi65r0ydi66pb9wbchkd7fcfld693f-gnused-4.9-info"
+            }
+          ],
+          "store_path": "/nix/store/jb94qnhpj9075naaw5d23qq4inclgrik-gnused-4.9"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/af4a8i43kc2ss4rnmf0swkk2mprsw6xq-gnused-4.9",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/0x53ijixqcvxczlifndlcwp140q84af2-gnused-4.9-info"
+            }
+          ],
+          "store_path": "/nix/store/af4a8i43kc2ss4rnmf0swkk2mprsw6xq-gnused-4.9"
+        }
+      }
+    },
+    "gradle@latest": {
+      "last_modified": "2026-04-23T13:07:47Z",
+      "plugin_version": "0.0.1",
+      "resolved": "github:NixOS/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30#gradle",
+      "source": "devbox-search",
+      "version": "8.14.4",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/zzsnqp9kl1d4vwwng1lxxv2lkk6rv5zw-gradle-8.14.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/zzsnqp9kl1d4vwwng1lxxv2lkk6rv5zw-gradle-8.14.4"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/y6qzcrz3yjwhl5fpcsj0y0wgv8nm7xn2-gradle-8.14.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/y6qzcrz3yjwhl5fpcsj0y0wgv8nm7xn2-gradle-8.14.4"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/nkn89sg8fhykbp72hd6c9419hg14vkih-gradle-8.14.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/nkn89sg8fhykbp72hd6c9419hg14vkih-gradle-8.14.4"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/wx27n954ghsisqim85w8xs2bklflfnd2-gradle-8.14.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/wx27n954ghsisqim85w8xs2bklflfnd2-gradle-8.14.4"
+        }
+      }
+    },
+    "jdk17@latest": {
+      "last_modified": "2025-10-22T20:59:19Z",
+      "resolved": "github:NixOS/nixpkgs/01b6809f7f9d1183a2b3e081f0a1e6f8f415cb09#jdk17",
+      "source": "devbox-search",
+      "version": "17.0.12",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/hlm8a8cnp4hm8xkg0a2yy4kv7cq44jii-zulu-ca-jdk-17.0.12",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/hlm8a8cnp4hm8xkg0a2yy4kv7cq44jii-zulu-ca-jdk-17.0.12"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/i4zgq9685y6284hbf5a7ac9ysb88dvlz-zulu-ca-jdk-17.0.12",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/i4zgq9685y6284hbf5a7ac9ysb88dvlz-zulu-ca-jdk-17.0.12"
+        }
+      }
+    },
+    "jq@latest": {
+      "last_modified": "2026-04-27T06:11:55Z",
+      "resolved": "github:NixOS/nixpkgs/6368eda62c9775c38ef7f714b2555a741c20c72d#jq",
+      "source": "devbox-search",
+      "version": "1.8.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/zpaiv3csv85i5qdhwlivlbg8a5clnqmh-jq-1.8.1-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/vs9rx9xgqachcay4mn95m1gwifzxrhm4-jq-1.8.1-man",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/iksz05vk9j78ls9agfg9blhax9azgv69-jq-1.8.1-doc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/inmyqx7646xrcqrwxipacv5gkf3ca6m3-jq-1.8.1"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/h46rnp90pvk5ky12r9drbzhl1fqlmjnf-jq-1.8.1-dev"
+            }
+          ],
+          "store_path": "/nix/store/zpaiv3csv85i5qdhwlivlbg8a5clnqmh-jq-1.8.1-bin"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/blgzs73jx017qji4n78v4wg1qxcg3cav-jq-1.8.1-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/s8h2klkc7rw485yqj3s73ancc5915v2m-jq-1.8.1-man",
+              "default": true
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/2v9443fs97gdg5mz9lk3q603hryhqijm-jq-1.8.1"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/lx675fc624glij1dh9iw89pavkvfkv73-jq-1.8.1-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/r992wf8cylhf9ayxwf64lawdfxcr4cl8-jq-1.8.1-doc"
+            }
+          ],
+          "store_path": "/nix/store/blgzs73jx017qji4n78v4wg1qxcg3cav-jq-1.8.1-bin"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/cpq0n6nrgs7jwyr121qshzk2fvjkmjbh-jq-1.8.1-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/flsm1xvpbr9681y4y8101v5c5m3qmcim-jq-1.8.1-man",
+              "default": true
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/spn7m9y4302yvw9zafpy1g2sz3z9xnx1-jq-1.8.1"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/0p7h41icsq99c08sym6iw4wzdsl35r13-jq-1.8.1-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/h6wn2lzbxq1v2dypaj4kpv4nnkkm9yld-jq-1.8.1-doc"
+            }
+          ],
+          "store_path": "/nix/store/cpq0n6nrgs7jwyr121qshzk2fvjkmjbh-jq-1.8.1-bin"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/v5c3inhfq6xshmwg1c254vfbcy4jp3k9-jq-1.8.1-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/lsyqny7h1riwhzajwy2vjjdd63viiwvm-jq-1.8.1-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/p8x5zv9s9qg3ld8b7jdm03hkpdqybjl9-jq-1.8.1-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/g2wlgi44rn837jdirpwi3lk5f2iy13zg-jq-1.8.1-doc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/09bq2i0kb008ccg3qdbyxv81ggxxnn09-jq-1.8.1"
+            }
+          ],
+          "store_path": "/nix/store/v5c3inhfq6xshmwg1c254vfbcy4jp3k9-jq-1.8.1-bin"
+        }
+      }
+    },
+    "lsof@latest": {
+      "last_modified": "2026-04-23T13:07:47Z",
+      "resolved": "github:NixOS/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30#lsof",
+      "source": "devbox-search",
+      "version": "4.99.6",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/794v9p3sc6nnzgmjb9h6dcj4flqj079s-lsof-4.99.6",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/794v9p3sc6nnzgmjb9h6dcj4flqj079s-lsof-4.99.6"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/00mpj4w9whhzxzn7ba861zc1i6lyym2f-lsof-4.99.6",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/00mpj4w9whhzxzn7ba861zc1i6lyym2f-lsof-4.99.6"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/nh7r13k8wqaxdpwvmp0wzn4shwd30vys-lsof-4.99.6",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/nh7r13k8wqaxdpwvmp0wzn4shwd30vys-lsof-4.99.6"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/kx33za9mnfmaf8cgpnndk7nwaq7qid4q-lsof-4.99.6",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/kx33za9mnfmaf8cgpnndk7nwaq7qid4q-lsof-4.99.6"
+        }
+      }
+    },
+    "nodejs@20": {
+      "last_modified": "2026-04-23T13:07:47Z",
+      "plugin_version": "0.0.2",
+      "resolved": "github:NixOS/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30#nodejs_20",
+      "source": "devbox-search",
+      "version": "20.20.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/gvr230jrjzznrhlmfymjj37x0dx3srvv-nodejs-20.20.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/gvr230jrjzznrhlmfymjj37x0dx3srvv-nodejs-20.20.2"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/jx5whkya850cy6a1fjf74p5dfqlcp1cq-nodejs-20.20.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/jx5whkya850cy6a1fjf74p5dfqlcp1cq-nodejs-20.20.2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ggqdy8b4b62gr1ak2v41dka5s1dmflzk-nodejs-20.20.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/ggqdy8b4b62gr1ak2v41dka5s1dmflzk-nodejs-20.20.2"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/nr0dnrnibq8114xa0i7zr7qg6n05q03g-nodejs-20.20.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/nr0dnrnibq8114xa0i7zr7qg6n05q03g-nodejs-20.20.2"
+        }
+      }
+    },
+    "process-compose@latest": {
+      "last_modified": "2026-04-23T13:07:47Z",
+      "resolved": "github:NixOS/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30#process-compose",
+      "source": "devbox-search",
+      "version": "1.103.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/c593fs5f4sqvs7h6nvbkv7k5sa59bdh8-process-compose-1.103.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/c593fs5f4sqvs7h6nvbkv7k5sa59bdh8-process-compose-1.103.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/pjg73wzwdqag6spj17snhm5isp6fmp12-process-compose-1.103.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/pjg73wzwdqag6spj17snhm5isp6fmp12-process-compose-1.103.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/cf20j149ha8hbjdamw1zhdc4bysm5986-process-compose-1.103.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/cf20j149ha8hbjdamw1zhdc4bysm5986-process-compose-1.103.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/qpmwpcvvfykq4yv6pqqlwm78yqqir3rn-process-compose-1.103.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/qpmwpcvvfykq4yv6pqqlwm78yqqir3rn-process-compose-1.103.0"
+        }
+      }
+    },
+    "watchman@latest": {
+      "last_modified": "2026-04-23T13:07:47Z",
+      "resolved": "github:NixOS/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30#watchman",
+      "source": "devbox-search",
+      "version": "2026.01.19.00",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/g5k6ijlypywkm99958q48wwq6vm8n61w-watchman-2026.01.19.00",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/g5k6ijlypywkm99958q48wwq6vm8n61w-watchman-2026.01.19.00"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/6500xn6fahdyyxj5kgv4pxw63lqra0s8-watchman-2026.01.19.00",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/6500xn6fahdyyxj5kgv4pxw63lqra0s8-watchman-2026.01.19.00"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/zb3f7p0vc0xacn9bcpx7z6wgc02fc78g-watchman-2026.01.19.00",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/zb3f7p0vc0xacn9bcpx7z6wgc02fc78g-watchman-2026.01.19.00"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/nlk8q15q89q8hl9xhpslf54255wafg9b-watchman-2026.01.19.00",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/nlk8q15q89q8hl9xhpslf54255wafg9b-watchman-2026.01.19.00"
+        }
+      }
+    },
+    "yarn-berry@latest": {
+      "last_modified": "2026-04-23T13:07:47Z",
+      "resolved": "github:NixOS/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30#yarn-berry",
+      "source": "devbox-search",
+      "version": "4.13.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/px13xgr16vrqz3z6a4jz39ii26s16gsb-yarn-berry-4.13.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/px13xgr16vrqz3z6a4jz39ii26s16gsb-yarn-berry-4.13.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/kwn5m8pqab1z7n35689pvzzy1hbs5y6f-yarn-berry-4.13.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/kwn5m8pqab1z7n35689pvzzy1hbs5y6f-yarn-berry-4.13.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/5qdcrz929n4crbmmjbf2m63pjn1rqsrz-yarn-berry-4.13.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/5qdcrz929n4crbmmjbf2m63pjn1rqsrz-yarn-berry-4.13.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/1svjsh9nwy9q0arbghi4swcz0b8cmym4-yarn-berry-4.13.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/1svjsh9nwy9q0arbghi4swcz0b8cmym4-yarn-berry-4.13.0"
+        }
+      }
+    }
+  }
+}

--- a/examples/E2E-latest/gradle.properties
+++ b/examples/E2E-latest/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.java.home=/nix/store/hlm8a8cnp4hm8xkg0a2yy4kv7cq44jii-zulu-ca-jdk-17.0.12

--- a/examples/E2E-latest/yarn.lock
+++ b/examples/E2E-latest/yarn.lock
@@ -2570,11 +2570,11 @@ __metadata:
 
 "@segment/analytics-react-native-e2e-tests@file:../shared-e2e::locator=AnalyticsReactNativeE2ELatest%40workspace%3A.":
   version: 1.0.0
-  resolution: "@segment/analytics-react-native-e2e-tests@file:../shared-e2e#../shared-e2e::hash=61b310&locator=AnalyticsReactNativeE2ELatest%40workspace%3A."
+  resolution: "@segment/analytics-react-native-e2e-tests@file:../shared-e2e#../shared-e2e::hash=f007df&locator=AnalyticsReactNativeE2ELatest%40workspace%3A."
   dependencies:
     body-parser: "npm:^1.20.0"
     express: "npm:^4.20.0"
-  checksum: 10c0/fe934efd7bfae1ed2957914e8f293429e61d045da1540d3096af2ea42585f3f7e78aef416fabec6b9fc04d6d691d7ec96ff6312d5e9e6f0521b25bfd5b0dbbb6
+  checksum: 10c0/47e624884c4e4200213f27607fbe5f96ce42ee63cbb17013f0139d3bc43f10ed06367f51bb02bd073a348ebb5e695f855ae0be308bde889e82bc28b5b1419e11
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds comprehensive CI testing for mobile-devtools devbox plugin integration in E2E examples.

## Changes

### 1. New Workflow: `devbox-plugin-integration.yml`

Tests the devbox plugin integration across both E2E examples (E2E-compat and E2E-latest) on both platforms (Android and iOS).

**Triggers:**

- ✅ **Pull Requests** to `feat/rn-devbox-plugin` when devbox files change
- ✅ **Weekly Schedule** (Mondays 10am UTC) to catch upstream plugin changes
- ✅ **Manual Trigger** with options to test specific examples/platforms
- ✅ **Workflow Call** for use as release prerequisite

### 2. Test Coverage

**Validation Job:**
- Validates devbox.json configuration
- Checks mobile-devtools plugin is included
- Runs on ubuntu-latest (fast, cheap)

**Android Build Tests:**
- Tests E2E-compat Android build
- Tests E2E-latest Android build
- Verifies Android tools availability
- Runs yarn install and Gradle build
- Runs on ubuntu-latest

**iOS Build Tests:**
- Tests E2E-compat iOS build
- Tests E2E-latest iOS build
- Verifies iOS tools availability
- Runs yarn install, pod install, and Xcode build
- Runs on macos-14 (required for Xcode)

**Summary Job:**
- Aggregates all test results
- Fails if any job fails
- Provides clear feedback on which tests failed

### 3. Benefits

✅ **Early Detection** - Catches breaking changes in mobile-devtools plugin before they affect developers

✅ **Example Parity** - Ensures both E2E-compat and E2E-latest work with the plugin

✅ **Release Safety** - Can be called as prerequisite to prevent releasing incompatible SDK

✅ **Clear Feedback** - Matrix-style testing shows exactly which example/platform combination fails

✅ **Cost Optimization** - Only runs iOS tests on macos-14 runners (expensive), uses ubuntu-latest where possible

## Testing

### Local Testing

```bash
# Tested E2E-compat
cd examples/E2E-compat
devbox version  # ✓ 0.17.2
devbox run install  # ✓ Yarn install successful
devbox run --list  # ✓ All scripts available

# Tested E2E-latest
cd examples/E2E-latest  
devbox run install  # ✓ Yarn install successful
```

### CI Testing

This PR will trigger the workflow and validate:
- ✓ Configuration validation
- ✓ Android E2E-compat build
- ✓ Android E2E-latest build  
- ✓ iOS E2E-compat build
- ✓ iOS E2E-latest build

## Integration

### Use as Release Prerequisite

To use this as a release prerequisite, add to `.github/workflows/release.yml`:

```yaml
jobs:
  devbox-integration:
    name: Devbox Plugin Integration
    uses: ./.github/workflows/devbox-plugin-integration.yml
    with:
      example: 'all'
  
  release-production:
    needs: [ci, devbox-integration]  # Add this dependency
    # ... rest of release job
```

### Manual Testing

Developers can trigger manually via Actions tab:
1. Go to Actions → Devbox Plugin Integration Tests
2. Click "Run workflow"
3. Select example (E2E-compat, E2E-latest, all)
4. Select platform (android, ios, both)

## Architecture Decisions

**Separate Jobs per Example/Platform**
- Makes it clear which combination fails
- Allows parallel execution
- Reduces total runtime

**Conditional Execution**
- Only runs relevant jobs based on trigger
- Saves CI minutes on scheduled/manual runs

**Pure Shell Mode**
- Uses `devbox run --pure` to ensure reproducible builds
- Isolates from host environment

**Node.js Caching**
- Caches yarn dependencies via actions/setup-node
- Speeds up subsequent runs

## Known Issues

**Android SDK Nix Build Warning**
- Android SDK evaluation shows build failures on macOS
- This is expected and doesn't block builds
- Android tools are installed on first use
- CI uses Linux runners which don't have this issue

## Related

- Branch: `feat/rn-devbox-plugin`
- Mobile-devtools plugin: https://github.com/segment-integrations/mobile-devtools
- Previous commits:
  - `8ea2ade5` - fix: update E2E examples for mobile-devtools devbox plugin compatibility
  - `ab47da45` - feat: add mobile-devtools devbox plugin to E2E examples

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)