### PR TITLE
ci: remove the post-release Update Apps step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,8 +186,3 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           NPM_CONFIG_IGNORE_SCRIPTS: 'true'
-
-      - name: Update Apps
-        run: |
-          yarn install --no-immutable
-          yarn --cwd examples/AnalyticsReactNativeExample install --no-immutable


### PR DESCRIPTION
## Summary
- Removes the "Update Apps" step from release-production. Traced its origin to a local devbox maintenance script (`update-apps`) that got wired into the release job at some point - as a CI step it never made sense: it runs after the actual npm publish (can't gate release correctness), and nothing commits/pushes the "updated" lockfiles back (runner is ephemeral, so it's a no-op with no lasting effect).
- It was also surfacing unrelated noise: `examples/AnalyticsReactNativeExample` is a standalone yarn project outside the root workspace, so it isn't covered by any of the curation-block fixes from #1305, and its own independently-resolved `flatted@3.3.1` hit a fresh curation block, making a successful release look broken.

## Test plan
- [x] Confirmed via https://github.com/segmentio/analytics-react-native/actions/runs/30126659790/job/89591958215 that `Release (production)` succeeds (npm publish completes) before this step runs and fails
- [ ] Next release run has no `Update Apps` step