### PR TITLE
fix(deps): widen react-native-get-random-values peer to 1.x || 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react": "18.2.0",
     "react-native": "^0.72.7",
     "react-native-builder-bob": "^0.23.1",
+    "react-native-get-random-values": "^1.11.0",
     "rimraf": "^5.0.5",
     "semantic-release": "^22.0.12",
     "semantic-release-yarn": "^3.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,7 @@
     "@segment/sovran-react-native": "^1.1.0",
     "react": "*",
     "react-native": "*",
-    "react-native-get-random-values": "1.x"
+    "react-native-get-random-values": "1.x || 2.x"
   },
   "peerDependenciesMeta": {
     "@react-native-async-storage/async-storage": {

--- a/packages/sovran/package.json
+++ b/packages/sovran/package.json
@@ -68,7 +68,8 @@
   "peerDependencies": {
     "@react-native-async-storage/async-storage": "2.x",
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-get-random-values": "1.x || 2.x"
   },
   "peerDependenciesMeta": {
     "@react-native-async-storage/async-storage": {
@@ -78,7 +79,6 @@
   "dependencies": {
     "ansi-regex": "5.0.1",
     "deepmerge": "^4.2.2",
-    "react-native-get-random-values": "1.x",
     "shell-quote": "1.8.0",
     "uuid": "^14.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4608,7 +4608,7 @@ __metadata:
     "@segment/sovran-react-native": ^1.1.0
     react: "*"
     react-native: "*"
-    react-native-get-random-values: 1.x
+    react-native-get-random-values: 1.x || 2.x
   peerDependenciesMeta:
     "@react-native-async-storage/async-storage":
       optional: true
@@ -4636,7 +4636,6 @@ __metadata:
     ansi-regex: "npm:5.0.1"
     deepmerge: "npm:^4.2.2"
     jest: "npm:^29.7.0"
-    react-native-get-random-values: "npm:1.x"
     semantic-release: "npm:^22.0.8"
     shell-quote: "npm:1.8.0"
     typescript: "npm:^5.2.2"
@@ -4645,6 +4644,7 @@ __metadata:
     "@react-native-async-storage/async-storage": 2.x
     react: "*"
     react-native: "*"
+    react-native-get-random-values: 1.x || 2.x
   peerDependenciesMeta:
     "@react-native-async-storage/async-storage":
       optional: true
@@ -6829,6 +6829,7 @@ __metadata:
     react: "npm:18.2.0"
     react-native: "npm:^0.72.7"
     react-native-builder-bob: "npm:^0.23.1"
+    react-native-get-random-values: "npm:^1.11.0"
     rimraf: "npm:^5.0.5"
     semantic-release: "npm:^22.0.12"
     semantic-release-yarn: "npm:^3.0.2"
@@ -16110,7 +16111,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-get-random-values@npm:1.x":
+"react-native-get-random-values@npm:^1.11.0":
   version: 1.11.0
   resolution: "react-native-get-random-values@npm:1.11.0"
   dependencies:


### PR DESCRIPTION
## Summary

Unblocks the New Architecture (RN 0.81+ / Expo SDK 54+) by letting consumers use `react-native-get-random-values@2.x` (required for New-Arch iOS builds) **without** breaking consumers still on older React Native, where only `1.x` works.

`Fixes #1102`

## The problem

`react-native-get-random-values@2.0.0` requires `react-native >=0.81`. New-Arch users need 2.x, but the SDK pinned `1.x`:

- `packages/core` declared it as a **peerDependency** `"1.x"` — so even if a consumer installed 2.x, they got a peer warning/violation.
- `packages/sovran` declared it as a **hard `dependency`** `"1.x"`. Because it's a hard dep, yarn force-resolves a single version for every consumer, so an app could not choose 2.x even though sovran never imports the package. This transitive pin is the real blocker behind #1102.

## The fix

- **core**: peer `"1.x"` → `"1.x || 2.x"`. The consumer picks the version compatible with their RN — old RN keeps `1.x`, RN ≥0.81 uses `2.x`.
- **sovran**: move `react-native-get-random-values` from `dependencies` → `peerDependencies` (`"1.x || 2.x"`). sovran's source never imports it (`git grep` confirms; it's only needed as the `crypto.getRandomValues` polyfill that the consuming app loads at its entry point, for `uuid`). It's already a documented install step in the README, so a peer is the correct declaration, and it stops the force-resolution that blocked 2.x.
- **root**: add it as a `devDependency` (`^1.11.0`) so the monorepo build/test still resolves it for `core/src/uuid.ts`. Mirrors how `@react-native-async-storage/async-storage` is handled (optional peer in packages + root devDependency).

## Why not just merge #1174?

[#1174](https://github.com/segmentio/analytics-react-native/pull/1174) raises the floor to `2.x`, which **drops support for RN < 0.81** and would break the `e2e-compat` example (RN 0.72) and any consumer on older RN. This PR keeps both working. (#1174 was also conflicting and edited since-removed example dirs.)

## Validation

Run locally against this branch:

- `yarn typecheck` — pass
- `yarn jest packages/core packages/sovran` — **40 suites, 353 passed, 1 todo**
- `yarn sovran build` + `yarn core build` — both succeed (commonjs + module + typescript targets)
- `yarn install` lockfile diff is minimal and matches the manifest changes

## Notes / follow-ups

- Moving sovran's entry from a hard dep to a peer means consumers who previously got it auto-installed transitively now install it explicitly. This is already the documented setup (README install command lists it), and matches how peers are handled elsewhere in this repo.
- Bumping the `e2e-latest` example (RN 0.84) to `^2.0.0` is intentionally left out to keep this scoped to the library fix; it needs its own example-lockfile regen and can be a follow-up alongside the New-Arch E2E work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)