### PR TITLE
fix(core): redact deep-link query params before sending as event properties…

### DIFF
--- a/packages/core/android/src/main/java/com/segmentanalyticsreactnative/AnalyticsReactNativeModule.kt
+++ b/packages/core/android/src/main/java/com/segmentanalyticsreactnative/AnalyticsReactNativeModule.kt
@@ -201,15 +201,12 @@ class AnalyticsReactNativeModule : ReactContextBaseJavaModule, ActivityEventList
 
     val uri = intent.data
     try {
-      properties["url"] = uri.toString()
-      for (parameter in uri!!.queryParameterNames) {
-        val value = uri.getQueryParameter(parameter)
-        if (value != null && value.trim { it <= ' ' }.isNotEmpty()) {
-          properties[parameter] = value
-        }
-      }
+      // Strip query string — deep-link params routinely carry secrets
+      // (OAuth codes, magic-link tokens). The JS layer applies further
+      // sanitization via deepLinkPropertiesDecorator if configured.
+      val sanitizedUrl = uri!!.buildUpon().clearQuery().fragment(null).build().toString()
+      properties["url"] = sanitizedUrl
     } catch (e: Exception) {
-      // handle error
       Log.d(name, "Error getting URL: ${e.message}")
       return
     }

--- a/packages/core/src/__tests__/internal/trackDeepLinks.test.ts
+++ b/packages/core/src/__tests__/internal/trackDeepLinks.test.ts
@@ -87,6 +87,72 @@ describe('#trackDeepLinks', () => {
     client.cleanup();
   });
 
+  it('strips query string from url by default to avoid leaking secrets', async () => {
+    const deepLinkData = {
+      url: 'myapp://reset?token=secret123&session=abc',
+      referring_application: 'Safari',
+    };
+    jest
+      .spyOn(store.deepLinkData, 'get')
+      .mockImplementation(createMockStoreGetter(() => deepLinkData));
+    const client = new SegmentClient(clientArgs);
+    jest.spyOn(client, 'process');
+
+    await client.init();
+
+    expect(client.process).toHaveBeenCalledWith({
+      event: 'Deep Link Opened',
+      properties: {
+        url: 'myapp://reset',
+        referring_application: 'Safari',
+      },
+      type: EventType.TrackEvent,
+    });
+    client.cleanup();
+  });
+
+  it('uses deepLinkPropertiesDecorator when provided, instead of default stripping', async () => {
+    const deepLinkData = {
+      url: 'myapp://reset?token=secret123&utm_source=email',
+      referring_application: 'Safari',
+    };
+    jest
+      .spyOn(store.deepLinkData, 'get')
+      .mockImplementation(createMockStoreGetter(() => deepLinkData));
+
+    const decorator = jest.fn(
+      (props: { url: string; referring_application: string }) => {
+        const u = new URL(
+          props.url.replace('myapp://', 'https://placeholder/')
+        );
+        return {
+          ...props,
+          url: `myapp://${u.pathname}`,
+          utm_source: u.searchParams.get('utm_source') ?? '',
+        };
+      }
+    );
+
+    const client = new SegmentClient({
+      ...clientArgs,
+      config: { ...clientArgs.config, deepLinkPropertiesDecorator: decorator },
+    });
+    jest.spyOn(client, 'process');
+
+    await client.init();
+
+    expect(decorator).toHaveBeenCalledWith(deepLinkData);
+    expect(client.process).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'Deep Link Opened',
+        properties: expect.objectContaining({
+          utm_source: 'email',
+        }),
+      })
+    );
+    client.cleanup();
+  });
+
   it('does not send a track event when trackDeepLinks is not enabled', async () => {
     const client = new SegmentClient({
       ...clientArgs,

--- a/packages/core/src/__tests__/util.test.ts
+++ b/packages/core/src/__tests__/util.test.ts
@@ -4,6 +4,7 @@ import {
   allSettled,
   deepCompare,
   getURL,
+  stripQueryString,
   validateApiHost,
 } from '../util';
 
@@ -214,6 +215,30 @@ describe('getURL function', () => {
     expect(getURL('http://proxy.example.com', '/path', true)).toBe(
       'http://proxy.example.com/path'
     );
+  });
+});
+
+describe('stripQueryString', () => {
+  it('returns the URL unchanged when there is no query string', () => {
+    expect(stripQueryString('myapp://example.com/reset')).toBe(
+      'myapp://example.com/reset'
+    );
+  });
+
+  it('strips the query string, keeping scheme, host and path', () => {
+    expect(stripQueryString('myapp://example.com/reset?token=abc123')).toBe(
+      'myapp://example.com/reset'
+    );
+  });
+
+  it('strips multiple query params', () => {
+    expect(stripQueryString('https://example.com/cb?code=xyz&state=abc')).toBe(
+      'https://example.com/cb'
+    );
+  });
+
+  it('handles a URL with no path, only query string', () => {
+    expect(stripQueryString('myapp://?token=secret')).toBe('myapp://');
   });
 });
 

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -65,6 +65,7 @@ import {
   getPluginsWithFlush,
   getPluginsWithReset,
   getURL,
+  stripQueryString,
 } from './util';
 import { getUUID } from './uuid';
 import type { FlushPolicy } from './flushPolicies';
@@ -588,11 +589,17 @@ export class SegmentClient {
 
   private trackDeepLinkEvent(deepLinkProperties: DeepLinkData) {
     if (deepLinkProperties.url !== '') {
+      const decorator = this.config.deepLinkPropertiesDecorator;
+      const sanitized = decorator
+        ? decorator({ ...deepLinkProperties })
+        : {
+            ...deepLinkProperties,
+            url: stripQueryString(deepLinkProperties.url),
+          };
+
       const event = createTrackEvent({
         event: 'Deep Link Opened',
-        properties: {
-          ...deepLinkProperties,
-        },
+        properties: { ...sanitized },
       });
 
       void this.process(event);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -145,6 +145,17 @@ export type Config = {
   trackAppLifecycleEvents?: boolean;
   maxBatchSize?: number;
   trackDeepLinks?: boolean;
+  /**
+   * Optional hook called before a "Deep Link Opened" event is built. Use it
+   * to redact or transform deep-link properties — e.g. to preserve specific
+   * query params while dropping secrets (OAuth codes, magic-link tokens).
+   * By default the SDK strips the entire query string from the URL, keeping
+   * only the scheme, host, and path.
+   */
+  deepLinkPropertiesDecorator?: (properties: {
+    referring_application: string;
+    url: string;
+  }) => { referring_application: string; url: string };
   defaultSettings?: SegmentAPISettings;
   autoAddSegmentDestination?: boolean;
   collectDeviceId?: boolean;

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -258,6 +258,11 @@ export const createPromise = <T>(
   };
 };
 
+export function stripQueryString(url: string): string {
+  const q = url.indexOf('?');
+  return q === -1 ? url : url.slice(0, q);
+}
+
 // Accepts a bare host[/path] value (e.g. "api.segment.io/v1") as supplied by
 // the settings CDN. Rejects anything that contains a scheme, credentials,
 // query string, or fragment — all of which could redirect uploads to an


### PR DESCRIPTION
**Summary**
Problem: When trackDeepLinks is enabled, the full deep-link URL (including query string) was spread into the Deep Link Opened event and uploaded. Deep links routinely carry secrets — OAuth authorization codes, magic-link/password-reset tokens, session IDs — that should never appear in analytics data.
On Android, individual query params were additionally spread as top-level event properties (e.g. token, code) alongside the raw URL.
**Changes**
**util.ts** — adds stripQueryString(url) helper that removes everything from ? onward, keeping scheme, host, and path.
**analytics.ts** — trackDeepLinkEvent now strips the query string from url by default before building the event. A new deepLinkPropertiesDecorator config hook lets callers override this (e.g. to allowlist safe params like utm_source while dropping secrets).
**types.ts** — adds deepLinkPropertiesDecorator?: (props) => props to Config with a doc comment explaining the risk.
**AnalyticsReactNativeModule.kt** — replaces the query-param spread loop with uri.buildUpon().clearQuery().fragment(null), stripping secrets at the native layer before they reach JS.
**Test plan**
 `stripQueryString` unit tests: no query string (unchanged), single param stripped, multiple params stripped, no-path URL
 `trackDeepLinks` integration tests: default stripping removes query string from URL; deepLinkPropertiesDecorator is called with original props and its return value is used
 `Existing deep-link` tests still pass (URLs without query strings are unaffected)
 Run yarn test in packages/core — all tests pass

**Migration note**
If you rely on query parameters being present in Deep Link Opened events, use deepLinkPropertiesDecorator to selectively re-add the ones you need:


```
createClient({
  writeKey: '...',
  trackDeepLinks: true,
  deepLinkPropertiesDecorator: ({ url, referring_application }) => {
    const params = new URL(url.replace('myapp://', 'https://placeholder/'));
    return {
      url: `myapp://${params.pathname}`,
      referring_application,
      utm_source: params.searchParams.get('utm_source') ?? undefined,
    };
  },
});
```