### PR TITLE
feat(e2e-shared): add event status tracking and connection indicators

### DIFF
--- a/examples/e2e-shared/src/app/Home.tsx
+++ b/examples/e2e-shared/src/app/Home.tsx
@@ -14,7 +14,7 @@ import {
 } from 'react-native';
 import { useAnalytics } from '@segment/analytics-react-native';
 import { segmentClient, logger, reconnect, onError } from './client';
-import type { EventEntry } from './plugins/Logger';
+import type { EventEntry, EventStatus } from './plugins/Logger';
 
 if (
   Platform.OS === 'android' &&
@@ -23,11 +23,7 @@ if (
   UIManager.setLayoutAnimationEnabledExperimental(true);
 }
 
-type ConnectionStatus =
-  | 'connected'
-  | 'network_error'
-  | 'server_error'
-  | 'unknown';
+type ConnectionStatus = 'connected' | 'network_error' | 'server_error' | 'idle';
 
 interface ErrorInfo {
   message: string;
@@ -44,7 +40,7 @@ const Home = ({ navigation }: { navigation: any }) => {
   const [writeKey, setWriteKey] = useState('yup');
   const [events, setEvents] = useState<EventEntry[]>([]);
   const [connectionStatus, setConnectionStatus] =
-    useState<ConnectionStatus>('unknown');
+    useState<ConnectionStatus>('idle');
   const [lastError, setLastError] = useState<ErrorInfo | null>(null);
 
   useEffect(() => {
@@ -55,8 +51,8 @@ const Home = ({ navigation }: { navigation: any }) => {
   useEffect(() => {
     const unsub = onError((error: any) => {
       const statusCode = error?.statusCode ?? -1;
-      const isServerError = statusCode > 0;
-      setConnectionStatus(isServerError ? 'server_error' : 'network_error');
+      const hasServerResponse = statusCode > 0;
+      setConnectionStatus(hasServerResponse ? 'server_error' : 'network_error');
 
       const message = error?.message ?? String(error);
       const parts = [message];
@@ -75,7 +71,17 @@ const Home = ({ navigation }: { navigation: any }) => {
 
   useEffect(() => {
     if (autoFlush) {
-      segmentClient.flush();
+      let hadError = false;
+      const unsub = onError(() => {
+        hadError = true;
+      });
+      segmentClient.flush().then(() => {
+        unsub();
+        if (!hadError) {
+          const hasSent = logger.getEvents().some((e) => e.status === 'sent');
+          if (hasSent) setConnectionStatus('connected');
+        }
+      });
     }
   }, [autoFlush]);
 
@@ -92,11 +98,23 @@ const Home = ({ navigation }: { navigation: any }) => {
     setAutoFlush(newValue);
   }, [autoFlush]);
 
+  const handleFlush = useCallback(async () => {
+    let hadError = false;
+    const unsub = onError(() => {
+      hadError = true;
+    });
+    await flush();
+    unsub();
+    if (!hadError) {
+      const hasSent = logger.getEvents().some((e) => e.status === 'sent');
+      if (hasSent) setConnectionStatus('connected');
+    }
+  }, [flush]);
+
   const handleReconnect = useCallback(() => {
-    setConnectionStatus('unknown');
+    setConnectionStatus('idle');
     setLastError(null);
     reconnect(writeKey);
-    setConnectionStatus('connected');
   }, [writeKey]);
 
   const toggleSection = (
@@ -106,8 +124,9 @@ const Home = ({ navigation }: { navigation: any }) => {
     setter((prev) => !prev);
   };
 
-  const sentCount = events.filter((e) => e.sent).length;
-  const queuedCount = events.filter((e) => !e.sent).length;
+  const sentCount = events.filter((e) => e.status === 'sent').length;
+  const failedCount = events.filter((e) => e.status === 'failed').length;
+  const queuedCount = events.filter((e) => e.status === 'queued').length;
 
   const statusColor =
     connectionStatus === 'connected'
@@ -117,6 +136,13 @@ const Home = ({ navigation }: { navigation: any }) => {
       : connectionStatus === 'server_error'
       ? colors.orange
       : colors.yellow;
+
+  const eventColor = (status: EventStatus) =>
+    status === 'sent'
+      ? colors.green
+      : status === 'failed'
+      ? colors.red
+      : colors.orange;
 
   return (
     <View style={styles.container}>
@@ -219,7 +245,7 @@ const Home = ({ navigation }: { navigation: any }) => {
           <View style={styles.buttonRow}>
             <TouchableOpacity
               style={[styles.wideButton, { backgroundColor: colors.pink }]}
-              onPress={() => flush()}
+              onPress={handleFlush}
               testID="BUTTON_FLUSH"
             >
               <Text style={styles.buttonText}>Flush</Text>
@@ -271,6 +297,12 @@ const Home = ({ navigation }: { navigation: any }) => {
               <Text style={styles.statLabel}>Queued</Text>
             </View>
             <View style={styles.stat}>
+              <Text style={[styles.statNumber, { color: colors.red }]}>
+                {failedCount}
+              </Text>
+              <Text style={styles.statLabel}>Failed</Text>
+            </View>
+            <View style={styles.stat}>
               <View
                 style={[styles.statusDot, { backgroundColor: statusColor }]}
               />
@@ -288,15 +320,7 @@ const Home = ({ navigation }: { navigation: any }) => {
 
           {lastError && (
             <Text
-              style={[
-                styles.errorText,
-                {
-                  color:
-                    connectionStatus === 'network_error'
-                      ? colors.red
-                      : colors.orange,
-                },
-              ]}
+              style={[styles.errorText, { color: statusColor }]}
               numberOfLines={2}
             >
               {lastError.message}
@@ -325,17 +349,16 @@ const Home = ({ navigation }: { navigation: any }) => {
                   <View
                     style={[
                       styles.eventDot,
-                      {
-                        backgroundColor: entry.sent
-                          ? colors.green
-                          : colors.orange,
-                      },
+                      { backgroundColor: eventColor(entry.status) },
                     ]}
                   />
                   <Text style={styles.eventType}>{entry.type}</Text>
                   <Text style={styles.eventName} numberOfLines={1}>
                     {entry.name}
                   </Text>
+                  {entry.statusCode !== undefined && (
+                    <Text style={styles.eventStatus}>{entry.statusCode}</Text>
+                  )}
                   <Text style={styles.eventTime}>
                     {new Date(entry.timestamp).toLocaleTimeString()}
                   </Text>
@@ -481,6 +504,7 @@ const styles = StyleSheet.create({
   eventDot: { width: 8, height: 8, borderRadius: 4, marginRight: 8 },
   eventType: { color: '#aaa', fontSize: 11, width: 50 },
   eventName: { color: 'white', fontSize: 13, flex: 1, marginRight: 8 },
+  eventStatus: { color: '#aaa', fontSize: 11, marginRight: 6 },
   eventTime: { color: '#888', fontSize: 11 },
 });
 

--- a/examples/e2e-shared/src/app/client.ts
+++ b/examples/e2e-shared/src/app/client.ts
@@ -2,6 +2,7 @@ import {
   createClient,
   CountFlushPolicy,
   SegmentClient,
+  ErrorType,
 } from '@segment/analytics-react-native';
 import { Platform } from 'react-native';
 import { Logger } from './plugins/Logger';
@@ -16,6 +17,9 @@ const errorListeners: ErrorListener[] = [];
 
 function buildClient(writeKey: string): SegmentClient {
   const useProxy = writeKey === 'yup';
+  let pendingDropCount = 0;
+  let lastStatusCode: number | undefined;
+
   const client = createClient({
     writeKey,
     maxBatchSize: 1000,
@@ -25,6 +29,12 @@ function buildClient(writeKey: string): SegmentClient {
     collectDeviceId: true,
     debug: true,
     errorHandler: (error: any) => {
+      if (error?.type === ErrorType.EventsDropped) {
+        pendingDropCount += error.metadata?.droppedCount ?? 0;
+      }
+      if (error?.statusCode !== undefined) {
+        lastStatusCode = error.statusCode;
+      }
       errorListeners.forEach((fn) => fn(error));
     },
     ...(useProxy
@@ -47,8 +57,21 @@ function buildClient(writeKey: string): SegmentClient {
 
   const originalFlush = client.flush.bind(client);
   client.flush = async () => {
+    const queuedCount = logger
+      .getEvents()
+      .filter((e) => e.status === 'queued').length;
+    pendingDropCount = 0;
+    lastStatusCode = undefined;
+
     await originalFlush();
-    logger.markAllSent();
+
+    if (pendingDropCount > 0) {
+      logger.markFailed(pendingDropCount, lastStatusCode);
+    }
+    const sentCount = queuedCount - pendingDropCount;
+    if (sentCount > 0) {
+      logger.markSent(sentCount);
+    }
   };
 
   return client;

--- a/examples/e2e-shared/src/app/plugins/Logger.ts
+++ b/examples/e2e-shared/src/app/plugins/Logger.ts
@@ -4,11 +4,14 @@ import {
   SegmentEvent,
 } from '@segment/analytics-react-native';
 
+export type EventStatus = 'queued' | 'sent' | 'failed';
+
 export type EventEntry = {
   type: string;
   name: string;
   timestamp: string;
-  sent: boolean;
+  status: EventStatus;
+  statusCode?: number;
 };
 
 type Listener = (events: EventEntry[]) => void;
@@ -26,15 +29,34 @@ export class Logger extends Plugin {
       type: event.type,
       name: this.getEventName(event),
       timestamp: event.timestamp ?? new Date().toISOString(),
-      sent: false,
+      status: 'queued',
     };
     this.events = [...this.events, entry];
     this.notify();
     return event;
   }
 
-  markAllSent() {
-    this.events = this.events.map((e) => (e.sent ? e : { ...e, sent: true }));
+  markSent(count: number) {
+    this.updateQueued(count, 'sent', 200);
+  }
+
+  markFailed(count: number, statusCode?: number) {
+    this.updateQueued(count, 'failed', statusCode);
+  }
+
+  private updateQueued(
+    count: number,
+    newStatus: EventStatus,
+    statusCode?: number
+  ) {
+    let remaining = count;
+    this.events = this.events.map((e) => {
+      if (remaining > 0 && e.status === 'queued') {
+        remaining--;
+        return { ...e, status: newStatus, statusCode };
+      }
+      return e;
+    });
     this.notify();
   }
 


### PR DESCRIPTION
## Summary

Adds proper event status tracking to the example app. Events now show whether they were successfully sent, are pending, or failed — with HTTP status codes displayed per event.

## Changes

- Logger plugin tracks three states: queued (orange), sent (green), failed (red) with HTTP status code
- Client tracks dropped events via `ErrorType.EventsDropped` instead of blindly marking all as sent after flush
- Connection status indicator: green (OK) when events post successfully, orange (Rejected) when server responds with error (e.g. 401), red (Unreachable) when no server response
- Stats row shows Sent / Queued / Failed counters

## Why

Previously all events were marked green after flush regardless of whether the server accepted or rejected them. With an invalid write key, events would show as "sent" even though they were dropped with a 401. This makes it possible to visually verify the SDK's error handling behavior.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)