### PR TITLE
fix(plugins) Mixpanel plugin wrong EU URL

### DIFF
--- a/packages/plugins/plugin-mixpanel/src/MixpanelPlugin.ts
+++ b/packages/plugins/plugin-mixpanel/src/MixpanelPlugin.ts
@@ -20,11 +20,13 @@ import group from './methods/group';
 import alias from './methods/alias';
 import track from './methods/track';
 
-export const EU_SERVER = 'api.eu.mixpanel.com';
+export const EU_SERVER = 'https://api-eu.mixpanel.com';
+export const US_SERVER = 'https://api.mixpanel.com';
 export class MixpanelPlugin extends DestinationPlugin {
   type = PluginType.destination;
   key = 'Mixpanel';
   trackScreens = false;
+  serverURL = US_SERVER;
   private mixpanel: Mixpanel | undefined;
   private settings: SegmentMixpanelSettings | undefined;
   private isInitialized = () =>
@@ -41,8 +43,11 @@ export class MixpanelPlugin extends DestinationPlugin {
     if (mixpanelSettings.token.length === 0) {
       return;
     }
+    if (mixpanelSettings.enableEuropeanEndpoint === true) {
+      this.serverURL = EU_SERVER;
+    }
     this.mixpanel = new Mixpanel(mixpanelSettings.token, false);
-    this.mixpanel.init().catch((error) => {
+    this.mixpanel.init(undefined, undefined, this.serverURL).catch((error) => {
       this.analytics?.reportInternalError(
         new SegmentError(
           ErrorType.PluginError,
@@ -52,10 +57,6 @@ export class MixpanelPlugin extends DestinationPlugin {
       );
     });
     this.settings = mixpanelSettings;
-
-    if (mixpanelSettings.enableEuropeanEndpoint === true) {
-      this.mixpanel?.setServerURL(EU_SERVER);
-    }
   }
 
   identify(event: IdentifyEventType) {


### PR DESCRIPTION
Summary
Fixes Mixpanel EU data residency routing in the React Native destination plugin. When Enable European Union Endpoint is on in Segment, the plugin now initializes mixpanel-react-native against https://api-eu.mixpanel.com instead of the broken api.eu.mixpanel.com hostname and the previous US-default-then-setServerURL() flow as per [docs](https://docs.mixpanel.com/docs/privacy/eu-residency).

Changes
- MixpanelPlugin: correct EU_SERVER from api.eu.mixpanel.com → https://api-eu.mixpanel.com (Mixpanel’s documented EU ingestion endpoint; the old hostname does not resolve).
- MixpanelPlugin: add exported US_SERVER (https://api.mixpanel.com) and pass the chosen endpoint into mixpanel.init(undefined, undefined, serverURL) so the native SDK starts on the right region from the first request.
- MixpanelPlugin: remove post-init setServerURL() — avoids initializing against the US default and retargeting afterward (race with early lifecycle events when trackAppLifecycleEvents is enabled).

Why
Apps using the Mixpanel device-mode plugin with EU data residency enabled in Segment were not reliably sending events to Mixpanel’s EU ingestion API. 

<img width="1228" height="176" alt="Screenshot 2026-06-23 at 14 19 00" src="https://github.com/user-attachments/assets/b296a022-b5e6-49f0-ab4b-c6cf20363bf2" />
