### PR TITLE
feat(core): honor Retry-After on any retryable code (HTTP 529 + beyond)

### DIFF
--- a/e2e-cli/e2e-config.json
+++ b/e2e-cli/e2e-config.json
@@ -5,6 +5,7 @@
   "patch": null,
   "env": {
     "BROWSER_BATCHING": "true",
-    "HTTP_CONFIG_SETTINGS": "true"
+    "HTTP_CONFIG_SETTINGS": "true",
+    "GENERIC_RETRY_AFTER": "true"
   }
 }

--- a/packages/core/src/backoff/RetryManager.ts
+++ b/packages/core/src/backoff/RetryManager.ts
@@ -164,10 +164,18 @@ export class RetryManager {
   }
 
   /**
-   * Handle a 429 rate limit response.
-   * Uses server-specified wait time from Retry-After header.
+   * Handle a response that carries a server-directed wait via the Retry-After
+   * header. Originally added for 429 rate limiting, this is the authoritative
+   * "the server told us exactly how long to wait" path and is reused for any
+   * retryable status code (429, 529, 503, 408, …) that includes Retry-After.
+   *
+   * Uses the server-specified wait time (clamped to maxRetryInterval), pauses
+   * all uploads, and enforces the same maxRetryCount / maxRateLimitDuration
+   * safety valves as the 429 path.
    */
-  async handle429(retryAfterSeconds: number): Promise<RetryResult | undefined> {
+  async handleRetryAfter(
+    retryAfterSeconds: number
+  ): Promise<RetryResult | undefined> {
     if (this.rateLimitConfig?.enabled !== true) {
       return undefined;
     }
@@ -187,6 +195,14 @@ export class RetryManager {
       this.rateLimitConfig.maxRateLimitDuration,
       now
     );
+  }
+
+  /**
+   * Handle a 429 rate limit response.
+   * Delegates to the shared Retry-After (server-directed wait) path.
+   */
+  async handle429(retryAfterSeconds: number): Promise<RetryResult | undefined> {
+    return this.handleRetryAfter(retryAfterSeconds);
   }
 
   /**

--- a/packages/core/src/backoff/__tests__/RetryManager.test.ts
+++ b/packages/core/src/backoff/__tests__/RetryManager.test.ts
@@ -146,6 +146,75 @@ describe('RetryManager', () => {
     });
   });
 
+  describe('handleRetryAfter (generic server-directed wait)', () => {
+    it('waits the server-directed time for a non-429 code', async () => {
+      const now = 1000000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+
+      const rm = new RetryManager(
+        'test-key',
+        mockPersistor,
+        defaultRateLimitConfig,
+        defaultBackoffConfig,
+        mockLogger
+      );
+
+      // e.g. a 529 with Retry-After: 30
+      expect(await rm.handleRetryAfter(30)).toBe('rate_limited');
+
+      jest.spyOn(Date, 'now').mockReturnValue(now + 29000);
+      expect(await rm.canRetry()).toBe(false);
+      jest.spyOn(Date, 'now').mockReturnValue(now + 31000);
+      expect(await rm.canRetry()).toBe(true);
+    });
+
+    it('clamps the wait to maxRetryInterval', async () => {
+      const rm = new RetryManager(
+        'test-key',
+        mockPersistor,
+        defaultRateLimitConfig,
+        defaultBackoffConfig,
+        mockLogger
+      );
+
+      await rm.handleRetryAfter(500); // exceeds maxRetryInterval of 300
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('exceeds maxRetryInterval')
+      );
+    });
+
+    it('returns undefined when rate limit config is disabled', async () => {
+      const disabledConfig: RateLimitConfig = {
+        ...defaultRateLimitConfig,
+        enabled: false,
+      };
+      const rm = new RetryManager(
+        'test-key',
+        mockPersistor,
+        disabledConfig,
+        defaultBackoffConfig,
+        mockLogger
+      );
+
+      expect(await rm.handleRetryAfter(30)).toBeUndefined();
+    });
+
+    it('handle429 delegates to the same path', async () => {
+      const rm = new RetryManager(
+        'test-key',
+        mockPersistor,
+        defaultRateLimitConfig,
+        defaultBackoffConfig,
+        mockLogger
+      );
+
+      const spy = jest.spyOn(rm, 'handleRetryAfter');
+      await rm.handle429(15);
+      expect(spy).toHaveBeenCalledWith(15);
+    });
+  });
+
   describe('handle429', () => {
     it('increments retry count', async () => {
       const now = 1000000;

--- a/packages/core/src/plugins/SegmentDestination.ts
+++ b/packages/core/src/plugins/SegmentDestination.ts
@@ -34,14 +34,22 @@ export const SEGMENT_DESTINATION_KEY = 'Segment.io';
 type BatchResult = {
   batch: SegmentEvent[];
   messageIds: string[];
-  status: 'success' | '429' | 'transient' | 'permanent' | 'network_error';
+  // 'retry_after' = a retryable response that carried a Retry-After header
+  // (429 or any other retryable code), so we wait the server-directed time
+  // instead of computing exponential backoff.
+  status:
+    | 'success'
+    | 'retry_after'
+    | 'transient'
+    | 'permanent'
+    | 'network_error';
   statusCode?: number;
   retryAfterSeconds?: number;
 };
 
 type ErrorAggregation = {
   successfulMessageIds: string[];
-  rateLimitResults: BatchResult[];
+  serverDirectedResults: BatchResult[];
   hasTransientError: boolean;
   permanentErrorMessageIds: string[];
   retryableMessageIds: string[];
@@ -92,14 +100,28 @@ export class SegmentDestination extends DestinationPlugin {
 
     switch (classification.errorType) {
       case 'rate_limit':
+        // 429: always a server-directed wait. Default to 60s when the header
+        // is missing/invalid, preserving prior behavior.
         return {
           batch,
           messageIds,
-          status: '429',
+          status: 'retry_after',
           statusCode: res.status,
           retryAfterSeconds: retryAfterSeconds ?? 60,
         };
       case 'transient':
+        // Any other retryable code (529, 503, 408, …): if the server sent a
+        // valid Retry-After, honor it as a server-directed wait. Otherwise use
+        // exponential backoff (unchanged behavior).
+        if (retryAfterSeconds !== undefined) {
+          return {
+            batch,
+            messageIds,
+            status: 'retry_after',
+            statusCode: res.status,
+            retryAfterSeconds,
+          };
+        }
         return {
           batch,
           messageIds,
@@ -107,6 +129,7 @@ export class SegmentDestination extends DestinationPlugin {
           statusCode: res.status,
         };
       default:
+        // Permanent: drop. Retry-After is ignored on non-retryable codes.
         return {
           batch,
           messageIds,
@@ -136,13 +159,16 @@ export class SegmentDestination extends DestinationPlugin {
         retryCount,
       });
 
-      const retryAfterSeconds =
-        res.status === 429
-          ? parseRetryAfter(
-              res.headers.get('Retry-After'),
-              this.getRateLimitConfig()?.maxRetryInterval
-            )
-          : undefined;
+      // Parse Retry-After on any error response (not just 429). The header —
+      // regardless of which retryable status code carries it — is the
+      // authoritative signal for how long to wait. classifyBatchResult decides
+      // whether to honor it (retryable codes) or ignore it (permanent codes).
+      const retryAfterSeconds = res.ok
+        ? undefined
+        : parseRetryAfter(
+            res.headers.get('Retry-After'),
+            this.getRateLimitConfig()?.maxRetryInterval
+          );
 
       return this.classifyBatchResult(
         res,
@@ -173,7 +199,7 @@ export class SegmentDestination extends DestinationPlugin {
   private aggregateErrors(results: BatchResult[]): ErrorAggregation {
     const aggregation: ErrorAggregation = {
       successfulMessageIds: [],
-      rateLimitResults: [],
+      serverDirectedResults: [],
       hasTransientError: false,
       permanentErrorMessageIds: [],
       retryableMessageIds: [],
@@ -184,8 +210,8 @@ export class SegmentDestination extends DestinationPlugin {
         case 'success':
           aggregation.successfulMessageIds.push(...result.messageIds);
           break;
-        case '429':
-          aggregation.rateLimitResults.push(result);
+        case 'retry_after':
+          aggregation.serverDirectedResults.push(result);
           aggregation.retryableMessageIds.push(...result.messageIds);
           break;
         case 'transient':
@@ -256,12 +282,14 @@ export class SegmentDestination extends DestinationPlugin {
       return false;
     }
 
-    const has429 = aggregation.rateLimitResults.length > 0;
+    const hasServerDirectedWait = aggregation.serverDirectedResults.length > 0;
     let result: RetryResult | undefined;
 
-    if (has429) {
-      for (const r of aggregation.rateLimitResults) {
-        result = await this.retryManager.handle429(r.retryAfterSeconds ?? 60);
+    if (hasServerDirectedWait) {
+      for (const r of aggregation.serverDirectedResults) {
+        result = await this.retryManager.handleRetryAfter(
+          r.retryAfterSeconds ?? 60
+        );
       }
     } else if (aggregation.hasTransientError) {
       result = await this.retryManager.handleTransientError();
@@ -316,9 +344,10 @@ export class SegmentDestination extends DestinationPlugin {
       aggregation.successfulMessageIds.length -
       aggregation.permanentErrorMessageIds.length;
     if (failedCount > 0) {
-      const has429 = aggregation.rateLimitResults.length > 0;
+      const hasServerDirectedWait =
+        aggregation.serverDirectedResults.length > 0;
       this.analytics?.logger.warn(
-        `${failedCount} events will retry (429: ${has429}, transient: ${aggregation.hasTransientError})`
+        `${failedCount} events will retry (retry-after: ${hasServerDirectedWait}, transient: ${aggregation.hasTransientError})`
       );
     }
   }

--- a/packages/core/src/plugins/__tests__/SegmentDestination.retryAfter.test.ts
+++ b/packages/core/src/plugins/__tests__/SegmentDestination.retryAfter.test.ts
@@ -1,0 +1,221 @@
+import { SegmentClient } from '../../analytics';
+import * as api from '../../api';
+import {
+  createMockStoreGetter,
+  getMockLogger,
+  MockSegmentStore,
+} from '../../test-helpers';
+import { HttpConfig, SegmentEvent, UpdateType } from '../../types';
+import {
+  SEGMENT_DESTINATION_KEY,
+  SegmentDestination,
+} from '../SegmentDestination';
+import { RetryManager } from '../../backoff/RetryManager';
+
+jest.mock('uuid');
+
+/**
+ * Generic Retry-After wiring tests (design: "Generic Retry-After Header
+ * Support (HTTP 529 + Beyond)", Option B).
+ *
+ * Verifies SegmentDestination routes any retryable response that carries a
+ * Retry-After header through the server-directed wait path (RetryManager
+ * .handleRetryAfter) rather than exponential backoff (.handleTransientError),
+ * regardless of which status code (429, 529, 503, 408) carried it. Codes
+ * without the header keep using backoff, and permanent codes ignore it.
+ */
+describe('SegmentDestination — generic Retry-After', () => {
+  const store = new MockSegmentStore();
+  const clientArgs = {
+    logger: getMockLogger(),
+    config: {
+      writeKey: '123-456',
+      maxBatchSize: 100,
+      flushInterval: 0,
+    },
+    store,
+  };
+
+  // A minimal httpConfig that enables both the rate-limit (server-directed)
+  // and backoff paths, with the doc's retryable status overrides.
+  const httpConfig: HttpConfig = {
+    rateLimitConfig: {
+      enabled: true,
+      maxRetryCount: 100,
+      maxRetryInterval: 300,
+      maxRateLimitDuration: 43200,
+    },
+    backoffConfig: {
+      enabled: true,
+      maxRetryCount: 100,
+      baseBackoffInterval: 0.5,
+      maxBackoffInterval: 300,
+      maxTotalBackoffDuration: 43200,
+      jitterPercent: 0,
+      default4xxBehavior: 'drop',
+      default5xxBehavior: 'retry',
+      statusCodeOverrides: {
+        '408': 'retry',
+        '529': 'retry',
+      },
+    },
+  };
+
+  /** Build a Response-like object the plugin can read status/headers from. */
+  const fakeResponse = (
+    status: number,
+    headers: Record<string, string> = {}
+  ): Response => {
+    const lower: Record<string, string> = {};
+    for (const [k, v] of Object.entries(headers)) {
+      lower[k.toLowerCase()] = v;
+    }
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: String(status),
+      headers: {
+        get: (name: string) => lower[name.toLowerCase()] ?? null,
+      },
+    } as unknown as Response;
+  };
+
+  const setup = (events: SegmentEvent[]) => {
+    const plugin = new SegmentDestination();
+    const analytics = new SegmentClient({
+      ...clientArgs,
+      store: new MockSegmentStore({
+        settings: { [SEGMENT_DESTINATION_KEY]: {} },
+      }),
+    });
+    plugin.configure(analytics);
+
+    // update() with an integration-level httpConfig so the plugin lazily
+    // constructs a real RetryManager (the code path under test).
+    plugin.update(
+      {
+        integrations: {
+          [SEGMENT_DESTINATION_KEY]: { httpConfig } as never,
+        },
+      },
+      UpdateType.initial
+    );
+
+    jest
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore - reach into the queue plugin's store like the sibling suite
+      .spyOn(plugin.queuePlugin.queueStore!, 'getState')
+      .mockImplementation(createMockStoreGetter(() => ({ events })));
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore - retryManager is private; grab it for spying
+    const retryManager = plugin.retryManager as RetryManager;
+    const retryAfterSpy = jest.spyOn(retryManager, 'handleRetryAfter');
+    const transientSpy = jest.spyOn(retryManager, 'handleTransientError');
+
+    return { plugin, retryManager, retryAfterSpy, transientSpy };
+  };
+
+  const event = (id: string): SegmentEvent =>
+    ({ messageId: id } as SegmentEvent);
+
+  beforeEach(() => {
+    store.reset();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('creates a RetryManager from integration httpConfig', () => {
+    const { retryManager } = setup([event('m-1')]);
+    expect(retryManager).toBeInstanceOf(RetryManager);
+  });
+
+  it.each([529, 503, 408])(
+    'routes %s + Retry-After through the server-directed wait, not backoff',
+    async (status) => {
+      jest
+        .spyOn(api, 'uploadEvents')
+        .mockResolvedValue(fakeResponse(status, { 'Retry-After': '30' }));
+
+      const { plugin, retryAfterSpy, transientSpy } = setup([event('m-1')]);
+
+      await plugin.flush();
+
+      expect(retryAfterSpy).toHaveBeenCalledTimes(1);
+      expect(retryAfterSpy).toHaveBeenCalledWith(30);
+      expect(transientSpy).not.toHaveBeenCalled();
+    }
+  );
+
+  it('uses exponential backoff for 529 WITHOUT a Retry-After header', async () => {
+    jest.spyOn(api, 'uploadEvents').mockResolvedValue(fakeResponse(529));
+
+    const { plugin, retryAfterSpy, transientSpy } = setup([event('m-1')]);
+
+    await plugin.flush();
+
+    expect(transientSpy).toHaveBeenCalledTimes(1);
+    expect(retryAfterSpy).not.toHaveBeenCalled();
+  });
+
+  it('still honors Retry-After on 429 (unchanged behavior)', async () => {
+    jest
+      .spyOn(api, 'uploadEvents')
+      .mockResolvedValue(fakeResponse(429, { 'Retry-After': '12' }));
+
+    const { plugin, retryAfterSpy, transientSpy } = setup([event('m-1')]);
+
+    await plugin.flush();
+
+    expect(retryAfterSpy).toHaveBeenCalledWith(12);
+    expect(transientSpy).not.toHaveBeenCalled();
+  });
+
+  it('parses HTTP-date Retry-After on 529 into a relative wait', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    const when = new Date(1_000_000 + 45_000).toUTCString();
+    jest
+      .spyOn(api, 'uploadEvents')
+      .mockResolvedValue(fakeResponse(529, { 'Retry-After': when }));
+
+    const { plugin, retryAfterSpy } = setup([event('m-1')]);
+
+    await plugin.flush();
+
+    expect(retryAfterSpy).toHaveBeenCalledTimes(1);
+    // ~45s from "now"; date second-rounding can yield 44 or 45.
+    const waited = retryAfterSpy.mock.calls[0][0];
+    expect(waited).toBeGreaterThanOrEqual(44);
+    expect(waited).toBeLessThanOrEqual(45);
+  });
+
+  it('clamps an excessive Retry-After to maxRetryInterval on 529', async () => {
+    jest
+      .spyOn(api, 'uploadEvents')
+      .mockResolvedValue(fakeResponse(529, { 'Retry-After': '99999' }));
+
+    const { plugin, retryAfterSpy } = setup([event('m-1')]);
+
+    await plugin.flush();
+
+    // parseRetryAfter clamps to maxRetryInterval (300) before it reaches the
+    // RetryManager.
+    expect(retryAfterSpy).toHaveBeenCalledWith(300);
+  });
+
+  it('ignores Retry-After on a permanent (non-retryable) code', async () => {
+    jest
+      .spyOn(api, 'uploadEvents')
+      .mockResolvedValue(fakeResponse(400, { 'Retry-After': '30' }));
+
+    const { plugin, retryAfterSpy, transientSpy } = setup([event('m-1')]);
+
+    await plugin.flush();
+
+    expect(retryAfterSpy).not.toHaveBeenCalled();
+    expect(transientSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Generalizes Retry-After handling so the SDK honors the header on **any** retryable status code (529, 503, 408, …), not just 429. Implements Option B of the "Generic Retry-After Header Support (HTTP 529 + Beyond)" design.

## Changes
- `SegmentDestination`: parse `Retry-After` on any error response (not just 429); route retryable responses that carry it through the server-directed wait path, while codes without the header keep exponential backoff and permanent codes still drop (header ignored).
- `RetryManager`: add `handleRetryAfter()` as the generic server-directed-wait entry point; `handle429()` now delegates to it (zero behavior change for 429).
- Internal rename for honesty: batch status `'429'` → `'retry_after'`, `rateLimitResults` → `serverDirectedResults`.
- Tests: new `SegmentDestination.retryAfter.test.ts` (9 wiring tests across 429/529/503/408, HTTP-date, clamp, absent-header, permanent-ignored) + 4 new `RetryManager` tests for `handleRetryAfter`.
- `e2e-cli/e2e-config.json`: opt into the `GENERIC_RETRY_AFTER` conformance suite in sdk-e2e-tests.

## Why
HTTP 529 ("site overloaded") and other 5xx codes can send `Retry-After`, but the SDK was ignoring it and computing its own (often shorter) backoff — hammering an already-overloaded endpoint. Respecting the server's requested wait on any retryable response is the RFC 9110 §10.2.3-correct behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)