### PR TITLE
fix(idfa): return promise from getTrackingAuthorizationStatus

### DIFF
--- a/packages/plugins/plugin-idfa/src/IdfaPlugin.tsx
+++ b/packages/plugins/plugin-idfa/src/IdfaPlugin.tsx
@@ -60,7 +60,7 @@ make additional tracking decisions based on the user response
   }
 
   getTrackingStatus() {
-    getTrackingAuthorizationStatus()
+    return getTrackingAuthorizationStatus()
       .then((idfa: IdfaData) => {
         // update our context with the idfa data
         void this.analytics?.context.set({ device: { ...idfa } });


### PR DESCRIPTION
The `getTrackingStatus` function in the IDFA plugin calls `getTrackingAuthorizationStatus` which returns a promise of the current tracking state, but getTrackingStatus never returned it.

Closes https://github.com/segmentio/analytics-react-native/issues/1070