### PR TITLE
fix(deps): switch react-native-get-random-values to optional

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,6 +68,9 @@
   "peerDependenciesMeta": {
     "@react-native-async-storage/async-storage": {
       "optional": true
+    },
+    "react-native-get-random-values": {
+      "optional": true
     }
   },
   "engines": {

--- a/packages/core/src/uuid.ts
+++ b/packages/core/src/uuid.ts
@@ -1,7 +1,29 @@
-import 'react-native-get-random-values';
 import { v4 as uuidv4 } from 'uuid';
 
+// `uuid` relies on a `crypto.getRandomValues` implementation, which React Native
+// does not provide out of the box. `react-native-get-random-values` is the
+// canonical polyfill, but it is an optional peer dependency: consumers may
+// already polyfill `crypto.getRandomValues` themselves. We attempt to load it
+// here, but never hard fail at import time so those apps keep working without it
+// installed. (Metro treats requires inside a try/catch as optional, so this does
+// not break bundling when the package is absent.)
+declare const require: (module: string) => unknown;
+
+try {
+  require('react-native-get-random-values');
+} catch {
+  // No-op: a `crypto.getRandomValues` polyfill may already be installed globally.
+}
+
 export const getUUID = (): string => {
-  const UUID = uuidv4().toString();
-  return UUID;
+  try {
+    return uuidv4().toString();
+  } catch {
+    throw new Error(
+      "@segment/analytics-react-native requires a 'crypto.getRandomValues' " +
+        "polyfill, which doesn't appear to be installed. Install " +
+        "'react-native-get-random-values' and import before " +
+        'initializing the analytics client.'
+    );
+  }
 };

--- a/packages/sovran/package.json
+++ b/packages/sovran/package.json
@@ -74,6 +74,9 @@
   "peerDependenciesMeta": {
     "@react-native-async-storage/async-storage": {
       "optional": true
+    },
+    "react-native-get-random-values": {
+      "optional": true
     }
   },
   "dependencies": {


### PR DESCRIPTION
`react-native-get-random-values` is required as a peer dependency in both the core and sovran packages. This is used for UUID v4 generation. 

I am using `react-native-quick-crypto` in my app and already polyfill the `crypto.getRandomValues` function globally. The peer dependency forces me to install `react-native-get-random-values` even though it no-op on setup.


**On the same topic:**
I have found in my testing that the UUID generation done on the native side is about 40% faster then using the JS `uuid` package. Looking back a past PRs and issues, it seems that it has bounced around a few times from being a pure native function to then using `uuid` and a polyfill because issues while debugging.

I wonder if there is a middle ground where it checks for the best solution at run time, without needing to use a slower solution all the time.

Example: `crypto.randomUUID()` -> if native module, generate uuid  -> use polyfill and `uuid` package.