### PR TITLE
ci: release + PR checks without devbox/Nix as a stopgap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,42 +10,55 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  ARTIFACTORY_URL: ${{ vars.ARTIFACTORY_URL }}
+
 jobs:
   ci:
     name: Lint + Build + Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Install devbox
-        uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
-      - name: Route Nix/devbox packages through Artifactory
-        uses: ./.github/actions/devbox-artifactory-cache
+      - name: Artifactory OIDC Auth
+        uses: ./.github/actions/artifactory-oidc
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+      - run: corepack enable
       - name: Install dependencies
-        run: devbox run ci:install
+        run: yarn install --immutable
       - name: Lint (eslint)
-        run: devbox run lint
+        run: yarn lint
       - name: Lint (formatting)
-        run: devbox run format-check
+        run: yarn format:check
       - name: Build
-        run: devbox run build
+        run: yarn build
       - name: Typecheck
-        run: devbox run typecheck
+        run: yarn typecheck
       - name: Test
-        run: devbox run test
+        run: yarn test
 
   commitlint:
     name: Commitlint
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Install devbox
-        uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
-      - name: Route Nix/devbox packages through Artifactory
-        uses: ./.github/actions/devbox-artifactory-cache
+      - name: Artifactory OIDC Auth
+        uses: ./.github/actions/artifactory-oidc
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+      - run: corepack enable
       - name: Install dependencies
-        run: devbox run ci:install
+        run: yarn install --immutable
       - name: Validate PR title
-        run: devbox run ci:commitlint
+        run: echo "$PR_TITLE" | yarn commitlint
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,11 +8,10 @@
 
 name: E2E Tests
 
+# Push/pull_request triggers disabled for now - runs have been stuck queued
+# (not a code/action problem here specifically, unlike ci.yml's devbox
+# startup_failure). Re-enable once confirmed healthy.
 on:
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
   workflow_dispatch:
     inputs:
       e2e_tests_ref:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,22 +30,22 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Artifactory OIDC Auth
         uses: ./.github/actions/artifactory-oidc
-      - name: Install devbox
-        uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
-      - name: Route Nix/devbox packages through Artifactory
-        uses: ./.github/actions/devbox-artifactory-cache
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+      - run: corepack enable
       - name: Install dependencies
-        run: devbox run ci:install
+        run: yarn install --immutable
       - name: Lint (eslint)
-        run: devbox run lint
+        run: yarn lint
       - name: Lint (formatting)
-        run: devbox run format-check
+        run: yarn format:check
       - name: Build
-        run: devbox run build
+        run: yarn build
       - name: Typecheck
-        run: devbox run typecheck
+        run: yarn typecheck
       - name: Test
-        run: devbox run test
+        run: yarn test
 
   release-dryrun:
     name: Release (dry-run)
@@ -66,13 +66,16 @@ jobs:
       - name: Artifactory OIDC Auth
         uses: ./.github/actions/artifactory-oidc
 
-      - name: Install devbox
-        uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
-      - name: Route Nix/devbox packages through Artifactory
-        uses: ./.github/actions/devbox-artifactory-cache
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+      - run: corepack enable
 
       - name: Release (dry-run)
-        run: devbox run release-dry-run
+        run: |
+          yarn install --immutable
+          yarn build
+          yarn multi-semantic-release --dry-run
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -96,17 +99,19 @@ jobs:
       - name: Artifactory OIDC Auth
         uses: ./.github/actions/artifactory-oidc
 
-      - name: Install devbox
-        uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
-      - name: Route Nix/devbox packages through Artifactory
-        uses: ./.github/actions/devbox-artifactory-cache
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+      - run: corepack enable
 
       - name: Release (beta)
         run: |
-          BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-          devbox run -e GITHUB_REF=refs/heads/$BRANCH_NAME release
+          yarn install --immutable
+          yarn build
+          yarn release
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_REF: refs/heads/${{ github.ref_name }}
           NPM_CONFIG_IGNORE_SCRIPTS: 'true'
 
   release-production:
@@ -129,16 +134,21 @@ jobs:
       - name: Artifactory OIDC Auth
         uses: ./.github/actions/artifactory-oidc
 
-      - name: Install devbox
-        uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
-      - name: Route Nix/devbox packages through Artifactory
-        uses: ./.github/actions/devbox-artifactory-cache
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+      - run: corepack enable
 
       - name: Release (production)
-        run: devbox run release
+        run: |
+          yarn install --immutable
+          yarn build
+          yarn release
         env:
           GH_TOKEN: ${{ github.token }}
           NPM_CONFIG_IGNORE_SCRIPTS: 'true'
 
       - name: Update Apps
-        run: devbox run update-apps
+        run: |
+          yarn install --no-immutable
+          yarn --cwd examples/AnalyticsReactNativeExample install --no-immutable


### PR DESCRIPTION
## Summary
Both `release.yml` and `ci.yml` had jobs using `jetify-com/devbox-install-action`, which is blocked outright by org policy (third-party action). `ci.yml`'s run history confirms `startup_failure` on every single run going back weeks - every PR check on the repo has been broken, not just releases. #1303 fixes the underlying action properly, but it and the Nix/Artifactory work it depends on (#1301/#1302 here, twilio-internal/artifactory-cloud-twilio-config#11/#12) aren't merged yet.

**`release.yml`** - every job's devbox steps replaced with the exact commands `devbox.json` already ran, directly: `actions/setup-node` (node 22) + `corepack enable` + plain `yarn` invocations. Artifactory OIDC Auth step untouched (npm/yarn curation, unrelated to devbox).

**`ci.yml`** - `Lint + Build + Test` and `Commitlint` ported to the identical commands now used in `release.yml`'s own `ci` job - both jobs are named `Lint + Build + Test` and are now byte-for-byte the same steps, so `release.yml`'s `needs: [ci]` gate is the same check PRs already have to pass.

**`e2e-tests.yml`** - triggers disabled for now (`workflow_dispatch` only). Unlike the other two, this one never used devbox and never hit `startup_failure` - its recent runs show stuck `queued`/`cancelled` instead, a separate, still-unresolved runner-availability issue. Left alone rather than "fixed" for a problem it doesn't actually have.

## Important: overlaps with #1303
This and #1303 both touch `release.yml`/`ci.yml`'s devbox steps in different, incompatible ways. Once devbox/Nix + Artifactory is fully working and merged, this stopgap should be reconciled or reverted rather than left alongside it long-term.

## Not verified end-to-end
- No way to safely test `corepack`/`yarn` locally without touching this machine's global Node setup
- A manually-dispatched `dry-run` release has been stuck `queued` for 10+ minutes with no runner assigned (`runner_id: 0`) - looks like a separate, currently-ongoing GHA runner-availability issue on this repo, unrelated to this PR's content

## Test plan
- [ ] `Lint + Build + Test` and `Commitlint` pass on this PR once runners are healthy
- [ ] Manual `workflow_dispatch` with `type: dry-run` succeeds