### PR TITLE
ci: use ubuntu-latest-large for Publish E2E CLI

### DIFF
--- a/.github/workflows/publish-e2e-cli.yml
+++ b/.github/workflows/publish-e2e-cli.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
       - name: Checkout SDK
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
Last workflow on master still pinned to the plain `ubuntu-latest` label — `ci.yml`, `e2e-tests.yml`, and `release.yml` are already on `ubuntu-latest-large`. This job's recent runs have been stuck `queued` for 20+ hours, consistent with `ubuntu-latest` capacity no longer being reliably available to this org while `ubuntu-latest-large` (Twilio's runners) is.

Note: this overlaps with #1296 ("migrate runs-on to Twilio runner labels + SHA-pin actions", open since June 25) for this one file. That PR is now `CONFLICTING`/stale against master — its `ci.yml`/`e2e-tests.yml`/`release.yml` changes already landed independently since it was opened, leaving `publish-e2e-cli.yml` as the one file it still would've fixed. Flagging rather than closing #1296 myself, since it's not mine to close.

(`claude-doc-sync.yml` also needs this same label change - already pushed as a separate commit on #1313, since that PR is still open and unmerged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)