### PR TITLE
chore(deps): bundle Dependabot updates to reduce PR spam

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,18 @@
 version: 2
 updates:
-  # Root workspace - SDK dependencies only
+  # GitHub Actions - pin and group all action updates together
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: 'chore(deps)'
+    groups:
+      actions:
+        patterns:
+          - '*'
+
+  # Root workspace (monorepo packages)
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
@@ -8,13 +20,51 @@ updates:
     commit-message:
       prefix: 'chore(deps)'
     groups:
-      production-dependencies:
+      all-dependencies:
         patterns:
           - '*'
-        exclude-patterns:
-          - '*-dev'
-          - '*-test'
-      development-dependencies:
+
+  # Examples and tooling - group all into single PR per directory
+  - package-ecosystem: 'npm'
+    directory: '/examples/AnalyticsReactNativeExample'
+    schedule:
+      interval: 'monthly'
+    commit-message:
+      prefix: 'chore(deps)'
+    groups:
+      all-dependencies:
         patterns:
-          - '*-dev'
-          - '*-test'
+          - '*'
+
+  - package-ecosystem: 'npm'
+    directory: '/examples/E2E-compat'
+    schedule:
+      interval: 'monthly'
+    commit-message:
+      prefix: 'chore(deps)'
+    groups:
+      all-dependencies:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'npm'
+    directory: '/examples/E2E-latest'
+    schedule:
+      interval: 'monthly'
+    commit-message:
+      prefix: 'chore(deps)'
+    groups:
+      all-dependencies:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'npm'
+    directory: '/e2e-cli'
+    schedule:
+      interval: 'monthly'
+    commit-message:
+      prefix: 'chore(deps)'
+    groups:
+      all-dependencies:
+        patterns:
+          - '*'


### PR DESCRIPTION
## Summary
Fixes Dependabot config to cover all `package.json` locations and groups dependencies into bundled PRs instead of individual ones per package.

## Changes
- Add all example directories as Dependabot targets (was only covering root)
- Group all deps per directory into a single PR instead of individual PRs per package
- Add GitHub Actions ecosystem monitoring (also grouped)
- Monthly schedule for examples, weekly for SDK root and actions

## Why
The old config created 14+ individual PRs for each vulnerability in example directories. Grouping consolidates these into ~5 bundled PRs. After merge, Dependabot will auto-close individual PRs and open grouped replacements.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)