### PR TITLE
fix(deps): make react-native-get-random-values optional

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,6 +68,9 @@
   "peerDependenciesMeta": {
     "@react-native-async-storage/async-storage": {
       "optional": true
+    },
+    "react-native-get-random-values": {
+      "optional": true
     }
   },
   "engines": {

--- a/packages/core/src/uuid.ts
+++ b/packages/core/src/uuid.ts
@@ -1,7 +1,25 @@
-import 'react-native-get-random-values';
 import { v4 as uuidv4 } from 'uuid';
 
+// `uuid` relies on a `crypto.getRandomValues` implementation, which React
+// Native does not provide out of the box. `react-native-get-random-values` is
+// the canonical polyfill, but it's an optional peer dependency: consumers may
+// already polyfill `crypto.getRandomValues` themselves (e.g. via
+// react-native-quick-crypto), so we don't want to force it on everyone.
+try {
+  require('react-native-get-random-values');
+} catch {
+  // No-op: a `crypto.getRandomValues` polyfill may already be installed globally.
+}
+
 export const getUUID = (): string => {
-  const UUID = uuidv4().toString();
-  return UUID;
+  try {
+    return uuidv4().toString();
+  } catch {
+    throw new Error(
+      "@segment/analytics-react-native requires a 'crypto.getRandomValues' " +
+        "polyfill, which doesn't appear to be installed. Install " +
+        "'react-native-get-random-values' and import before " +
+        'initializing the analytics client.'
+    );
+  }
 };

--- a/packages/sovran/package.json
+++ b/packages/sovran/package.json
@@ -74,6 +74,9 @@
   "peerDependenciesMeta": {
     "@react-native-async-storage/async-storage": {
       "optional": true
+    },
+    "react-native-get-random-values": {
+      "optional": true
     }
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4559,6 +4559,8 @@ __metadata:
   peerDependenciesMeta:
     "@react-native-async-storage/async-storage":
       optional: true
+    react-native-get-random-values:
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4594,6 +4596,8 @@ __metadata:
     react-native-get-random-values: 1.x || 2.x
   peerDependenciesMeta:
     "@react-native-async-storage/async-storage":
+      optional: true
+    react-native-get-random-values:
       optional: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Alternative to #1298 (by @SYoder1), same goal: `react-native-get-random-values` is a hard peer dependency used purely to install a `crypto.getRandomValues` polyfill, but some apps already polyfill it themselves (e.g. via `react-native-quick-crypto`) and shouldn't be forced to install a redundant package.

This takes a different implementation approach than #1298:
- Marks `react-native-get-random-values` optional in `peerDependenciesMeta` for both `core` and `sovran` (same as #1298).
- Loads it defensively in `packages/core/src/uuid.ts` using the same `try { require(...) } catch {}` idiom this codebase already uses for the optional `@react-native-async-storage/async-storage` peer dependency (`packages/sovran/src/persistor/async-storage-persistor.ts`), rather than introducing a new local `require` type declaration.
- `getUUID()` now throws a clear, actionable error only if `crypto.getRandomValues` genuinely isn't available (neither via the polyfill nor any other source) — apps with a working polyfill see no behavior change.

Not a breaking change: apps that already have `react-native-get-random-values` installed keep working identically (the module still gets `require`d for its side effect); this only removes the forced install for apps using a different polyfill.

Verified locally: `yarn lint`, `yarn format:check` (prettier only — `shfmt` unavailable in my env, but no `.sh` files are touched), `yarn build`, `yarn typecheck`, and `yarn test` (70/70 suites, 492 passed) all pass with no new warnings introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)