### PR TITLE
ci: add Artifactory OIDC auth to the release/publish pipeline

### DIFF
--- a/.github/actions/artifactory-oidc/action.yml
+++ b/.github/actions/artifactory-oidc/action.yml
@@ -1,0 +1,58 @@
+name: 'Artifactory OIDC Auth'
+description: 'Exchange GitHub OIDC token for an Artifactory access token and configure Yarn Berry to resolve through it'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Exchange OIDC token for Artifactory access token
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if ! command -v jq >/dev/null 2>&1; then
+          echo "::error::jq is required by the artifactory-oidc action but was not found on the runner."
+          exit 1
+        fi
+
+        BASE_URL=$(echo "${ARTIFACTORY_URL}" | sed -E 's#/+$##')
+        if [ -z "$BASE_URL" ]; then
+          echo "::error::ARTIFACTORY_URL is empty."
+          exit 1
+        fi
+
+        GITHUB_JWT=$(curl -sS \
+          -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${BASE_URL}" \
+          | jq -r '.value')
+
+        RESP=$(curl -sS "${BASE_URL}/access/api/v1/oidc/token" \
+          -H 'Content-Type: application/json' \
+          -d "{\"grant_type\":\"urn:ietf:params:oauth:grant-type:token-exchange\",
+               \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\",
+               \"subject_token\":\"${GITHUB_JWT}\",
+               \"provider_name\":\"github-actions-segmentio\"}")
+        ART_TOKEN=$(echo "$RESP" | jq -r '.access_token // empty')
+
+        if [ -z "$ART_TOKEN" ]; then
+          echo "::error::OIDC token exchange failed. Redacted response below:"
+          echo "$RESP" | jq 'walk(if type == "object" then with_entries(if (.key | test("token"; "i")) then .value = "<redacted>" else . end) else . end)' 2>/dev/null \
+            || echo "::error::(response withheld — not valid JSON)"
+          exit 1
+        fi
+        echo "::add-mask::$ART_TOKEN"
+
+        REGISTRY="${BASE_URL}/artifactory/api/npm/virtual-npm-thirdparty/"
+        {
+          echo "YARN_NPM_REGISTRY_SERVER=${REGISTRY}"
+          echo "YARN_NPM_AUTH_TOKEN=${ART_TOKEN}"
+          echo "YARN_NPM_ALWAYS_AUTH=true"
+        } >> "$GITHUB_ENV"
+
+        cat >> .yarnrc.yml <<YAML
+        npmRegistries:
+          "${REGISTRY}":
+            npmAuthToken: "${ART_TOKEN}"
+            npmAlwaysAuth: true
+        YAML
+
+        echo "::notice::Yarn configured to use Artifactory registry"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,20 @@ concurrency:
   group: release
   cancel-in-progress: true
 
+env:
+  ARTIFACTORY_URL: ${{ vars.ARTIFACTORY_URL }}
+
 jobs:
   ci:
     name: Lint + Build + Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Artifactory OIDC Auth
+        uses: ./.github/actions/artifactory-oidc
       - name: Install devbox
         uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
       - name: Install dependencies
@@ -53,6 +61,9 @@ jobs:
           fetch-depth: 0
           token: ${{ github.token }}
 
+      - name: Artifactory OIDC Auth
+        uses: ./.github/actions/artifactory-oidc
+
       - name: Install devbox
         uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
 
@@ -78,6 +89,9 @@ jobs:
           fetch-depth: 0
           token: ${{ github.token }}
 
+      - name: Artifactory OIDC Auth
+        uses: ./.github/actions/artifactory-oidc
+
       - name: Install devbox
         uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
 
@@ -87,6 +101,7 @@ jobs:
           devbox run -e GITHUB_REF=refs/heads/$BRANCH_NAME release
         env:
           GH_TOKEN: ${{ github.token }}
+          NPM_CONFIG_IGNORE_SCRIPTS: 'true'
 
   release-production:
     name: Release (production)
@@ -105,6 +120,9 @@ jobs:
           fetch-depth: 0
           token: ${{ github.token }}
 
+      - name: Artifactory OIDC Auth
+        uses: ./.github/actions/artifactory-oidc
+
       - name: Install devbox
         uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
 
@@ -112,6 +130,7 @@ jobs:
         run: devbox run release
         env:
           GH_TOKEN: ${{ github.token }}
+          NPM_CONFIG_IGNORE_SCRIPTS: 'true'
 
       - name: Update Apps
         run: devbox run update-apps

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-yarn commitlint --edit $1
+devbox run -- yarn commitlint --edit $1

--- a/devbox.lock
+++ b/devbox.lock
@@ -199,7 +199,7 @@
     },
     "nodejs@22": {
       "last_modified": "2026-03-27T11:17:38Z",
-      "plugin_version": "0.0.2",
+      "plugin_version": "0.0.4",
       "resolved": "github:NixOS/nixpkgs/832efc09b4caf6b4569fbf9dc01bec3082a00611#nodejs_22",
       "source": "devbox-search",
       "version": "22.22.2",


### PR DESCRIPTION
## Summary
Ports the Artifactory OIDC + npm trusted-publisher setup already shipped in `segmentio/analytics-next` to this repo.

- Adds `.github/actions/artifactory-oidc` - exchanges a GitHub OIDC token for a short-lived Artifactory access token and configures Yarn Berry (env vars + an explicit `npmRegistries` block) to resolve through it
- Wires it into every `release.yml` job that installs dependencies (`ci`, dry-run, beta, production)
- Passes `NPM_CONFIG_IGNORE_SCRIPTS` through the actual publish steps (beta/production)
- Fixes `.husky/commit-msg` to run `commitlint` via `devbox run` (it was calling the global `yarn` directly, bypassing the pinned version devbox exists to enforce - unrelated pre-existing bug, hit while testing this locally)

Provenance doesn't need a separate env var here - `release.config.js` already sets `provenance: true` on `@semantic-release/npm`.

## Prerequisites confirmed already in place
- `segmentio/analytics-react-native` is already in Artifactory's `trusted_builds` list
- The `ARTIFACTORY_URL` repo variable is already set
- `@semantic-release/npm` is already `^13.1.5`, and devbox's pinned Node 22 resolves npm `11.11.0` - both satisfy npm's OIDC trusted-publisher requirement (npm >= 11.5.1), no version bump needed

## Not done here (manual, npmjs.org-side)
Each of the 17 publicly-published packages in this monorepo needs its own npm **trusted publisher** registration (repo + `release.yml` + the relevant environment name) before publish actually authenticates via OIDC instead of the existing (currently unused by this workflow) `NPM_TOKEN` secret.

## Test plan
- [x] `devbox run check` passes locally (70 suites, 492 tests)
- [ ] Confirm a real `Release (dry-run)` run resolves dependencies through Artifactory without curation errors
- [ ] After trusted-publisher registration, confirm a real beta/production release authenticates via OIDC