### PR TITLE
ci: add label-gated issue investigation via Claude

### DIFF
--- a/.github/workflows/claude-issue-investigate.yml
+++ b/.github/workflows/claude-issue-investigate.yml
@@ -6,7 +6,8 @@ on:
     types: [labeled]
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
   issues: read
   id-token: write
 
@@ -34,6 +35,12 @@ jobs:
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code
 
+      # New commits need an author - Claude never has repo write access outside this job.
+      - name: Configure git identity for Claude's commits
+        run: |
+          git config --global user.email "claude-bot@users.noreply.github.com"
+          git config --global user.name "claude-bot"
+
       # ISSUE_NUMBER only - title/body are untrusted, so Claude fetches them itself via gh rather than us splicing them into this script.
       - name: Write prompt
         env:
@@ -45,9 +52,10 @@ jobs:
           1. Run \`gh issue view $ISSUE_NUMBER\` to read the full issue (title, body, comments).
           2. Based on the description, actually try to reproduce the reported problem using this repository's existing code and test tooling - write and run a small script or test case that exercises the described behavior, don't just reason about whether it would fail.
           3. If you reproduce it, identify the root cause in the source code.
-          4. If you cannot reproduce it, explain exactly what you tried, why it didn't reproduce, and what additional information (exact repro steps, versions, environment) would help.
-          5. Do not commit, push, open a PR, or comment on the issue - your only output is the report file below.
-          6. Write your findings to investigation-report.md in the repository root: a summary, the exact reproduction steps you tried, whether it reproduced, your root-cause diagnosis if found, and a suggested fix approach if you have one.
+          4. If you can reproduce it and you're confident the fix is small, narrow, and clearly correct, implement it, create a new branch off master named \`fix/issue-$ISSUE_NUMBER\`, commit, push it, and open a pull request against master with \`gh pr create\` that includes "Fixes #$ISSUE_NUMBER" in the body. If the right fix is unclear, would need broader changes, or you're not confident it's correct, do not open a PR - note that in the report instead.
+          5. If you cannot reproduce it, explain exactly what you tried, why it didn't reproduce, and what additional information (exact repro steps, versions, environment) would help.
+          6. Do not comment on the issue itself.
+          7. Always write your findings to investigation-report.md in the repository root: a summary, the exact reproduction steps you tried, whether it reproduced, your root-cause diagnosis if found, and whether you opened a fix PR (with its number) or why you decided not to.
           EOF
 
       - name: Investigate with Claude

--- a/.github/workflows/claude-issue-investigate.yml
+++ b/.github/workflows/claude-issue-investigate.yml
@@ -1,0 +1,67 @@
+name: Investigate issue
+
+# Gated on a maintainer-added label rather than issues: opened, since this is a public repo and anyone can open an issue - this way a human triages first before spending budget on a Claude session.
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+  issues: read
+  id-token: write
+
+jobs:
+  investigate:
+    if: github.event.label.name == 'investigate'
+    runs-on: ubuntu-latest-large
+    env:
+      ARTIFACTORY_URL: ${{ vars.ARTIFACTORY_URL }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Artifactory OIDC Auth
+        uses: ./.github/actions/artifactory-oidc
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+
+      - run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      # ISSUE_NUMBER only - title/body are untrusted, so Claude fetches them itself via gh rather than us splicing them into this script.
+      - name: Write prompt
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          cat > "$RUNNER_TEMP/claude-prompt.txt" <<EOF
+          Investigate GitHub issue #$ISSUE_NUMBER in this repository.
+
+          1. Run \`gh issue view $ISSUE_NUMBER\` to read the full issue (title, body, comments).
+          2. Based on the description, actually try to reproduce the reported problem using this repository's existing code and test tooling - write and run a small script or test case that exercises the described behavior, don't just reason about whether it would fail.
+          3. If you reproduce it, identify the root cause in the source code.
+          4. If you cannot reproduce it, explain exactly what you tried, why it didn't reproduce, and what additional information (exact repro steps, versions, environment) would help.
+          5. Do not commit, push, open a PR, or comment on the issue - your only output is the report file below.
+          6. Write your findings to investigation-report.md in the repository root: a summary, the exact reproduction steps you tried, whether it reproduced, your root-cause diagnosis if found, and a suggested fix approach if you have one.
+          EOF
+
+      - name: Investigate with Claude
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          claude -p "$(cat "$RUNNER_TEMP/claude-prompt.txt")" \
+            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,Bash(git:*),Bash(gh:*),Bash(yarn:*),Bash(npm:*),Bash(node:*)"
+
+      - name: Upload investigation report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: issue-${{ github.event.issue.number }}-investigation
+          path: investigation-report.md
+          if-no-files-found: warn


### PR DESCRIPTION
Adds `.github/workflows/claude-issue-investigate.yml`: when a maintainer adds the `investigate` label to an issue, Claude reads it, attempts a real reproduction using the repo's own tooling (installs deps, writes and runs a small repro script/test), and writes a diagnosis to `investigation-report.md`, uploaded as a job artifact.

**Update:** if Claude reproduces the issue and is confident the fix is small, narrow, and clearly correct, it now branches (`fix/issue-<number>`), commits, pushes, and opens a PR against master with `gh pr create` (including "Fixes #<number>"). If the right fix is unclear, needs broader changes, or it isn't confident, it still just notes that in the report — no PR. It never comments on the issue itself either way.

**Why label-gated, not `issues: opened`:** this is a public repo and anyone can open an issue. Triggering on every new issue with no gate would let any user (including spam) kick off a real, paid Claude session — now with write access, that gate matters even more. A maintainer adding the `investigate` label puts a human trust decision in front of both the spend and the write access.

**Permissions:** `contents: write` and `pull-requests: write` (needed for the fix-PR path), `issues: read`, and `id-token: write` for the existing `./.github/actions/artifactory-oidc` step `yarn install` depends on. Any PR Claude opens still needs human review to merge — master's branch protection isn't bypassed here, so a bad or injected fix can't land without someone approving it.

**Issue title/body are never spliced into the shell script** that builds the prompt — only the numeric issue number is (not attacker-influenceable). Claude fetches the actual issue content itself via `gh issue view` as a tool call, so untrusted text never touches our own bash.

**No turn/budget cap** — runs until it either reproduces the issue or concludes it needs more information.

Also creates the `investigate` label on the repo (didn't exist before), so there's actually something to apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)