### PR TITLE
chore(deps): group Dependabot security updates and fix example dir casing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 version: 2
 updates:
-  # GitHub Actions - pin and group all action updates together
+  # GitHub Actions - pin and group all action updates together.
+  # Two groups so BOTH scheduled version bumps and Dependabot security
+  # updates get batched into a single PR (groups default to version-updates
+  # only, which is why security advisories were leaking out individually).
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
@@ -9,10 +12,16 @@ updates:
       prefix: 'chore(deps)'
     groups:
       actions:
+        applies-to: version-updates
+        patterns:
+          - '*'
+      actions-security:
+        applies-to: security-updates
         patterns:
           - '*'
 
-  # Root workspace (monorepo packages)
+  # Root workspace (monorepo packages) - covers the root package.json and all
+  # yarn workspace members (packages/*). Weekly.
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
@@ -21,50 +30,55 @@ updates:
       prefix: 'chore(deps)'
     groups:
       all-dependencies:
+        applies-to: version-updates
+        patterns:
+          - '*'
+      all-dependencies-security:
+        applies-to: security-updates
         patterns:
           - '*'
 
-  # Examples and tooling - group all into single PR per directory
+  # Examples and tooling (npm) - one grouped PR per directory, monthly.
+  # Directory names are case-sensitive: the real dirs are lowercase
+  # (e2e-compat / e2e-latest), not E2E-*.
   - package-ecosystem: 'npm'
-    directory: '/examples/AnalyticsReactNativeExample'
+    directories:
+      - '/e2e-cli'
+      - '/examples/AnalyticsReactNativeExample'
+      - '/examples/e2e-compat'
+      - '/examples/e2e-latest'
     schedule:
       interval: 'monthly'
     commit-message:
       prefix: 'chore(deps)'
     groups:
       all-dependencies:
+        applies-to: version-updates
+        patterns:
+          - '*'
+      all-dependencies-security:
+        applies-to: security-updates
         patterns:
           - '*'
 
-  - package-ecosystem: 'npm'
-    directory: '/examples/E2E-compat'
+  # Ruby tooling (CocoaPods/Fastlane) in the example apps. Without a bundler
+  # entry, gem security advisories (e.g. activesupport/addressable CVEs) open
+  # one ungrouped PR each. Group them, monthly.
+  - package-ecosystem: 'bundler'
+    directories:
+      - '/examples/AnalyticsReactNativeExample'
+      - '/examples/e2e-compat'
+      - '/examples/e2e-latest'
     schedule:
       interval: 'monthly'
     commit-message:
       prefix: 'chore(deps)'
     groups:
       all-dependencies:
+        applies-to: version-updates
         patterns:
           - '*'
-
-  - package-ecosystem: 'npm'
-    directory: '/examples/E2E-latest'
-    schedule:
-      interval: 'monthly'
-    commit-message:
-      prefix: 'chore(deps)'
-    groups:
-      all-dependencies:
-        patterns:
-          - '*'
-
-  - package-ecosystem: 'npm'
-    directory: '/e2e-cli'
-    schedule:
-      interval: 'monthly'
-    commit-message:
-      prefix: 'chore(deps)'
-    groups:
-      all-dependencies:
+      all-dependencies-security:
+        applies-to: security-updates
         patterns:
           - '*'


### PR DESCRIPTION
## Why

Dependabot is still opening a flood of individual PRs despite the `groups` config added in #1261. Root cause: **`groups` only applies to *version* updates by default** — every Dependabot *security* update (CVE/GHSA-triggered) opens its own ungrouped PR regardless of grouping. The repo has automated security fixes enabled, so all the per-package stragglers (#1269–#1273, #1280, #1282–#1283, #1286–#1291) are security PRs slipping past the groups.

Two secondary bugs made it worse:

1. **Case-sensitive directory mismatch.** The config referenced `/examples/E2E-compat` and `/examples/E2E-latest`, but the real dirs are lowercase `e2e-compat` / `e2e-latest`. Those entries matched nothing, so those dirs were never grouped (or updated).
2. **No `bundler` ecosystem.** The example apps have `Gemfile.lock`s, so gem advisories (`activesupport`, `addressable` — #1269/#1270) opened ungrouped security PRs with nowhere to group.

## What changed

- Added an explicit **`applies-to: security-updates`** group alongside the existing `version-updates` group for every ecosystem/directory, so security bumps batch into one PR too. (A group targets one or the other, so each ecosystem now has two group entries.)
- Fixed the `E2E-*` → `e2e-*` casing.
- Added a **`bundler`** entry for the three example-app Gemfiles.
- Collapsed the per-directory npm blocks using the `directories` (plural) key.

## Effect

Once merged, scheduled and security updates each collapse to **one grouped PR per ecosystem per directory** instead of one PR per dependency. The existing individual PRs will be closed out separately (superseded by the regrouped runs).

## Notes

- `examples/e2e-shared` has a `package.json` but no lockfile — it's covered by the root yarn workspace, so it intentionally has no standalone entry.
- The pre-commit hook ran the full lint/test suite; warnings shown are pre-existing and unrelated to this YAML-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)