### PR TITLE
ci: route devbox/Nix package resolution through Artifactory

### DIFF
--- a/.github/actions/devbox-artifactory-cache/action.yml
+++ b/.github/actions/devbox-artifactory-cache/action.yml
@@ -1,0 +1,54 @@
+name: 'Devbox Artifactory Nix Cache'
+description: 'Route devbox/Nix package resolution through Artifactory instead of cache.nixos.org'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Configure Nix substituter
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        NIX_CACHE_URL="https://otk.artifactory.twilio.com/artifactory/remote-nix-cache-nixos"
+
+        # User-level nix.conf (merged with any system config) - no sudo needed,
+        # works regardless of how the Nix install in the previous step laid
+        # out its system config.
+        mkdir -p "$HOME/.config/nix"
+        {
+          echo "substituters = https://cache.nixos.org ${NIX_CACHE_URL}"
+          echo "trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+        } >> "$HOME/.config/nix/nix.conf"
+
+        # Read by our patched devbox binary (see below) as the fromStore for
+        # fetchClosure - stock devbox hardcodes cache.nixos.org and ignores this.
+        echo "DEVBOX_NIX_BINARY_CACHE=${NIX_CACHE_URL}" >> "$GITHUB_ENV"
+
+    # Upstream devbox always fetches package outputs from cache.nixos.org
+    # (https://github.com/jetify-com/devbox/pull/2891 proposes the same
+    # DEVBOX_NIX_BINARY_CACHE override upstream, not yet merged). Until then,
+    # build a patched binary from the exact devbox version this repo's
+    # devbox.lock nixpkgs pin already provides (0.16.0 @ nixpkgs-unstable
+    # afce96367b2e37fc29afb5543573cd49db3357b7), same patch already in use by
+    # segmentio/ajs-renderer - and overwrite whatever devbox-install-action
+    # just put on PATH, so every later `devbox run` call picks it up
+    # regardless of PATH ordering.
+    - name: Build and install patched devbox
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        STOCK_DEVBOX="$(command -v devbox)"
+
+        nix --extra-experimental-features 'nix-command flakes' profile install \
+          --impure --expr '
+            let
+              pkgs = import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/afce96367b2e37fc29afb5543573cd49db3357b7.tar.gz") {};
+            in
+            pkgs.devbox.overrideAttrs (o: {
+              patches = (o.patches or [ ]) ++ [ ${{ github.action_path }}/configurable-nix-binary-cache.patch ];
+            })
+          '
+
+        cp -f "$(command -v devbox)" "$STOCK_DEVBOX"
+        devbox version

--- a/.github/actions/devbox-artifactory-cache/configurable-nix-binary-cache.patch
+++ b/.github/actions/devbox-artifactory-cache/configurable-nix-binary-cache.patch
@@ -1,0 +1,148 @@
+diff --git a/internal/devpkg/narinfo_cache.go b/internal/devpkg/narinfo_cache.go
+index e39fd2a..5c79300 100644
+--- a/internal/devpkg/narinfo_cache.go
++++ b/internal/devpkg/narinfo_cache.go
+@@ -15,15 +15,29 @@
+ 	"github.com/pkg/errors"
+ 	"go.jetify.com/devbox/internal/debug"
+ 	"go.jetify.com/devbox/internal/devbox/providers/nixcache"
++	"go.jetify.com/devbox/internal/envir"
+ 	"go.jetify.com/devbox/internal/goutil"
+ 	"go.jetify.com/devbox/internal/lock"
+ 	"go.jetify.com/devbox/internal/nix"
+ 	"golang.org/x/sync/errgroup"
+ )
+ 
+-// binaryCache is the store from which to fetch this package's binaries.
+-// It is used as FromStore in builtins.fetchClosure.
+-const binaryCache = "https://cache.nixos.org"
++// defaultBinaryCache is the public Nix binary cache that Devbox queries by
++// default for prebuilt package outputs.
++const defaultBinaryCache = "https://cache.nixos.org"
++
++// BinaryCache is the store from which to fetch a package's binaries. It is
++// used as the FromStore in builtins.fetchClosure and as the first cache
++// queried when checking whether a package's outputs are already built.
++//
++// It defaults to the public cache (https://cache.nixos.org) but can be
++// overridden with the DEVBOX_NIX_BINARY_CACHE environment variable. This is
++// useful in network-restricted environments where the public cache is
++// unreachable and an internal mirror/proxy serving the same store paths must
++// be used instead.
++func BinaryCache() string {
++	return envir.GetValueOrDefault(envir.DevboxNixBinaryCache, defaultBinaryCache)
++}
+ 
+ // useDefaultOutputs is a special value for the outputName parameter of
+ // fetchNarInfoStatusOnce, which indicates that the default outputs should be
+@@ -320,7 +334,7 @@ func(o *s3.Options) {
+ var nixCacheIsConfigured = goutil.OnceValueWithContext(nixcache.IsConfigured)
+ 
+ func readCaches(ctx context.Context) ([]string, error) {
+-	cacheURIs := []string{binaryCache}
++	cacheURIs := []string{BinaryCache()}
+ 	if !nixCacheIsConfigured.Do(ctx) {
+ 		return cacheURIs, nil
+ 	}
+diff --git a/internal/envir/env.go b/internal/envir/env.go
+index 5cf0c37..382ec20 100644
+--- a/internal/envir/env.go
++++ b/internal/envir/env.go
+@@ -6,6 +6,13 @@
+ const (
+ 	DevboxCache   = "DEVBOX_CACHE"
+ 	DevboxGateway = "DEVBOX_GATEWAY"
++	// DevboxNixBinaryCache overrides the default Nix binary cache that Devbox
++	// queries for prebuilt package outputs (https://cache.nixos.org). This is
++	// useful in network-restricted environments where the public cache is
++	// unreachable and an internal mirror/proxy must be used instead. The value
++	// should be a substituter URL serving the same store paths (e.g. an
++	// Artifactory/Nexus generic remote that mirrors cache.nixos.org).
++	DevboxNixBinaryCache = "DEVBOX_NIX_BINARY_CACHE"
+ 	// DevboxLatestVersion is the latest version available of the devbox CLI binary.
+ 	// NOTE: it should NOT start with v (like 0.4.8)
+ 	DevboxLatestVersion  = "DEVBOX_LATEST_VERSION"
+diff --git a/internal/shellgen/generate.go b/internal/shellgen/generate.go
+index 838152f..16c3052 100644
+--- a/internal/shellgen/generate.go
++++ b/internal/shellgen/generate.go
+@@ -17,6 +17,7 @@
+ 	"github.com/pkg/errors"
+ 	"go.jetify.com/devbox/internal/cuecfg"
+ 	"go.jetify.com/devbox/internal/debug"
++	"go.jetify.com/devbox/internal/devpkg"
+ 	"go.jetify.com/devbox/internal/redact"
+ )
+ 
+@@ -161,9 +162,41 @@ func toJSON(a any) string {
+ }
+ 
+ var templateFuncs = template.FuncMap{
+-	"json":     toJSON,
+-	"contains": strings.Contains,
+-	"debug":    debug.IsEnabled,
++	"json":              toJSON,
++	"contains":          strings.Contains,
++	"debug":             debug.IsEnabled,
++	"fetchClosureStore": fetchClosureStore,
++	"nixString":         nixString,
++}
++
++// fetchClosureStore returns the store URL to use as the fromStore of a
++// builtins.fetchClosure in the generated flake.
++//
++// fetchClosure only supports http(s) stores, so when a package's outputs were
++// found in an http(s) cache we use that cache directly (it's where the path
++// actually lives, which may be the public cache or a configured mirror via
++// DEVBOX_NIX_BINARY_CACHE). For s3 caches fetchClosure can't fetch directly, so
++// we fall back to the configured binary cache as a placeholder store — the path
++// is already built locally, so fetchClosure won't actually fetch from it.
++func fetchClosureStore(cacheURI string) string {
++	if strings.HasPrefix(cacheURI, "http://") || strings.HasPrefix(cacheURI, "https://") {
++		return cacheURI
++	}
++	return devpkg.BinaryCache()
++}
++
++// nixString renders s as a double-quoted Nix string literal, escaping the
++// characters that are special inside one: backslash, double quote, and the
++// "${" antiquotation (interpolation) start. This keeps values that originate
++// from configuration (e.g. a cache URL from DEVBOX_NIX_BINARY_CACHE) from
++// breaking flake evaluation or being interpreted as Nix interpolation.
++func nixString(s string) string {
++	r := strings.NewReplacer(
++		`\`, `\\`,
++		`"`, `\"`,
++		`${`, `\${`,
++	)
++	return `"` + r.Replace(s) + `"`
+ }
+ 
+ func makeFlakeFile(d devboxer, plan *flakePlan) error {
+diff --git a/internal/shellgen/tmpl/flake.nix.tmpl b/internal/shellgen/tmpl/flake.nix.tmpl
+index 3bd0513..cbe1321 100644
+--- a/internal/shellgen/tmpl/flake.nix.tmpl
++++ b/internal/shellgen/tmpl/flake.nix.tmpl
+@@ -42,13 +42,16 @@
+             {{ if $output.CacheURI -}}
+             (builtins.trace "downloading {{ $pkg.Versioned }}" (builtins.fetchClosure {
+               {{/*
+-                HACK HACK HACK! fetchClosure only supports http(s) caches and not
+-                s3 caches. Until we implement that, we put a fake store here.
+-                Since we pre-build everything, fetchClosure will not actually
+-                fetch anything and just use the local version. This may break
+-                if user somehow removes the local store path.
++                fetchClosure only supports http(s) caches and not s3 caches.
++                fetchClosureStore returns the http(s) cache the output was found
++                in (the public cache or a configured mirror via
++                DEVBOX_NIX_BINARY_CACHE), falling back to the default binary
++                cache for s3 caches. Since we pre-build everything, fetchClosure
++                will not actually fetch anything for an s3 cache and just use the
++                local version. This may break if the user somehow removes the
++                local store path.
+               */}}
+-              fromStore = "https://cache.nixos.org";
++              fromStore = {{ fetchClosureStore $output.CacheURI | nixString }};
+               fromPath = "{{ $pkg.InputAddressedPathForOutput $output.Name }}";
+               inputAddressed = true;
+             }))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install devbox
         uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
+      - name: Route Nix/devbox packages through Artifactory
+        uses: ./.github/actions/devbox-artifactory-cache
       - name: Install dependencies
         run: devbox run ci:install
       - name: Lint (eslint)
@@ -39,6 +41,8 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install devbox
         uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
+      - name: Route Nix/devbox packages through Artifactory
+        uses: ./.github/actions/devbox-artifactory-cache
       - name: Install dependencies
         run: devbox run ci:install
       - name: Validate PR title

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install devbox
         uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
+      - name: Route Nix/devbox packages through Artifactory
+        uses: ./.github/actions/devbox-artifactory-cache
       - name: Install dependencies
         run: devbox run ci:install
       - name: Lint (eslint)
@@ -55,6 +57,8 @@ jobs:
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
+      - name: Route Nix/devbox packages through Artifactory
+        uses: ./.github/actions/devbox-artifactory-cache
 
       - name: Release (dry-run)
         run: devbox run release-dry-run
@@ -80,6 +84,8 @@ jobs:
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
+      - name: Route Nix/devbox packages through Artifactory
+        uses: ./.github/actions/devbox-artifactory-cache
 
       - name: Release (beta)
         run: |
@@ -107,6 +113,8 @@ jobs:
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
+      - name: Route Nix/devbox packages through Artifactory
+        uses: ./.github/actions/devbox-artifactory-cache
 
       - name: Release (production)
         run: devbox run release

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-yarn commitlint --edit $1
+devbox run -- yarn commitlint --edit $1

--- a/devbox.lock
+++ b/devbox.lock
@@ -199,7 +199,7 @@
     },
     "nodejs@22": {
       "last_modified": "2026-03-27T11:17:38Z",
-      "plugin_version": "0.0.2",
+      "plugin_version": "0.0.4",
       "resolved": "github:NixOS/nixpkgs/832efc09b4caf6b4569fbf9dc01bec3082a00611#nodejs_22",
       "source": "devbox-search",
       "version": "22.22.2",


### PR DESCRIPTION
## Summary
All supply-chain vectors are required to go through Artifactory's scanning/curation proxy, not just npm - this repo's devbox/Nix packages (nodejs, yarn-berry, jq, cocoapods, etc.) were still being fetched straight from `cache.nixos.org`, unfiltered.

Adopts the same mechanism already shipped in `segmentio/ajs-renderer` (#515): upstream devbox hardcodes `cache.nixos.org` as its `fetchClosure` source and ignores any override, so a patched devbox binary (same patch ajs-renderer uses - devbox's own `DEVBOX_NIX_BINARY_CACHE` override, proposed upstream at [jetify-com/devbox#2891](https://github.com/jetify-com/devbox/pull/2891), not yet merged) is built from source and installed over whatever `devbox-install-action` just put on PATH, immediately after every existing "Install devbox" step in `ci.yml` and `release.yml`.

ajs-renderer's version of this involves a whole custom CI base Docker image, an apt-installed `nix-bin`, and a disabled flake registry - that complexity exists specifically to work around Twilio Buildkite's locked-down egress. GitHub Actions runners have open internet, so none of that bootstrap is needed here - just the patch + nix.conf substituter + `DEVBOX_NIX_BINARY_CACHE`.

Also reapplies the `.husky/commit-msg` → `devbox run` fix from #1301, since this branch was cut before that merged and hit the same failure.

## Verified locally before pushing
- The patch applies cleanly to devbox 0.16.0, the version this repo's own `devbox.lock` `nixpkgs-unstable` pin (`afce96367b`) already provides
- The patched expression actually builds (`nix build --impure --expr`), and the resulting binary's compiled string table contains `DEVBOX_NIX_BINARY_CACHE`, confirming the patch compiled in rather than silently no-op'ing

## NOT verified - needs a real CI run
- Whether segmentio's GitHub-Actions-OIDC-authenticated identity (or anonymous access) can actually reach `https://otk.artifactory.twilio.com/artifactory/remote-nix-cache-nixos` - this is a different Artifactory repo than the npm proxy, onboarded separately, and I found no IPD doc confirming general segmentio access the way `trusted_builds` covers npm
- Whether that substituter actually serves the specific package/version closures `devbox.lock` resolves (nodejs 22, yarn-berry, cocoapods, jq, treefmt, nixfmt, shfmt) - if any are missing, the build falls back to building locally instead of hard-failing, but will be much slower

## Test plan
- [x] Patch applies cleanly to devbox 0.16.0 (verified locally)
- [x] Patched devbox binary builds and contains the new env var (verified locally)
- [ ] Real CI run confirms Artifactory substituter access + package availability